### PR TITLE
fix(gh): republish with resolved workspace dependency

### DIFF
--- a/packages/gh/package.json
+++ b/packages/gh/package.json
@@ -25,7 +25,11 @@
   },
   "main": "index.js",
   "homepage": "https://github.com/MoLow/reporters/tree/main/packages/gh",
-  "repository": "https://github.com/MoLow/reporters.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MoLow/reporters.git",
+    "directory": "packages/gh"
+  },
   "author": "Moshe Atlow",
   "license": "MIT"
 }


### PR DESCRIPTION
## Why

`@reporters/gh@2.0.0` and `@reporters/gh@2.0.1` shipped to npm with an unresolved dependency:

```json
"@reporters/github": "workspace:^"
```

`workspace:^` is a yarn monorepo-only protocol, so downstream installs fail with `Workspace not found`. The publish flow was fixed in #188 (`yarn npm publish` now resolves the protocol to a concrete range). This PR cuts a fresh release so a correctly-published artifact reaches npm.

## What

- `Release-As: 2.0.2` footer + a `packages/gh/`-scoped change so release-please opens a release PR for `@reporters/gh@2.0.2`.
- Expand `repository` to the object form with `directory: "packages/gh"`, so npm links to the package's subdirectory (complements the provenance enabled in #188).

## Merge flow

Merging this PR triggers release-please to open a **"chore: release main"** PR bumping `@reporters/gh` to `2.0.2`. Merging *that* release PR creates the tag and runs the fixed publish job. After it's live, the broken `2.0.0`–`2.0.1` will be deprecated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)