### PR TITLE
fix(github): tolerate test:fail events without a details.error

### DIFF
--- a/packages/github/index.js
+++ b/packages/github/index.js
@@ -82,9 +82,9 @@ function transformEvent(event) {
       return new Command('debug', {}, `completed running ${event.data.name}`).toString();
     case 'test:fail': {
       const error = event.data.details?.error;
-      if (error?.code === 'ERR_TEST_FAILURE' && error?.failureType === 'subtestsFailed') {
-        // This means the failed subtests are already reported
-        // no need to re-annotate the file itself
+      if (!error || (error.code === 'ERR_TEST_FAILURE' && error.failureType === 'subtestsFailed')) {
+        // Either no error object on the event, or failed subtests are already
+        // reported — no need to re-annotate the file itself.
         break;
       }
       const err = error.code === 'ERR_TEST_FAILURE' ? error.cause : error;

--- a/packages/github/tests/index.test.js
+++ b/packages/github/tests/index.test.js
@@ -1,12 +1,14 @@
 'use strict';
 
 const { test, describe, beforeEach } = require('node:test');
+const assert = require('node:assert');
 const { spawnSync } = require('child_process');
 const { tmpdir } = require('os');
 const { join } = require('path');
 const path = require('path');
 const { readFileSync, writeFileSync } = require('fs');
 const { Snap, nodeMajor } = require('../../../tests/utils');
+const { transformEvent } = require('../index');
 
 const snapshot = Snap(`${__filename}.${nodeMajor}`);
 const GITHUB_STEP_SUMMARY = join(tmpdir(), 'github-actions-test-reporter');
@@ -45,5 +47,31 @@ describe('github reporter', () => {
   test('should noop if not in github actions', async () => {
     const silentChild = spawnSync(process.execPath, ['--test-reporter', './index.js', '../../tests/example'], { env: { } });
     await snapshot(silentChild);
+  });
+
+  test('transformEvent tolerates test:fail with no error object', () => {
+    // Node can emit test:fail where details.error is null (e.g. hook re-runs
+    // that reset this.error — see lib/internal/test_runner/test.js). The
+    // reporter must not throw on such events, otherwise the unhandled 'error'
+    // on the Transform stream crashes the whole test runner.
+    assert.doesNotThrow(() => transformEvent({
+      type: 'test:fail',
+      data: {
+        name: 'no error',
+        details: { error: null },
+        file: 'x.js',
+        line: 1,
+        column: 1,
+      },
+    }));
+    assert.doesNotThrow(() => transformEvent({
+      type: 'test:fail',
+      data: {
+        name: 'no details',
+        file: 'x.js',
+        line: 1,
+        column: 1,
+      },
+    }));
   });
 });


### PR DESCRIPTION
## Summary

- Guard against `event.data.details.error === null` in `transformEvent` for `test:fail`. Previously, `error.code` was dereferenced without optional chaining, throwing `TypeError: Cannot read properties of null (reading 'code')`.
- Add a unit test that exercises `transformEvent` with `details.error: null` and missing `details`.

## Why this matters

`transformEvent` runs inside `SpecReporter._transform` (a Transform stream). A synchronous throw from the reporter surfaces as an unhandled `'error'` event on the stream, which crashes the whole `node --test` process. Any reporter wired in alongside — including Node's internal [`rerun`](https://github.com/nodejs/node/blob/main/lib/internal/test_runner/reporter/rerun.js) reporter used by `--test-rerun-failures` — loses its chance to flush. The end result for a CI using `--test-rerun-failures` is a truncated `all-test-results.json` and an unchanged `rerun-failures.json`, so retry attempts keep re-running the same set of failed tests instead of narrowing.

Node can emit `test:fail` with a null error object — for example when a hook re-run resets `this.error` (see [`lib/internal/test_runner/test.js`](https://github.com/nodejs/node/blob/main/lib/internal/test_runner/test.js)). The existing code on line 84 already acknowledges `details.error` may be absent by using optional chaining; line 85's `subtestsFailed` check did too. Only line 90 was missing the guard.

## Repro

```js
transformEvent({
  type: 'test:fail',
  data: { name: 'x', details: { error: null }, file: 'x.js', line: 1, column: 1 },
});
// Before: TypeError: Cannot read properties of null (reading 'code')
// After:  no throw, no annotation emitted
```

Confirmed in the wild: an [eon-io/eon-service CI run](https://github.com/eon-io/eon-service/actions/runs/24628427042) crashed mid-run with this exact stack, corrupting the rerun-failures bookkeeping across three retry attempts.

## Test plan

- [x] New unit test `transformEvent tolerates test:fail with no error object` passes on this branch and fails on `main`
- [x] `yarn test` across all packages passes
- [x] `yarn lint` has 0 errors