### PR TITLE
Add support for esm in `@reporters/github`

### DIFF
--- a/packages/github/index.js
+++ b/packages/github/index.js
@@ -10,7 +10,18 @@ const stack = new StackUtils({ cwd: WORKSPACE, internals: StackUtils.nodeInterna
 
 const isFile = (name) => name?.startsWith(WORKSPACE);
 
-const getFilePath = (name) => (isFile(name) ? path.relative(WORKSPACE, require.resolve(name) ?? '') : null);
+function getFilePath(name) {
+  try {
+    const fileURL = new URL(name);
+    if (fileURL.protocol === 'file:') {
+      return fileURL.pathname;
+    }
+  } catch (err) {
+    // swallow the `ERR_INVALID_URL` error; rethrow everything else
+    if (err.code !== 'ERR_INVALID_URL') throw err;
+  }
+  return isFile(name) ? path.relative(WORKSPACE, require.resolve(name) ?? '') : null;
+}
 
 const parseStack = (error, file) => {
   const err = error?.code === 'ERR_TEST_FAILURE' ? error?.cause : error;

--- a/packages/github/tests/index.test.js
+++ b/packages/github/tests/index.test.js
@@ -1,4 +1,4 @@
-const { test, describe } = require('node:test');
+const { test, describe, beforeEach } = require('node:test');
 const { spawnSync } = require('child_process');
 const { tmpdir } = require('os');
 const { join } = require('path');
@@ -7,11 +7,16 @@ const path = require('path');
 const { readFileSync, writeFileSync } = require('fs');
 const { compareLines } = require('../../../tests/utils');
 const output = require('./output');
+const outputESM = require('./output-esm');
 
 const GITHUB_STEP_SUMMARY = join(tmpdir(), 'github-actions-test-reporter');
 writeFileSync(GITHUB_STEP_SUMMARY, '');
 
 describe('github reporter', () => {
+  beforeEach(() => {
+    writeFileSync(GITHUB_STEP_SUMMARY, '');
+  });
+
   test('spawn with reporter', () => {
     const child = spawnSync(process.execPath, ['--test-reporter', './index.js', '../../tests/example'], {
       env: { GITHUB_ACTIONS: true, GITHUB_STEP_SUMMARY, GITHUB_WORKSPACE: path.resolve(__dirname, '../../../') },
@@ -20,6 +25,19 @@ describe('github reporter', () => {
     assert.strictEqual(child.stderr?.toString(), '');
     compareLines(child.stdout?.toString(), output.stdout);
     compareLines(readFileSync(GITHUB_STEP_SUMMARY).toString(), output.summary);
+  });
+
+  test('spawn with reporter - esm', () => {
+    const child = spawnSync(process.execPath, ['--test-reporter', './index.js', '../../tests/test.mjs'], {
+      env: { GITHUB_ACTIONS: true, GITHUB_STEP_SUMMARY, GITHUB_WORKSPACE: path.resolve(__dirname, '../../../') },
+    });
+
+    console.log(readFileSync(GITHUB_STEP_SUMMARY).toString());
+    // writeFileSync('./output-esm', child.stdout?.toString());
+
+    assert.strictEqual(child.stderr?.toString(), '');
+    compareLines(child.stdout?.toString(), outputESM.stdout);
+    compareLines(readFileSync(GITHUB_STEP_SUMMARY).toString(), outputESM.summary);
   });
 
   test('should noop if not in github actions', () => {

--- a/packages/github/tests/output-esm.js
+++ b/packages/github/tests/output-esm.js
@@ -1,0 +1,11 @@
+module.exports = {
+  stdout: `::debug::starting to run should fail
+::error title=should fail,file=tests/test.mjs,line=5,col=3::\\[Error \\[ERR_TEST_FAILURE\\]: false == true\\] {%0A  failureType: 'testCodeFailure',%0A  cause: AssertionError [ERR_ASSERTION]: false == true%0A      at TestContext.<anonymous> (.*/test.mjs:5:3).* code: 'ERR_TEST_FAILURE'%0A}
+::group::Test results (0 passed, 1 failed)
+::notice::Total Tests: 1%0ASuites 📂: 0%0APassed ✅: 0%0AFailed ❌: 1%0ACanceled 🚫: 0%0ASkipped ⏭️: 0%0ATodo 📝: 0%0ADuration 🕐: 0.145ms
+::endgroup::
+`,
+  summary: `<h1>Test Results</h1>
+<table><tr><td>Total Tests</td><td>1</td></tr><tr><td>Suites 📂</td><td>0</td></tr><tr><td>Passed ✅</td><td>0</td></tr><tr><td>Failed ❌</td><td>1</td></tr><tr><td>Canceled 🚫</td><td>0</td></tr><tr><td>Skipped ⏭️</td><td>0</td></tr><tr><td>Todo 📝</td><td>0</td></tr><tr><td>Duration 🕐</td><td>0.114ms</td></tr></table>
+`,
+};

--- a/tests/test.mjs
+++ b/tests/test.mjs
@@ -1,0 +1,6 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+test('should fail', () => {
+  assert(false);
+});


### PR DESCRIPTION
This adds support for esm in the github reporter by trying to use `URL` to determine the path. 

Not sure how we want to test this, feel free to directly commit to this branch. Otherwise I'll try to come up with something after I do some manual testing.