### PR TITLE
Michael/fix exit no test

### DIFF
--- a/packages/testwatch/index.js
+++ b/packages/testwatch/index.js
@@ -220,8 +220,7 @@ ${Object.entries(this.#currentCommands)
   }
 
   async run() {
-    await this.#runTests();
-    await once(this.#emitter, 'drained');
+    await Promise.all([once(this.#emitter, 'drained'), this.#runTests()]);
     this.#emitter.on('drained', () => this.#compactHelp());
     this.#help();
     for await (const data of on(process.stdin, 'data')) {

--- a/packages/testwatch/tests/index.test.js
+++ b/packages/testwatch/tests/index.test.js
@@ -156,6 +156,17 @@ describe('testwatch', { concurrency: true, skip: !isSupported ? 'unsupported nod
     });
 
     describe('files filter', () => {
+      it('should not exit if no test found on first run', async () => {
+        const { outputs, stderr } = await spawnInteractive('q', ['notexist']);
+        const activeFilters = '\nActive Filters: file name **/notexist*.*\n';
+        const notFound = '\nNo files found for pattern **/notexist*.*';
+        assert.strictEqual(stderr, '');
+        assert.deepStrictEqual(outputs, [
+          '',
+          `${notFound}\n${activeFilters}${mainMenuWithFilters}\n`,
+        ]);
+      });
+
       it('should set first argument as file filter', async () => {
         const { outputs, stderr } = await spawnInteractive('q', ['ind']);
         const activeFilters = '\nActive Filters: file name **/ind*.*\n';


### PR DESCRIPTION
Need to merge #64 first.
Close #62 

We can't use `Promise.race` because `runTests` does not await for tests to complete (this is what the `drained` event is for..)