### PR TITLE
fix(github): correctly convert `file:` URL to path

### DIFF
--- a/packages/github/index.js
+++ b/packages/github/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const path = require('node:path');
+const { fileURLToPath } = require("node:url");
 const util = require('node:util');
 const { EOL } = require('node:os');
 const core = require('@actions/core');
@@ -12,11 +13,14 @@ const stack = new StackUtils({ cwd: WORKSPACE, internals: StackUtils.nodeInterna
 
 const isFile = (name) => name?.startsWith(WORKSPACE);
 
-const getRelativeFilePath = (name) => (isFile(name) ? path.relative(WORKSPACE, require.resolve(name) ?? '') : null);
+const getRelativeFilePath = (name) => (isFile(name) ? path.relative(WORKSPACE, name) : null);
 
 function getFilePath(fileName) {
   if (fileName.startsWith('file://')) {
-    return getRelativeFilePath(new URL(fileName).pathname);
+    return getRelativeFilePath(fileURLToPath(fileName));
+  }
+  if (!path.isAbsolute(fileName)) {
+    return getRelativeFilePath(path.resolve(fileName) ?? "");
   }
   return getRelativeFilePath(fileName);
 }

--- a/packages/github/index.js
+++ b/packages/github/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require('node:path');
-const { fileURLToPath } = require("node:url");
+const { fileURLToPath } = require('node:url');
 const util = require('node:util');
 const { EOL } = require('node:os');
 const core = require('@actions/core');
@@ -20,7 +20,7 @@ function getFilePath(fileName) {
     return getRelativeFilePath(fileURLToPath(fileName));
   }
   if (!path.isAbsolute(fileName)) {
-    return getRelativeFilePath(path.resolve(fileName) ?? "");
+    return getRelativeFilePath(path.resolve(fileName) ?? '');
   }
   return getRelativeFilePath(fileName);
 }


### PR DESCRIPTION
Needed for https://github.com/nodejs/node/pull/48409

When the path contains URL-significant chars (e.g. `%`, `?`, `#`), it breaks the reporter. Also, using `require.resolve` to resolve relative paths will be problematic as it would resolve it relatively from the current reporter module instead of the CWD. Using `path.resolve` should be a better fit.