### PR TITLE
fix line reporting for assert errors

### DIFF
--- a/packages/github/index.js
+++ b/packages/github/index.js
@@ -14,7 +14,13 @@ const getFilePath = (name) => (isFile(name) ? path.relative(WORKSPACE, require.r
 
 const parseStack = (error, file) => {
   const stackLines = (error?.stack ?? '').split(/\r?\n/);
-  const line = stackLines.find((l) => l.includes(file)) ?? stackLines[0];
+  let line = stackLines.find((l) => l.includes(file));
+  // When an error is thrown inside of `test` or `it`, the stack trace is stripped away.
+  // It is available as `error.cause` though, so try again with that.
+  if (line === undefined && error.cause instanceof Error) {
+    return parseStack(error.cause, file);
+  }
+  ([line] = stackLines);
   return line ? stack.parseLine(line) : null;
 };
 

--- a/packages/github/tests/index.test.js
+++ b/packages/github/tests/index.test.js
@@ -12,11 +12,11 @@ const GITHUB_STEP_SUMMARY = join(tmpdir(), 'github-actions-test-reporter');
 writeFileSync(GITHUB_STEP_SUMMARY, '');
 
 describe('github reporter', () => {
-  const child = spawnSync(process.execPath, ['--test-reporter', './index.js', '../../tests/example'], {
-    env: { GITHUB_ACTIONS: true, GITHUB_STEP_SUMMARY, GITHUB_WORKSPACE: path.resolve(__dirname, '../../../') },
-  });
+  test('spawn with reporter', () => {
+    const child = spawnSync(process.execPath, ['--test-reporter', './index.js', '../../tests/example'], {
+      env: { GITHUB_ACTIONS: true, GITHUB_STEP_SUMMARY, GITHUB_WORKSPACE: path.resolve(__dirname, '../../../') },
+    });
 
-  test('spwan with reporter', () => {
     assert.strictEqual(child.stderr?.toString(), '');
     compareLines(child.stdout?.toString(), output.stdout);
     compareLines(readFileSync(GITHUB_STEP_SUMMARY).toString(), output.summary);

--- a/packages/github/tests/output.js
+++ b/packages/github/tests/output.js
@@ -3,11 +3,13 @@ module.exports = {
 ::debug::starting to run is ok
 ::debug::completed running is ok
 ::debug::starting to run fails
-::error title=fails,file=tests/example.js::\\[Error \\[ERR_TEST_FAILURE\\]: this is an error\\] {%0A  failureType: 'testCodeFailure',%0A  cause: Error: this is an error%0A      at .*.<anonymous> (.*/example.js:6:11).*
+::error title=fails,file=tests/example.js::\\[Error \\[ERR_TEST_FAILURE\\]: this is an error\\] {%0A  failureType: 'testCodeFailure',%0A  cause: Error: this is an error%0A      at TestContext.<anonymous> (.*/example.js:7:11)%0A      at Test.runInAsyncScope (node:async_hooks:206:9)%0A      at Test.run (node:internal/test_runner/test:569:25)%0A      at Suite.processPendingSubtests (node:internal/test_runner/test:316:27)%0A      at Test.postRun (node:internal/test_runner/test:638:19)%0A      at Test.run (node:internal/test_runner/test:597:10)%0A      at async Promise.all (index 0)%0A      at async Suite.run (node:internal/test_runner/test:806:7)%0A      at async startSubtest (node:internal/test_runner/harness:204:3),%0A  code: 'ERR_TEST_FAILURE'%0A}
 ::debug::starting to run is a diagnostic
 ::debug::completed running is a diagnostic
 ::notice file=tests/example.js::this is a diagnostic
-::error title=tests,file=tests/example.js::\\[Error \\[ERR_TEST_FAILURE\\]: 1 subtest failed\\] { failureType: 'subtestsFailed', cause: '1 subtest failed', code: 'ERR_TEST_FAILURE' }
+::debug::starting to run should fail
+::error title=should fail,file=tests/example.js::\\[Error \\[ERR_TEST_FAILURE\\]: The expression evaluated to a falsy value:%0A%0A  assert(false)%0A\\] {%0A  failureType: 'testCodeFailure',%0A  cause: AssertionError \\[ERR_ASSERTION\\]: The expression evaluated to a falsy value:%0A  %0A    assert(false)%0A  %0A      at TestContext.<anonymous> (.*/example.js:10:31)%0A      at Test.runInAsyncScope (node:async_hooks:206:9)%0A      at Test.run (node:internal/test_runner/test:569:25)%0A      at Suite.processPendingSubtests (node:internal/test_runner/test:316:27)%0A      at Test.postRun (node:internal/test_runner/test:638:19)%0A      at Test.run (node:internal/test_runner/test:597:10)%0A      at async Suite.processPendingSubtests (node:internal/test_runner/test:316:7) {%0A    generatedMessage: true,%0A    code: 'ERR_ASSERTION',%0A    actual: false,%0A    expected: true,%0A    operator: '=='%0A  },%0A  code: 'ERR_TEST_FAILURE'%0A}
+::error title=tests,file=tests/example.js::\\[Error \\[ERR_TEST_FAILURE\\]: 2 subtests failed\\] { failureType: 'subtestsFailed', cause: '2 subtests failed', code: 'ERR_TEST_FAILURE' }
 ::debug::starting to run more tests
 ::debug::starting to run is ok
 ::debug::completed running is ok
@@ -16,8 +18,8 @@ module.exports = {
 ::debug::completed running is skipped
 ::debug::starting to run is a todo
 ::debug::completed running is a todo
-::group::Test results \\(3 passed, 1 failed\\)
-::notice::Total Tests: 6%0ASuites 📂: 2%0APassed ✅: 3%0AFailed ❌: 1%0ACanceled 🚫: 0%0ASkipped ⏭️: 1%0ATodo 📝: 1%0ADuration 🕐: .*ms
+::group::Test results (3 passed, 2 failed)
+::notice::Total Tests: 7%0ASuites 📂: 2%0APassed ✅: 3%0AFailed ❌: 2%0ACanceled 🚫: 0%0ASkipped ⏭️: 1%0ATodo 📝: 1%0ADuration 🕐: 0.094ms
 ::endgroup::
 `,
   summary: `<h1>Test Results</h1>

--- a/tests/example.js
+++ b/tests/example.js
@@ -1,4 +1,5 @@
 const { describe, it, test } = require('node:test');
+const assert = require('node:assert');
 
 describe('tests', () => {
   it('is ok', () => {});
@@ -6,6 +7,7 @@ describe('tests', () => {
     throw new Error('this is an error');
   });
   test('is a diagnostic', async (t) => { t.diagnostic('this is a diagnostic'); });
+  test('should fail', () => { assert(false); });
 });
 
 describe('more tests', () => {


### PR DESCRIPTION
This fixes line reporting for when an error is thrown within a `test` or `it` and is missing its stack trace (https://github.com/nodejs/node/issues/48840)

Maybe when #48840 is closed we can remove this code.

Also, how do I update the `output` for the test? Seems like its not agreeing with me no matter what I do.