### PR TITLE
Add "type" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "reporters",
   "version": "1.0.2",
   "description": "A collection of reporters for `node:test`",
+  "type": "commonjs",
   "main": "index.js",
   "private": true,
   "scripts": {

--- a/packages/bail/package.json
+++ b/packages/bail/package.json
@@ -2,6 +2,7 @@
   "name": "@reporters/bail",
   "version": "1.1.2",
   "description": "A Bail library for `node:test`",
+  "type": "commonjs",
   "keywords": [
     "node:test",
     "test",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -2,6 +2,7 @@
   "name": "@reporters/github",
   "version": "1.5.2",
   "description": "A github actions reporter for `node:test`",
+  "type": "commonjs",
   "keywords": [
     "github actions",
     "node:test",

--- a/packages/junit/package.json
+++ b/packages/junit/package.json
@@ -2,6 +2,7 @@
   "name": "@reporters/junit",
   "version": "1.2.4",
   "description": "A jUnit reporter for `node:test`",
+  "type": "commonjs",
   "keywords": [
     "junit",
     "node:test",

--- a/packages/silent/package.json
+++ b/packages/silent/package.json
@@ -2,6 +2,7 @@
   "name": "@reporters/silent",
   "version": "1.2.3",
   "description": "A silent reporter for `node:test`",
+  "type": "commonjs",
   "keywords": [
     "node:test",
     "test",

--- a/packages/testwatch/package.json
+++ b/packages/testwatch/package.json
@@ -2,6 +2,7 @@
   "name": "@reporters/testwatch",
   "version": "1.4.1",
   "description": "An interactive repl for `node:test`",
+  "type": "commonjs",
   "keywords": [
     "node:test",
     "test",


### PR DESCRIPTION
CI is failing for https://github.com/nodejs/node/pull/49869 because this package lacks a `"type"` field in its `package.json` and our CI doesn’t put it under a `node_modules` folder: https://github.com/nodejs/node/actions/runs/6306631169/job/17122062558?pr=49869

Adding `type` is a recommended practice even for CommonJS packages: https://nodejs.org/api/packages.html#determining-module-system:~:text=Package%20authors%20should%20include%20the%20%22type%22%20field.