### PR TITLE
chore: address review feedback on the tree reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,34 +26,7 @@ Available reporters:
 - [testwatch](https://www.npmjs.com/package/@reporters/testwatch) - An interactive REPL for `node:test` watch mode.
 - [web](https://www.npmjs.com/package/@reporters/web) - a self-contained, interactive HTML tree report (with an optional hosted live viewer)
 
-## Tree reporters: `live` and `web`
-
-[`@reporters/live`](https://www.npmjs.com/package/@reporters/live) and [`@reporters/web`](https://www.npmjs.com/package/@reporters/web) render the whole run as a collapsible **tree** built from the `node:test` event stream (powered by React). They share a common core that keeps the tree state; `live` renders it to the terminal with [Ink](https://github.com/vadimdemedes/ink), `web` renders it as an interactive HTML page. Both auto-expand failures, collapse passed suites to a count, and let you expand/collapse each test's diagnostics.
-
-```bash
-# live — a tree that updates in place as tests run (TTY); plain text in CI
-node --test --test-reporter=@reporters/live
-
-# web — write a single, self-contained, interactive HTML file
-node --test --test-reporter=@reporters/web --test-reporter-destination=report.html
-```
-
-> [!NOTE]
-> Under the default process isolation, Node buffers each test file's events until that file's turn to report, so files appear as they complete. For true real-time, per-test streaming in `live`, run with `--test-isolation=none`.
-
-### `web` modes
-
-`@reporters/web` emits an NDJSON event log, consumed two ways via `REPORTERS_WEB_MODE`:
-
-- **`embedded`** (default) — a single, offline, self-contained `.html` file with the React app and the event log inlined. Even a crashed/interrupted run leaves a renderable partial file.
-- **`ndjson`** — the raw NDJSON event log only. Host it anywhere and open it in the hosted viewer at **https://molow.github.io/reporters/** with `?src=<url-to-your-run.ndjson>` to watch it live (the viewer polls the file as it grows).
-
-```bash
-# raw NDJSON for the hosted viewer
-REPORTERS_WEB_MODE=ndjson node --test \
-  --test-reporter=@reporters/web --test-reporter-destination=run.ndjson
-# then open: https://molow.github.io/reporters/?src=<url-to-run.ndjson>
-```
+The `live` and `web` reporters render the run as an interactive **tree** and share a common core — see their package READMEs ([live](packages/live/README.md), [web](packages/web/README.md)) for details.
 
 ## GitHub Actions: `gh` vs `github`
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "private": true,
   "scripts": {
     "mono": "c8 node scripts/mono-run.js",
-    "build": "yarn workspace @reporters/tree-core build && yarn workspace @reporters/live build && yarn workspace @reporters/web build",
-    "test": "yarn build && yarn mono test",
+    "build": "yarn mono build",
+    "test": "yarn mono build && yarn mono test",
     "test:clean-snapshots": "rm -rf packages/**/.snapshots",
     "test:update-snapshots": "SNAP_UPDATE=1 yarn test",
     "lint": "eslint ."

--- a/packages/live/README.md
+++ b/packages/live/README.md
@@ -1,0 +1,28 @@
+# @reporters/live
+
+A live, React-powered **tree** reporter for `node:test`. It renders the whole
+run as a collapsible tree in your terminal (via [Ink](https://github.com/vadimdemedes/ink)),
+updating in place as tests run — each test flips to ✓/✗ the moment it actually
+finishes, not when the reporter gets around to it.
+
+```bash
+node --test --test-reporter=@reporters/live --test
+```
+
+- **Live** — tests appear as they start and complete in real execution order.
+- **Full tree, always expanded** — you always see every test; only per-test
+  diagnostics (errors, stdout/stderr, `diagnostic()` messages) collapse.
+- **Interactive review** — after the run it stays open so you can browse:
+  - `↑`/`↓` (or `k`/`j`) — move between tests that have diagnostics
+  - `space` / `enter` — toggle the selected test's diagnostics
+  - `q` / `Ctrl+C` — close
+- **CI-friendly** — outside a TTY it prints a plain-text tree at the end instead
+  of ANSI. Force that anywhere with `REPORTERS_LIVE_PLAIN=1`.
+
+> [!NOTE]
+> Under the default process isolation, Node buffers each test file's events
+> until that file's turn to report, so files fill in as they complete. For true
+> real-time, per-test streaming across files, run with `--test-isolation=none`.
+
+Built on the shared `@reporters/tree-core` model (also used by
+[`@reporters/web`](https://www.npmjs.com/package/@reporters/web)).

--- a/packages/live/package.json
+++ b/packages/live/package.json
@@ -35,7 +35,9 @@
     "react": "^19.0.0"
   },
   "devDependencies": {
-    "@reporters/tree-core": "workspace:^"
+    "@reporters/tree-core": "workspace:^",
+    "tsup": "^8.5.0",
+    "typescript": "^5.7.0"
   },
   "bugs": {
     "url": "https://github.com/MoLow/reporters/issues"

--- a/packages/tree-core/package.json
+++ b/packages/tree-core/package.json
@@ -26,6 +26,10 @@
     "build": "tsup",
     "test": "node --test"
   },
+  "devDependencies": {
+    "tsup": "^8.5.0",
+    "typescript": "^5.7.0"
+  },
   "bugs": {
     "url": "https://github.com/MoLow/reporters/issues"
   },

--- a/packages/tree-core/src/format.ts
+++ b/packages/tree-core/src/format.ts
@@ -1,12 +1,17 @@
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+
 export function formatDuration(ms: number | undefined): string {
   if (ms == null) return '';
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  if (ms < 60000) {
-    const seconds = ms / 1000;
-    const rounded = Math.round(seconds * 10) / 10;
+  if (ms < SECOND) return `${Math.round(ms)}ms`;
+  if (ms < MINUTE) {
+    const rounded = Math.round((ms / SECOND) * 10) / 10;
     return `${rounded % 1 === 0 ? rounded.toFixed(0) : rounded}s`;
   }
-  const minutes = Math.floor(ms / 60000);
-  const seconds = Math.round((ms % 60000) / 1000);
-  return `${minutes}m ${seconds}s`;
+  if (ms < HOUR) {
+    return `${Math.floor(ms / MINUTE)}m ${Math.round((ms % MINUTE) / SECOND)}s`;
+  }
+  // Hours and beyond (h + m); keeps long-running suites readable.
+  return `${Math.floor(ms / HOUR)}h ${Math.round((ms % HOUR) / MINUTE)}m`;
 }

--- a/packages/tree-core/tests/helpers.test.ts
+++ b/packages/tree-core/tests/helpers.test.ts
@@ -26,6 +26,9 @@ test('formatDuration renders ms, seconds and minutes', () => {
   assert.strictEqual(formatDuration(1000), '1s');
   assert.strictEqual(formatDuration(1500), '1.5s');
   assert.strictEqual(formatDuration(65000), '1m 5s');
+  assert.strictEqual(formatDuration(3600000), '1h 0m');
+  assert.strictEqual(formatDuration(3600000 + 125000), '1h 2m');
+  assert.strictEqual(formatDuration(9000000), '2h 30m');
   assert.strictEqual(formatDuration(undefined), '');
 });
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -1,0 +1,42 @@
+# @reporters/web
+
+A self-contained, interactive **HTML** tree reporter for `node:test`. It renders
+the whole run as a collapsible tree on a single, offline HTML page (React,
+inlined — no CDN, no network), with a summary, search/filter, per-test
+diagnostics, and light/dark themes.
+
+```bash
+node --test --test-reporter=@reporters/web --test-reporter-destination=report.html
+```
+
+It streams like every other reporter — it yields to whatever
+`--test-reporter-destination` points at.
+
+## Modes
+
+The reporter emits an NDJSON event log, consumed two ways via
+`REPORTERS_WEB_MODE`:
+
+- **`embedded`** (default) — a single, self-contained `.html` file with the React
+  app and the event log inlined. Works offline, as a CI artifact, or attached to
+  a gist. Even a crashed/interrupted run leaves a renderable partial file.
+- **`ndjson`** — the raw NDJSON event log only. Host it anywhere and open it in
+  the hosted viewer at **https://molow.github.io/reporters/** with
+  `?src=<url-to-your-run.ndjson>` to watch it live (the viewer polls the file as
+  it grows, using HTTP Range for newly appended lines).
+
+```bash
+# raw NDJSON for the hosted viewer
+REPORTERS_WEB_MODE=ndjson node --test \
+  --test-reporter=@reporters/web --test-reporter-destination=run.ndjson
+# then host run.ndjson and open: https://molow.github.io/reporters/?src=<its-url>
+```
+
+`embedded` is the default because it needs no hosting; `ndjson` is opt-in for the
+live hosted viewer. (The mode isn't inferred from TTY/CI: the reporter writes to
+a destination, not the terminal, so those signals don't say which format you
+want.) On completion the reporter prints a hint to stderr with the report path /
+viewer URL.
+
+Built on the shared `@reporters/tree-core` model (also used by
+[`@reporters/live`](https://www.npmjs.com/package/@reporters/live)).

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,7 +32,9 @@
   "devDependencies": {
     "@reporters/tree-core": "workspace:^",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "tsup": "^8.5.0",
+    "typescript": "^5.7.0"
   },
   "bugs": {
     "url": "https://github.com/MoLow/reporters/issues"

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,7 +1,10 @@
 import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { resolve } from 'node:path';
 import { serializeWireLine, type TestEvent } from '@reporters/tree-core';
 import { htmlHeader, HTML_FOOTER, safeEventLine } from './template.ts';
+
+const VIEWER_URL = 'https://molow.github.io/reporters/';
 
 function readClientBundle(): string {
   try {
@@ -10,6 +13,25 @@ function readClientBundle(): string {
   } catch {
     return '/* @reporters/web client bundle missing — run the package build */';
   }
+}
+
+/** Best-effort: the single file this reporter is being written to, parsed from
+ *  `--test-reporter-destination`. Undefined if there are none/many (ambiguous)
+ *  or the destination is a stream (stdout/stderr). */
+function soleFileDestination(): string | undefined {
+  const flag = '--test-reporter-destination';
+  const dests: string[] = [];
+  const { argv } = process;
+  for (let i = 0; i < argv.length; i += 1) {
+    if (argv[i] === flag && argv[i + 1]) dests.push(argv[i + 1]);
+    else if (argv[i].startsWith(`${flag}=`)) dests.push(argv[i].slice(flag.length + 1));
+  }
+  const files = dests.filter((d) => d && d !== 'stdout' && d !== 'stderr');
+  return files.length === 1 ? files[0] : undefined;
+}
+
+function hint(message: string): void {
+  process.stderr.write(`${message}\n`);
 }
 
 /**
@@ -21,16 +43,30 @@ function readClientBundle(): string {
  *    `--test-reporter-destination=report.html`.
  *  - `ndjson`: streams only the raw NDJSON event log, for the hosted viewer
  *    (open the viewer with `?src=<url-to-the-ndjson>`).
+ *
+ * `embedded` is the default deliberately: it's fully self-contained and works
+ * everywhere (offline, as a CI artifact, attached to a gist) with no hosting.
+ * `ndjson` is opt-in because it only becomes a report once its file is hosted
+ * and opened in the viewer. This isn't inferred from TTY / CI: the reporter
+ * writes to a destination (usually a file), not to the terminal, so those
+ * signals don't indicate which format is wanted.
  */
 export default async function* web(source: AsyncIterable<TestEvent>): AsyncGenerator<string> {
   const mode = process.env.REPORTERS_WEB_MODE === 'ndjson' ? 'ndjson' : 'embedded';
+  const dest = soleFileDestination();
 
   if (mode === 'ndjson') {
     for await (const event of source) yield serializeWireLine(event);
+    hint(dest
+      ? `\n@reporters/web: host ${resolve(dest)} and open ${VIEWER_URL}?src=<its-url>`
+      : `\n@reporters/web: open ${VIEWER_URL}?src=<url-to-your-ndjson> to view`);
     return;
   }
 
   yield htmlHeader(readClientBundle());
   for await (const event of source) yield safeEventLine(serializeWireLine(event));
   yield HTML_FOOTER;
+  hint(dest
+    ? `\n@reporters/web: report written to ${pathToFileURL(resolve(dest)).href}`
+    : '\n@reporters/web: open the generated HTML report in a browser');
 }

--- a/packages/web/tests/reporter.test.ts
+++ b/packages/web/tests/reporter.test.ts
@@ -76,3 +76,27 @@ test('ndjson mode logs a viewer hint to stderr', async () => {
 test('embedded mode logs a hint to stderr', async () => {
   assert.match(await collectStderr('embedded'), /report/i);
 });
+
+async function collectStderrWithArgv(mode: string, extraArgv: string[]): Promise<string> {
+  const originalArgv = process.argv;
+  process.argv = [...originalArgv, ...extraArgv];
+  try {
+    return await collectStderr(mode);
+  } finally {
+    process.argv = originalArgv;
+  }
+}
+
+test('embedded hint includes the destination file path (ignoring stdout destinations)', async () => {
+  const err = await collectStderrWithArgv('embedded', [
+    '--test-reporter-destination', 'stdout',
+    '--test-reporter-destination=report.html',
+  ]);
+  assert.match(err, /report written to file:\/\/.*report\.html/);
+});
+
+test('ndjson hint includes the destination and the viewer URL', async () => {
+  const err = await collectStderrWithArgv('ndjson', ['--test-reporter-destination=run.ndjson']);
+  assert.match(err, /run\.ndjson/);
+  assert.match(err, /molow\.github\.io\/reporters\/\?src=/);
+});

--- a/packages/web/tests/reporter.test.ts
+++ b/packages/web/tests/reporter.test.ts
@@ -55,3 +55,24 @@ test('safeEventLine neutralizes a literal closing script tag', () => {
   const escaped = safeEventLine('{"m":"</script>"}');
   assert.doesNotMatch(escaped, /<\/script>/);
 });
+
+async function collectStderr(mode: string): Promise<string> {
+  const original = process.stderr.write.bind(process.stderr);
+  let captured = '';
+  // @ts-expect-error test spy
+  process.stderr.write = (chunk: string) => { captured += chunk; return true; };
+  try {
+    await collect(mode);
+  } finally {
+    process.stderr.write = original;
+  }
+  return captured;
+}
+
+test('ndjson mode logs a viewer hint to stderr', async () => {
+  assert.match(await collectStderr('ndjson'), /molow\.github\.io\/reporters\/\?src=/);
+});
+
+test('embedded mode logs a hint to stderr', async () => {
+  assert.match(await collectStderr('embedded'), /report/i);
+});

--- a/scripts/mono-run.js
+++ b/scripts/mono-run.js
@@ -12,7 +12,12 @@ function runCommand(dir) {
   }
   try {
     // eslint-disable-next-line import/no-dynamic-require, global-require
-    const { name } = require(`../packages/${dir.name}/package.json`);
+    const { name, scripts } = require(`../packages/${dir.name}/package.json`);
+    // Skip packages that don't define the requested script (e.g. `build` only
+    // exists in the TypeScript packages), so `yarn mono build` just works.
+    if (!scripts || !scripts[cmd[0]]) {
+      return;
+    }
     const args = ['workspace', name, ...cmd];
     console.log(`Running "yarn ${args.join(' ')}" in ${name}`);
     const child = spawnSync('yarn', args, { stdio: 'inherit' });

--- a/yarn.lock
+++ b/yarn.lock
@@ -479,6 +479,8 @@ __metadata:
     "@reporters/tree-core": "workspace:^"
     ink: "npm:^6.0.0"
     react: "npm:^19.0.0"
+    tsup: "npm:^8.5.0"
+    typescript: "npm:^5.7.0"
   languageName: unknown
   linkType: soft
 
@@ -518,6 +520,9 @@ __metadata:
 "@reporters/tree-core@workspace:^, @reporters/tree-core@workspace:packages/tree-core":
   version: 0.0.0-use.local
   resolution: "@reporters/tree-core@workspace:packages/tree-core"
+  dependencies:
+    tsup: "npm:^8.5.0"
+    typescript: "npm:^5.7.0"
   languageName: unknown
   linkType: soft
 
@@ -528,6 +533,8 @@ __metadata:
     "@reporters/tree-core": "workspace:^"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
+    tsup: "npm:^8.5.0"
+    typescript: "npm:^5.7.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Follow-up to #193, addressing the inline review comments.

| Comment | Resolution |
|---|---|
| `format.ts`: support hours and more? | `formatDuration` now renders `h + m` beyond an hour (e.g. `2h 30m`); added tests. |
| `package.json`: why not `yarn mono build`? | Root `build` is now `yarn mono build`; `mono-run` skips packages that don't define the requested script (only tree-core/live/web have `build`). `test` is `yarn mono build && yarn mono test`. |
| `README.md`: should split out to own readme | Added `packages/live/README.md` and `packages/web/README.md`; the root README just lists them. |
| `web/index.ts`: default based on tty / GitHub Actions? | Kept `embedded` as the default and documented why: the reporter writes to a destination (a file), not the terminal, so TTY/CI don't indicate the desired *format*. `embedded` is self-contained and works everywhere; `ndjson` is opt-in for the hosted viewer. |
| `web/index.ts`: log a link to the viewer / html report to stderr? | On completion the reporter prints a stderr hint — the report file path (embedded) or the viewer URL (ndjson), derived from `--test-reporter-destination` when unambiguous. |

Verified: `yarn lint` clean, all package suites pass on Node v22 and v26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)