### PR TITLE
docs: explain @reporters/gh vs @reporters/github

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,34 @@ node --test \
 Available reporters:
 
 - [bail](https://www.npmjs.com/package/@reporters/bail) - bail on first failure
-- [gh](https://www.npmjs.com/package/@reporters/gh) - a all in one github actions reporter
-- [github](https://www.npmjs.com/package/@reporters/github) - report to github actions
+- [gh](https://www.npmjs.com/package/@reporters/gh) - all-in-one GitHub Actions reporter (readable log + annotations + summary in one)
+- [github](https://www.npmjs.com/package/@reporters/github) - GitHub Actions annotations + job summary only (pair with another reporter for the log)
 - [jUnit](https://www.npmjs.com/package/@reporters/junit) - report to jUnit 
 - [mocha](https://www.npmjs.com/package/@reporters/mocha) - use any mocha reporter with `node:test`
 - [silent](https://www.npmjs.com/package/@reporters/silent) - a silent reporter
 - [slow](https://www.npmjs.com/package/@reporters/slow) - report slow tests
 - [testwatch](https://www.npmjs.com/package/@reporters/testwatch) - An interactive REPL for `node:test` watch mode.
+
+## GitHub Actions: `gh` vs `github`
+
+Both [`@reporters/gh`](https://www.npmjs.com/package/@reporters/gh) and [`@reporters/github`](https://www.npmjs.com/package/@reporters/github) add GitHub Actions annotations (inline errors + diagnostics) and a job summary. The difference is whether they also produce the human-readable test log:
+
+| | `@reporters/gh` | `@reporters/github` |
+|---|---|---|
+| Human-readable log | ✅ built in (spec-style) | ❌ none — pair with another reporter |
+| Annotations + job summary | ✅ | ✅ |
+| Reporters needed | one | two (it + e.g. `spec`) |
+| Output outside GitHub Actions | spec-style log | nothing (no-op) |
+| Best when | you want a single reporter that does everything | you already have a reporter you like and just want to add annotations |
+
+In short: reach for **`gh`** for the batteries-included experience, or **`github`** to layer annotations onto your own choice of reporter.
+
+```bash
+# gh — one reporter: readable log + annotations + summary
+node --test --test-reporter=@reporters/gh
+
+# github — annotations + summary, paired with spec for the readable log
+node --test \
+  --test-reporter=@reporters/github --test-reporter-destination=stdout \
+  --test-reporter=spec --test-reporter-destination=stdout
+```

--- a/packages/gh/README.md
+++ b/packages/gh/README.md
@@ -1,8 +1,16 @@
 [![npm version](https://img.shields.io/npm/v/@reporters/gh)](https://www.npmjs.com/package/@reporters/gh) ![tests](https://github.com/MoLow/reporters/actions/workflows/test.yaml/badge.svg?branch=main) [![codecov](https://codecov.io/gh/MoLow/reporters/branch/main/graph/badge.svg?token=0LFVC8SCQV)](https://codecov.io/gh/MoLow/reporters)
 
-# Github Actions Reporter
-A Github actions reporter for `node:test`
- 
+# GitHub Actions Reporter (all-in-one)
+An all-in-one GitHub Actions reporter for `node:test`: it prints a readable, spec-style test log **and** emits GitHub Actions annotations and a job summary — from a single reporter.
+
+Outside GitHub Actions it falls back to the plain spec-style log, so the same command works locally and in CI.
+
+> **`gh` vs [`github`](https://www.npmjs.com/package/@reporters/github)**
+> - **`@reporters/gh`** (this package) — all-in-one: a human-readable log **plus** annotations and summary, from one reporter. Use it when you want a single `--test-reporter` that does everything.
+> - **`@reporters/github`** — annotations and summary **only**; it prints no readable log, so you pair it with another reporter (e.g. `spec`). Use it when you already have a reporter you like and just want to layer GitHub annotations on top.
+>
+> See the [full comparison in the main README](https://github.com/MoLow/reporters#github-actions-gh-vs-github).
+
 ## Installation
 
 ```bash
@@ -19,6 +27,12 @@ yarn add --dev @reporters/gh
 # .github/workflows/test.yml
 - name: Run tests
   run: node --test --test-reporter=@reporters/gh
+```
+
+The same command also works locally — when not running in GitHub Actions it just prints the spec-style log (no annotations):
+
+```bash
+node --test --test-reporter=@reporters/gh
 ```
 
 ## Result

--- a/packages/github/README.md
+++ b/packages/github/README.md
@@ -1,8 +1,16 @@
 [![npm version](https://img.shields.io/npm/v/@reporters/github)](https://www.npmjs.com/package/@reporters/github) ![tests](https://github.com/MoLow/reporters/actions/workflows/test.yaml/badge.svg?branch=main) [![codecov](https://codecov.io/gh/MoLow/reporters/branch/main/graph/badge.svg?token=0LFVC8SCQV)](https://codecov.io/gh/MoLow/reporters)
 
-# Github Actions Reporter
-A Github actions reporter for `node:test`
- 
+# GitHub Actions Annotations Reporter
+Adds GitHub Actions annotations (inline error annotations and diagnostics) and a job summary to `node:test`.
+
+This reporter emits **only** GitHub Actions workflow commands — it produces no human-readable test log of its own, so you pair it with another reporter (e.g. `spec`) for the readable output. Outside GitHub Actions it emits nothing.
+
+> **`github` vs [`gh`](https://www.npmjs.com/package/@reporters/gh)**
+> - **`@reporters/github`** (this package) — annotations and summary **only**. Layer it on top of whatever reporter you already use; it stays out of the way locally (no output unless running in GitHub Actions).
+> - **`@reporters/gh`** — all-in-one: bundles a readable spec-style log **with** the annotations and summary, so you only need a single `--test-reporter`.
+>
+> See the [full comparison in the main README](https://github.com/MoLow/reporters#github-actions-gh-vs-github).
+
 ## Installation
 
 ```bash
@@ -22,6 +30,8 @@ yarn add --dev @reporters/github
     --test-reporter=@reporters/github --test-reporter-destination=stdout \
     --test-reporter=spec --test-reporter-destination=stdout
 ```
+
+The second reporter (`spec` here, but any reporter works) provides the human-readable log; `@reporters/github` adds the annotations and summary alongside it. If you'd rather not juggle two reporters, use [`@reporters/gh`](https://www.npmjs.com/package/@reporters/gh) instead.
 
 ## Result
 


### PR DESCRIPTION
## Summary

The two GitHub Actions reporters (`@reporters/gh` and `@reporters/github`) had near-identical READMEs — same title, same description, same screenshots — with nothing explaining what's different or when to use which. This documents the distinction in both package READMEs and the main repo README.

The actual difference: **`gh` is all-in-one** (readable spec-style log **plus** annotations + job summary, from one reporter; falls back to the plain log outside Actions), while **`github` is annotations + summary only** (no readable log — you pair it with another reporter like `spec`; no-op outside Actions).

## Changes

- **Main README** — distinct one-line descriptions for `gh`/`github` and a new **"GitHub Actions: `gh` vs `github`"** section with a comparison table and runnable examples.
- **`packages/gh/README.md`** — retitled "all-in-one", explains it bundles the readable log + annotations, notes it works locally, and a cross-linked `gh` vs `github` callout.
- **`packages/github/README.md`** — retitled "Annotations Reporter", explains it emits only annotations/summary (no readable log, no-op outside Actions) and why the usage pairs it with `spec`.

Docs only — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)