### PR TITLE
fix(ci): publish with yarn to resolve workspace: protocol

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,5 +70,5 @@ jobs:
         run: |
           PACKAGE_NAME=$(node -p "PACKAGE_NAME='${{ matrix.package }}'.split('/')[1]")
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_OUTPUT
-      - run: npm publish --provenance --access public
+      - run: yarn npm publish --provenance --access public
         working-directory: packages/${{ steps.package-name.outputs.PACKAGE_NAME }}


### PR DESCRIPTION
## Problem

`@reporters/gh@2.0.1` is broken on npm. Its published `package.json` contains:

```json
"@reporters/github": "workspace:^"
```

`workspace:^` is a yarn monorepo-only protocol — meaningless outside this repo. Downstream consumers fail to install with:

```
Error: @reporters/github@workspace:^: Workspace not found (@reporters/github@workspace:^)
```

Verified via `npm view @reporters/gh dependencies` (returns the literal `workspace:^`). `@reporters/gh` is the only published package with an internal workspace dependency, so it's the only one affected.

## Root cause

The release workflow publishes with plain `npm publish` inside the package dir. In a **yarn** workspace, plain `npm` does not rewrite the `workspace:` protocol, so the placeholder ships as-is. This became visible only after #183 made `gh` depend on `github` via `workspace:^`.

## Fix

Use `yarn npm publish`, which resolves `workspace:^` → `^2.0.1` on publish and still supports `--provenance` in GitHub Actions (yarn 4.15.0). Confirmed locally that `yarn pack` rewrites the dependency to `^2.0.1`.

## Follow-up (not in this PR)

npm versions are immutable, so the broken `2.0.1` can't be overwritten. After merge, cut/republish `@reporters/gh@2.0.2` (via release-please or a `workflow_dispatch` with `["@reporters/gh"]`). Until then, dependents must pin an older working `@reporters/gh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)