### PR TITLE
feat(web): implement the Panel design for the web report & live viewer

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -1,7 +1,18 @@
-import React, { useState } from 'react';
+import React, {
+  useEffect, useMemo, useState,
+} from 'react';
 import {
-  defaultExpanded, formatDuration, SYMBOLS, type Counts, type TestNode, type TreeSnapshot,
+  formatDuration, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
 } from '@reporters/tree-core';
+
+const GLYPH: Record<TestStatus, string> = {
+  passed: '✓', failed: '✕', skipped: '⊘', todo: '◇', running: '◐', queued: '○',
+};
+const STATUS_ORDER: TestStatus[] = ['passed', 'failed', 'skipped', 'todo', 'running', 'queued'];
+const SEVERITY: TestStatus[] = ['failed', 'running', 'queued', 'todo', 'skipped', 'passed'];
+const STATUS_LABEL: Record<TestStatus, string> = {
+  passed: 'passed', failed: 'failed', skipped: 'skipped', todo: 'todo', running: 'running', queued: 'queued',
+};
 
 function basename(file: string | undefined): string {
   if (!file) return '<unknown>';
@@ -9,170 +20,492 @@ function basename(file: string | undefined): string {
   return parts[parts.length - 1] || file;
 }
 
-function matches(node: TestNode, q: string): boolean {
-  if (!q) return true;
-  if (node.name.toLowerCase().includes(q) || basename(node.file).toLowerCase().includes(q)) return true;
-  return node.children.some((c) => matches(c, q));
+function displayName(node: TestNode): string {
+  return node.type === 'file' ? basename(node.file) : node.name;
+}
+
+function isContainer(node: TestNode): boolean {
+  return node.children.length > 0;
+}
+
+/** Container status = the worst status among descendants (severity order). */
+function rollup(node: TestNode): TestStatus {
+  if (!isContainer(node)) return node.status;
+  for (const s of SEVERITY) if (node.counts[s] > 0) return s;
+  return 'passed';
+}
+
+function sumDuration(node: TestNode): number {
+  if (!isContainer(node)) return node.durationMs ?? 0;
+  return node.children.reduce((total, child) => total + sumDuration(child), 0);
+}
+
+function reasonOf(node: TestNode): string | undefined {
+  if (typeof node.skip === 'string') return node.skip;
+  if (typeof node.todo === 'string') return node.todo;
+  return undefined;
 }
 
 function hasDiagnostics(node: TestNode): boolean {
-  return Boolean(node.error) || node.diagnostics.length > 0 || node.stdout.length > 0 || node.stderr.length > 0;
+  return Boolean(node.error)
+    || node.diagnostics.length > 0
+    || node.stdout.length > 0
+    || node.stderr.length > 0
+    || Boolean(reasonOf(node));
 }
 
-function Diagnostics({ node }: { node: TestNode }) {
+/** Severity of a test's diagnostics, for the row badge tint. */
+function diagSeverity(node: TestNode): TestStatus {
+  if (node.error || node.stderr.length > 0) return 'failed';
+  if (node.diagnostics.some((d) => d.level === 'warn')) return 'running';
+  return 'skipped';
+}
+
+function defaultExpanded(node: TestNode): boolean {
+  const { counts } = node;
+  if (node.type === 'file') return !(counts.total > 0 && counts.queued === counts.total);
+  if (node.type === 'suite') return counts.failed > 0 || counts.running > 0;
+  return false;
+}
+
+interface DiagBlock {
+  key: string;
+  title: string;
+  icon: string;
+  sev: TestStatus;
+  kind: 'error' | 'text' | 'list';
+  message?: string;
+  stack?: string;
+  text?: string;
+  err?: boolean;
+  items?: { level: string; sev: TestStatus; text: string }[];
+}
+
+function diagBlocks(node: TestNode): DiagBlock[] {
+  const blocks: DiagBlock[] = [];
+  if (node.error) {
+    blocks.push({
+      key: 'error', title: 'Error', icon: '✕', sev: 'failed', kind: 'error',
+      message: node.error.message, stack: node.error.stack ?? node.error.message,
+    });
+  }
+  if (node.stdout.length > 0) {
+    blocks.push({ key: 'stdout', title: 'stdout', icon: '›', sev: 'skipped', kind: 'text', text: node.stdout.join('') });
+  }
+  if (node.stderr.length > 0) {
+    blocks.push({ key: 'stderr', title: 'stderr', icon: '›', sev: 'failed', kind: 'text', text: node.stderr.join(''), err: true });
+  }
+  if (node.diagnostics.length > 0) {
+    blocks.push({
+      key: 'diag', title: 'diagnostics', icon: '◇', sev: 'skipped', kind: 'list',
+      items: node.diagnostics.map((d) => ({
+        level: d.level,
+        sev: d.level === 'error' ? 'failed' : d.level === 'warn' ? 'running' : 'skipped',
+        text: d.message,
+      })),
+    });
+  }
+  const reason = reasonOf(node);
+  if (reason) {
+    blocks.push({
+      key: 'reason', title: node.status === 'skipped' ? 'why skipped' : 'why todo',
+      icon: '⊘', sev: 'skipped', kind: 'text', text: reason,
+    });
+  }
+  return blocks;
+}
+
+interface FlatRow {
+  node: TestNode;
+  depth: number;
+  status: TestStatus;
+  container: boolean;
+  expanded: boolean;
+  hasDiag: boolean;
+  diagOpen: boolean;
+}
+
+interface Matches {
+  visible: Set<string>;
+  force: Set<string>;
+}
+
+function computeMatches(files: TestNode[], query: string): Matches {
+  const visible = new Set<string>();
+  const force = new Set<string>();
+  const addSubtree = (node: TestNode): void => {
+    for (const child of node.children) { visible.add(child.key); addSubtree(child); }
+  };
+  const walk = (node: TestNode, ancestors: string[]): boolean => {
+    const self = displayName(node).toLowerCase().includes(query);
+    let desc = false;
+    for (const child of node.children) if (walk(child, [...ancestors, node.key])) desc = true;
+    if (self || desc) {
+      visible.add(node.key);
+      for (const a of ancestors) visible.add(a);
+      if (desc) { force.add(node.key); for (const a of ancestors) force.add(a); }
+      if (self && node.children.length > 0) addSubtree(node);
+      return true;
+    }
+    return false;
+  };
+  for (const file of files) walk(file, []);
+  return { visible, force };
+}
+
+interface BuildOptions {
+  overrides: Map<string, boolean>;
+  query: string;
+  matches: Matches | null;
+}
+
+function isExpanded(node: TestNode, opts: BuildOptions): boolean {
+  if (opts.query && opts.matches?.force.has(node.key)) return true;
+  const { overrides } = opts;
+  return overrides.has(node.key) ? overrides.get(node.key)! : defaultExpanded(node);
+}
+
+function isDiagOpen(node: TestNode, overrides: Map<string, boolean>): boolean {
+  const key = `${node.key}::diag`;
+  return overrides.has(key) ? overrides.get(key)! : node.status === 'failed';
+}
+
+function buildRows(files: TestNode[], opts: BuildOptions): FlatRow[] {
+  const rows: FlatRow[] = [];
+  const push = (node: TestNode, depth: number): void => {
+    if (opts.query && !opts.matches!.visible.has(node.key)) return;
+    const container = isContainer(node);
+    const expanded = container && isExpanded(node, opts);
+    const diag = !container && hasDiagnostics(node);
+    rows.push({
+      node,
+      depth,
+      status: rollup(node),
+      container,
+      expanded,
+      hasDiag: diag,
+      diagOpen: diag && isDiagOpen(node, opts.overrides),
+    });
+    if (container && expanded) {
+      for (const child of node.children) push(child, depth + 1);
+    }
+  };
+  for (const file of files) push(file, 0);
+  return rows;
+}
+
+function collectContainerKeys(nodes: TestNode[], into: string[]): void {
+  for (const node of nodes) {
+    if (isContainer(node)) { into.push(node.key); collectContainerKeys(node.children, into); }
+  }
+}
+
+function computeTheme(): 'dark' | 'light' {
+  try {
+    const forced = new URLSearchParams(window.location.search).get('theme');
+    if (forced === 'dark' || forced === 'light') return forced;
+  } catch { /* location may be unavailable */ }
+  return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function useTheme(): void {
+  useEffect(() => {
+    const apply = () => { document.documentElement.dataset.theme = computeTheme(); };
+    apply();
+    const mq = window.matchMedia?.('(prefers-color-scheme: dark)');
+    mq?.addEventListener('change', apply);
+    return () => mq?.removeEventListener('change', apply);
+  }, []);
+}
+
+const SearchIcon = () => (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
+    <circle cx="11" cy="11" r="7" />
+    <line x1="21" y1="21" x2="16.5" y2="16.5" />
+  </svg>
+);
+
+function Diagnostics({ node, indent }: { node: TestNode; indent: string }) {
   return (
-    <div className={`diag${node.error ? ' has-error' : ''}`}>
-      {node.error ? (
-        <section>
-          <div className="label">error</div>
-          <pre className="err">{node.error.stack || node.error.message}</pre>
-        </section>
-      ) : null}
-      {node.diagnostics.length > 0 ? (
-        <section>
-          <div className="label">diagnostics</div>
-          <pre>{node.diagnostics.map((d) => d.message).join('\n')}</pre>
-        </section>
-      ) : null}
-      {node.stdout.length > 0 ? (
-        <section>
-          <div className="label">stdout</div>
-          <pre>{node.stdout.join('')}</pre>
-        </section>
-      ) : null}
-      {node.stderr.length > 0 ? (
-        <section>
-          <div className="label">stderr</div>
-          <pre>{node.stderr.join('')}</pre>
-        </section>
-      ) : null}
+    <div className="diag" style={{ margin: `5px 12px 11px ${indent}` }}>
+      {diagBlocks(node).map((block) => (
+        <div className="diag-sec" key={block.key}>
+          <span className="diag-bar" data-stf={block.sev} />
+          <div className="diag-body">
+            <div className="diag-head">
+              <span className="diag-icon" data-stc={block.sev}>{block.icon}</span>
+              <span className="diag-title">{block.title}</span>
+            </div>
+            {block.kind === 'error' ? (
+              <>
+                <div className="diag-msg"><span data-stc="failed">{block.message}</span></div>
+                <pre className="stack">{block.stack}</pre>
+              </>
+            ) : null}
+            {block.kind === 'text' ? (
+              <pre className={`text${block.err ? ' err' : ''}`}>{block.text}</pre>
+            ) : null}
+            {block.kind === 'list' ? (
+              <div className="diag-list">
+                {block.items!.map((item, i) => (
+                  <div className="diag-item" key={i}>
+                    <span className="diag-level" data-soft={item.sev}>{item.level}</span>
+                    <span className="txt">{item.text}</span>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ))}
     </div>
   );
 }
 
-interface RowProps {
-  node: TestNode;
-  query: string;
-  overrides: Map<string, boolean>;
-  toggle: (key: string, value: boolean) => void;
+interface RowViewProps {
+  row: FlatRow;
+  dense: boolean;
+  toggle: (key: string, current: boolean) => void;
 }
 
-function Row({
-  node, query, overrides, toggle,
-}: RowProps) {
-  if (!matches(node, query.toLowerCase())) return null;
-
-  const isContainer = node.children.length > 0;
-  const diag = hasDiagnostics(node);
-  const open = overrides.has(node.key) ? overrides.get(node.key)! : defaultExpanded(node);
-  const diagKey = `${node.key}::diag`;
-  const diagOpen = overrides.has(diagKey) ? overrides.get(diagKey)! : node.status === 'failed';
-
-  const label = node.type === 'file' ? basename(node.file) : node.name;
-  const clickable = isContainer || diag;
-  const onClick = () => {
-    if (isContainer) toggle(node.key, open);
-    else if (diag) toggle(diagKey, diagOpen);
+function RowView({ row, dense, toggle }: RowViewProps) {
+  const {
+    node, depth, status, container, expanded, hasDiag, diagOpen,
+  } = row;
+  const clickable = container || hasDiag;
+  const activate = () => {
+    if (container) toggle(node.key, expanded);
+    else if (hasDiag) toggle(`${node.key}::diag`, diagOpen);
+  };
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activate(); }
+    else if (e.key === 'ArrowRight' && ((container && !expanded) || (hasDiag && !diagOpen))) { e.preventDefault(); activate(); }
+    else if (e.key === 'ArrowLeft' && ((container && expanded) || (hasDiag && diagOpen))) { e.preventDefault(); activate(); }
   };
 
+  const counts = node.counts;
+  const isTest = node.type === 'test';
+  const nameColor = isTest && status === 'failed' ? 'var(--st-failed)'
+    : isTest && (status === 'skipped' || status === 'todo' || status === 'queued') ? 'var(--dim)'
+      : 'var(--fg)';
+  const ariaExpanded = container ? expanded : hasDiag ? diagOpen : undefined;
+  const step = dense ? 15 : 20;
+  const indent = `${depth * step + (dense ? 30 : 38)}px`;
+
   return (
-    <div className="node">
+    <div>
       <div
-        className={`row status-${node.status}${clickable ? ' clickable' : ''}`}
-        onClick={clickable ? onClick : undefined}
-        role={clickable ? 'button' : undefined}
-        tabIndex={clickable ? 0 : undefined}
-        onKeyDown={clickable ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } } : undefined}
+        className="row"
+        role="treeitem"
+        aria-expanded={ariaExpanded}
+        aria-label={`${displayName(node)}, ${status}${container ? `, ${counts.total} tests` : ''}`}
+        tabIndex={0}
+        data-clickable={clickable}
+        data-fail={isTest && status === 'failed'}
+        onClick={clickable ? activate : undefined}
+        onKeyDown={onKeyDown}
       >
-        <span className="twist">{isContainer ? (open ? '▾' : '▸') : diag ? '◆' : ''}</span>
-        <span className="glyph">{SYMBOLS[node.status]}</span>
-        <span className={`name${node.type === 'file' ? ' file' : ''}`}>{label}</span>
-        {node.durationMs != null ? <span className="dur">{formatDuration(node.durationMs)}</span> : null}
-        {isContainer && !open ? (
-          <span className="tally">
-            {node.counts.passed} {SYMBOLS.passed}
-            {node.counts.failed ? ` · ${node.counts.failed} ${SYMBOLS.failed}` : ''}
+        <span className="guides">
+          {Array.from({ length: depth }, (_, i) => <span className="guide" key={i} />)}
+        </span>
+        <span className="caret">{container ? (expanded ? '▾' : '▸') : ''}</span>
+        {isTest ? (
+          <span className="dot" data-stf={status} data-spin={status === 'running' ? 'true' : undefined} />
+        ) : (
+          <span className="cglyph" data-stc={status}>{GLYPH[status]}</span>
+        )}
+        <span className="name" data-kind={node.type} style={{ color: nameColor }}>{displayName(node)}</span>
+        {hasDiag ? (
+          <span className="diagbadge" data-soft={diagSeverity(node)}>{diagOpen ? 'Hide' : 'Details'}</span>
+        ) : null}
+        <span className="spacer" />
+        {container && !expanded ? (
+          <span className="pills">
+            {STATUS_ORDER.filter((s) => counts[s] > 0).map((s) => (
+              <span className="pill" data-soft={s} key={s}>{counts[s]}</span>
+            ))}
           </span>
         ) : null}
+        <span className="dur">{formatDuration(sumDuration(node)) || '—'}</span>
       </div>
-      {!isContainer && diag && diagOpen ? <Diagnostics node={node} /> : null}
-      {isContainer && open ? (
-        <div className="children">
-          {node.children.map((child) => (
-            <Row key={child.key} node={child} query={query} overrides={overrides} toggle={toggle} />
-          ))}
-        </div>
-      ) : null}
+      {hasDiag && diagOpen ? <Diagnostics node={node} indent={indent} /> : null}
     </div>
   );
 }
 
-function verdictOf(snapshot: TreeSnapshot): { cls: string; label: string } {
-  const { counts, summary } = snapshot;
-  if (summary) return summary.success ? { cls: 'v-passed', label: 'passed' } : { cls: 'v-failed', label: 'failed' };
-  if (counts.failed > 0) return { cls: 'v-failed', label: 'failing' };
-  if (counts.running > 0 || counts.queued > 0) return { cls: 'v-running', label: 'running' };
-  return { cls: 'v-passed', label: 'passed' };
-}
-
-function Meter({ counts }: { counts: Counts }) {
-  const total = Math.max(counts.total, 1);
-  const seg = (n: number, color: string) => (n > 0
-    ? <span key={color} style={{ width: `${(n / total) * 100}%`, background: color }} /> : null);
+function Verdict({ counts, inProgress, duration }: { counts: Counts; inProgress: boolean; duration: number }) {
+  const status: TestStatus = inProgress ? 'running' : counts.failed > 0 ? 'failed' : 'passed';
+  const label = inProgress ? 'Running' : counts.failed > 0 ? 'Failing' : 'Passing';
   return (
-    <div className="meter">
-      {seg(counts.passed, 'var(--passed)')}
-      {seg(counts.failed, 'var(--failed)')}
-      {seg(counts.skipped, 'var(--skipped)')}
-      {seg(counts.todo, 'var(--todo)')}
-      {seg(counts.running, 'var(--running)')}
-      {seg(counts.queued, 'var(--queued)')}
+    <div className="verdict" data-soft={status}>
+      <span className="verdict-glyph" data-spin={inProgress ? 'true' : undefined}>{GLYPH[status]}</span>
+      <div className="verdict-text">
+        <span className="verdict-main">{label}</span>
+        <span className="verdict-sub">
+          {counts.total}
+          {counts.total === 1 ? ' test' : ' tests'}
+          {' · '}
+          {formatDuration(duration) || '—'}
+        </span>
+      </div>
     </div>
   );
 }
 
-export function TreeView({ snapshot }: { snapshot: TreeSnapshot }) {
+function CenteredState({
+  icon, iconStatus, pulse, title, children,
+}: {
+  icon: string; iconStatus: TestStatus; pulse?: boolean; title: string; children?: React.ReactNode;
+}) {
+  return (
+    <div className="state">
+      <div className="state-icon" data-soft={iconStatus} data-pulse={pulse ? 'true' : undefined}>{icon}</div>
+      <div className="state-title">{title}</div>
+      {children}
+    </div>
+  );
+}
+
+export interface TreeViewProps {
+  snapshot: TreeSnapshot;
+  /** The viewer is still polling a live log (no final summary yet). */
+  streaming?: boolean;
+  /** The viewer's `?src=` is missing or unreachable. */
+  loadError?: boolean;
+  onRetry?: () => void;
+}
+
+export function TreeView({
+  snapshot, streaming = false, loadError = false, onRetry,
+}: TreeViewProps) {
+  useTheme();
   const [query, setQuery] = useState('');
+  const [dense, setDense] = useState(false);
   const [overrides, setOverrides] = useState<Map<string, boolean>>(new Map());
-  const toggle = (key: string, value: boolean) => {
-    setOverrides((prev) => new Map(prev).set(key, !value));
+
+  const files = snapshot.root.children;
+  const { counts } = snapshot;
+  const q = query.trim().toLowerCase();
+
+  const matches = useMemo(() => (q ? computeMatches(files, q) : null), [files, q]);
+  const rows = useMemo(
+    () => buildRows(files, { overrides, query: q, matches }),
+    [files, overrides, q, matches],
+  );
+
+  const toggle = (key: string, current: boolean) => {
+    setOverrides((prev) => new Map(prev).set(key, !current));
+  };
+  const collapseAll = () => {
+    const keys: string[] = [];
+    collectContainerKeys(files, keys);
+    setOverrides((prev) => {
+      const next = new Map(prev);
+      for (const key of keys) next.set(key, false);
+      return next;
+    });
   };
 
-  const { counts } = snapshot;
-  const verdict = verdictOf(snapshot);
-  const chip = (n: number, sym: string, cls: string, show = true) => (show ? (
-    <span className={`chip c-${cls}`}><span className="g">{sym}</span>{n}</span>
-  ) : null);
+  const inProgress = !snapshot.summary && (streaming || counts.running > 0 || counts.queued > 0);
+  const duration = snapshot.summary ? snapshot.summary.durationMs : sumDuration(snapshot.root);
+
+  if (loadError) {
+    return (
+      <div className="app" data-dense={dense}>
+        <CenteredState icon="⚠" iconStatus="failed" title="Couldn’t load the live log">
+          <div className="state-sub">
+            The viewer needs a <code style={{ fontFamily: 'var(--mono)', color: 'var(--st-todo)' }}>?src=</code>
+            {' '}that points at a reachable test log. It’s missing or the URL didn’t respond.
+          </div>
+          <code className="state-cmd">
+            …/viewer.html<span data-stc="todo">?src=https://ci.example/run-8821.ndjson</span>
+          </code>
+          {onRetry ? <button type="button" className="btn-primary" onClick={onRetry}>Retry</button> : null}
+        </CenteredState>
+      </div>
+    );
+  }
+
+  const statChips = STATUS_ORDER.filter((s) => s === 'passed' || s === 'failed' || counts[s] > 0);
+  const total = Math.max(counts.total, 1);
+  const barSegments = STATUS_ORDER.filter((s) => counts[s] > 0);
 
   return (
-    <div className="app">
-      <div className="statusbar">
-        <span className="brand"><b>node:test</b> report</span>
-        <span className={`verdict ${verdict.cls}`}><span className="dot" />{verdict.label}</span>
-        <span className="chips">
-          {chip(counts.passed, SYMBOLS.passed, 'passed')}
-          {chip(counts.failed, SYMBOLS.failed, 'failed')}
-          {chip(counts.skipped, SYMBOLS.skipped, 'skipped', counts.skipped > 0)}
-          {chip(counts.todo, SYMBOLS.todo, 'todo', counts.todo > 0)}
-          {chip(counts.running, SYMBOLS.running, 'running', counts.running > 0)}
-        </span>
-        <Meter counts={counts} />
-        {snapshot.summary ? <span className="dur">{formatDuration(snapshot.summary.durationMs)}</span> : null}
-        <input
-          className="search"
-          placeholder="filter tests…"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          aria-label="filter tests"
-        />
+    <div className="app" data-dense={dense}>
+      <header className="hdr">
+        <div className="hdr-row">
+          <Verdict counts={counts} inProgress={inProgress} duration={duration} />
+          <div className="chips">
+            {statChips.map((s) => (
+              <span className="chip" data-soft={s} key={s}>
+                <span className="chip-dot" data-stf={s} />
+                {counts[s]}
+                <span className="chip-label">{STATUS_LABEL[s]}</span>
+              </span>
+            ))}
+          </div>
+          <div className="tools">
+            <div className="search">
+              <SearchIcon />
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Filter tests"
+                aria-label="Filter tests"
+              />
+            </div>
+            <button type="button" className="btn" onClick={() => setDense((d) => !d)} title="Toggle density">
+              {dense ? 'Compact' : 'Cozy'}
+            </button>
+            <button type="button" className="btn" onClick={collapseAll} title="Collapse all">Collapse</button>
+          </div>
+        </div>
+        <div className="hdr-bar-row">
+          <div className="bar">
+            {barSegments.map((s) => (
+              <span
+                key={s}
+                data-stf={s}
+                data-pulse={s === 'running' ? 'true' : undefined}
+                style={{ width: `${(counts[s] / total) * 100}%` }}
+              />
+            ))}
+          </div>
+        </div>
+      </header>
+
+      <div className="tree" role="tree" aria-label="Test results">
+        {rows.length > 0 ? (
+          rows.map((row) => <RowView key={row.node.key} row={row} dense={dense} toggle={toggle} />)
+        ) : q ? (
+          <CenteredState icon="⌕" iconStatus="skipped" title={`No tests match “${query.trim()}”`}>
+            <div className="state-sub">Try a shorter query, or search by file name.</div>
+            <button type="button" className="btn-primary" onClick={() => setQuery('')}>Clear filter</button>
+          </CenteredState>
+        ) : (
+          <CenteredState icon="◴" iconStatus="queued" pulse title="Waiting for the first results">
+            <div className="state-sub">
+              No test files have reported yet. Results stream in file-by-file as the run progresses.
+            </div>
+            <code className="state-cmd">node --test --test-reporter @reporters/web</code>
+          </CenteredState>
+        )}
       </div>
-      {snapshot.root.children.length === 0 ? (
-        <div className="empty">No tests reported yet.</div>
-      ) : (
-        snapshot.root.children.map((file) => (
-          <Row key={file.key} node={file} query={query} overrides={overrides} toggle={toggle} />
-        ))
-      )}
+
+      <footer className="footer">
+        <span className="brand">@reporters/web</span>
+        <span>·</span>
+        <span>
+          {inProgress ? 'Live · streaming results'
+            : snapshot.summary ? 'Run complete'
+              : rows.length === 0 ? 'Awaiting run' : 'Run complete'}
+        </span>
+        <span className="legend">
+          {STATUS_ORDER.map((s) => (
+            <span key={s}><span className="ldot" data-stf={s} />{s}</span>
+          ))}
+        </span>
+      </footer>
     </div>
   );
 }

--- a/packages/web/src/client/viewer.tsx
+++ b/packages/web/src/client/viewer.tsx
@@ -22,15 +22,23 @@ async function main(): Promise<void> {
   if (!mount) return;
   const root = createRoot(mount);
 
+  let store: TreeStore = createTreeStore();
+  let streaming = true;
+  let loadError = false;
+  const retry = () => window.location.reload();
+  const draw = () => root.render(
+    <TreeView snapshot={store.getSnapshot()} streaming={streaming} loadError={loadError} onRetry={retry} />,
+  );
+
   const src = new URLSearchParams(window.location.search).get('src');
   if (!src) {
-    mount.innerHTML = '<div class="empty">Add <code>?src=&lt;url-to-your-run.ndjson&gt;</code> to view a report.</div>';
+    streaming = false;
+    loadError = true;
+    draw();
     return;
   }
 
-  let store: TreeStore = createTreeStore();
   const reader = createNdjsonReader(src);
-  const draw = () => root.render(<TreeView snapshot={store.getSnapshot()} />);
   draw();
 
   // Poll until the run reports a final summary, then stop.
@@ -39,10 +47,13 @@ async function main(): Promise<void> {
       const { events, reset } = await reader.pull();
       if (reset) store = createTreeStore();
       for (const event of events) store.apply(event);
+      loadError = false;
+      if (store.getSnapshot().summary) { streaming = false; draw(); break; }
       if (events.length || reset) draw();
-      if (store.getSnapshot().summary) { draw(); break; }
     } catch (err) {
-      // Transient fetch/CORS error: keep trying.
+      // Never received any data yet: the source is missing/unreachable — surface
+      // the error screen. Once data has arrived, treat failures as transient.
+      if (store.getSnapshot().root.children.length === 0) { loadError = true; draw(); }
       console.error(err);
     }
     await delay(POLL_MS);

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -1,118 +1,144 @@
+const DARK = `
+  --bg:#0d0e12; --panel:#15171e; --panel-2:#1a1d26; --raise:#20242f; --inset:#0a0b0e;
+  --fg:#eceef3; --dim:#9aa1ad; --faint:#646b78;
+  --line:rgba(255,255,255,.08); --line-2:rgba(255,255,255,.14);
+  --row-hover:rgba(255,255,255,.04);
+  --accent:#8b7cff; --accent-ink:#0c0a1f;
+  --st-passed:#34d27b; --st-failed:#fb5a6a; --st-skipped:#8a93a1; --st-todo:#7c9cff; --st-running:#ffb13d; --st-queued:#5d6573;
+  --soft-passed:rgba(52,210,123,.15); --soft-failed:rgba(251,90,106,.16); --soft-skipped:rgba(138,147,161,.16); --soft-todo:rgba(124,156,255,.16); --soft-running:rgba(255,177,61,.17); --soft-queued:rgba(93,101,115,.18);
+  --fail-tint:rgba(251,90,106,.07);
+`;
+
+const LIGHT = `
+  --bg:#f6f7f9; --panel:#ffffff; --panel-2:#f4f6f8; --raise:#eef1f4; --inset:#f8f9fb;
+  --fg:#161b22; --dim:#5a636f; --faint:#9099a5;
+  --line:rgba(17,24,33,.10); --line-2:rgba(17,24,33,.18);
+  --row-hover:rgba(17,24,33,.035);
+  --accent:#6357e6; --accent-ink:#ffffff;
+  --st-passed:#16a34a; --st-failed:#e23744; --st-skipped:#697381; --st-todo:#3f63d6; --st-running:#bf7400; --st-queued:#97a0ad;
+  --soft-passed:rgba(22,163,74,.12); --soft-failed:rgba(226,55,68,.10); --soft-skipped:rgba(105,115,129,.12); --soft-todo:rgba(63,99,214,.11); --soft-running:rgba(191,116,0,.13); --soft-queued:rgba(151,160,173,.14);
+  --fail-tint:rgba(226,55,68,.05);
+`;
+
 export const STYLES = `
 :root {
-  --bg: #0a0c11; --surface: #0f131a; --surface-2: #151b24; --border: #202833;
-  --guide: #1b222c; --text: #dbe2ec; --muted: #6c7787; --accent: #7aa2f7;
-  --passed: #3fb950; --failed: #f85149; --skipped: #d8a020;
-  --todo: #b083f0; --running: #58a6ff; --queued: #6c7787;
-  --shadow: 0 1px 0 rgba(0,0,0,.4), 0 8px 24px rgba(0,0,0,.25);
+  --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
 }
-@media (prefers-color-scheme: light) {
-  :root {
-    --bg: #f6f8fb; --surface: #ffffff; --surface-2: #eef2f7; --border: #dde4ec;
-    --guide: #e6ebf2; --text: #1b2733; --muted: #69727f; --accent: #2f5fd0;
-    --passed: #1a7f37; --failed: #cf222e; --skipped: #9a6700;
-    --todo: #8250df; --running: #0969da; --queued: #8b949e;
-    --shadow: 0 1px 2px rgba(31,41,55,.08), 0 8px 24px rgba(31,41,55,.06);
-  }
-}
+:root[data-theme="dark"] {${DARK}}
+:root[data-theme="light"] {${LIGHT}}
+@media (prefers-color-scheme: dark) { :root:not([data-theme]) {${DARK}} }
+@media (prefers-color-scheme: light) { :root:not([data-theme]) {${LIGHT}} }
+
 * { box-sizing: border-box; }
-html { color-scheme: dark light; }
+html, body { height: 100%; margin: 0; }
 body {
-  margin: 0; background: var(--bg); color: var(--text);
-  font-family: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
-  font-size: 13px; line-height: 1.6;
+  background: var(--bg); color: var(--fg);
+  font-family: var(--sans); font-size: 14px; line-height: 1.5;
   -webkit-font-smoothing: antialiased;
 }
-.font-ui { font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; }
-.app { max-width: 1040px; margin: 0 auto; padding: 0 20px 96px; }
+#root { height: 100%; }
+button { font-family: inherit; } input { font-family: inherit; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 6px; }
+::-webkit-scrollbar { width: 11px; height: 11px; }
+::-webkit-scrollbar-thumb { background: var(--line-2); border-radius: 7px; border: 3px solid transparent; background-clip: padding-box; }
+::-webkit-scrollbar-track { background: transparent; }
 
-/* ---- status bar ---- */
-.statusbar {
-  position: sticky; top: 0; z-index: 10;
-  display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
-  padding: 14px 16px; margin: 0 -16px 18px;
-  background: color-mix(in srgb, var(--bg) 82%, transparent);
-  backdrop-filter: blur(12px); -webkit-backdrop-filter: blur(12px);
-  border-bottom: 1px solid var(--border);
-}
-.brand {
-  font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
-  font-weight: 700; letter-spacing: -.01em; font-size: 14px; color: var(--muted);
-}
-.brand b { color: var(--text); }
-.verdict {
-  font-family: system-ui, -apple-system, sans-serif;
-  display: inline-flex; align-items: center; gap: 8px;
-  font-weight: 700; font-size: 12px; letter-spacing: .08em; text-transform: uppercase;
-  padding: 5px 12px; border-radius: 999px; border: 1px solid transparent;
-}
-.verdict .dot { width: 8px; height: 8px; border-radius: 50%; background: currentColor; }
-.verdict.v-passed { color: var(--passed); background: color-mix(in srgb, var(--passed) 14%, transparent); border-color: color-mix(in srgb, var(--passed) 35%, transparent); }
-.verdict.v-failed { color: var(--failed); background: color-mix(in srgb, var(--failed) 14%, transparent); border-color: color-mix(in srgb, var(--failed) 35%, transparent); }
-.verdict.v-running { color: var(--running); background: color-mix(in srgb, var(--running) 14%, transparent); border-color: color-mix(in srgb, var(--running) 35%, transparent); }
-.chips { display: flex; align-items: center; gap: 12px; }
-.chip { display: inline-flex; align-items: baseline; gap: 5px; font-weight: 600; font-variant-numeric: tabular-nums; }
-.chip .g { font-size: 12px; }
-.chip.c-passed { color: var(--passed); } .chip.c-failed { color: var(--failed); }
-.chip.c-skipped { color: var(--skipped); } .chip.c-todo { color: var(--todo); }
-.chip.c-running { color: var(--running); }
-.meter { flex: 1 1 160px; min-width: 100px; height: 6px; border-radius: 999px; background: var(--surface-2); overflow: hidden; display: flex; }
-.meter > span { height: 100%; }
-.dur { color: var(--muted); font-variant-numeric: tabular-nums; }
-.search {
-  font-family: system-ui, -apple-system, sans-serif;
-  background: var(--surface-2); border: 1px solid var(--border); color: var(--text);
-  border-radius: 8px; padding: 7px 11px; font-size: 13px; width: 160px; transition: border-color .15s, box-shadow .15s;
-}
-.search:focus { outline: none; border-color: var(--accent); box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 25%, transparent); }
-.search::placeholder { color: var(--muted); }
+/* status color helpers */
+[data-stc="passed"]{color:var(--st-passed)} [data-stc="failed"]{color:var(--st-failed)} [data-stc="skipped"]{color:var(--st-skipped)} [data-stc="todo"]{color:var(--st-todo)} [data-stc="running"]{color:var(--st-running)} [data-stc="queued"]{color:var(--st-queued)}
+[data-stf="passed"]{background:var(--st-passed)} [data-stf="failed"]{background:var(--st-failed)} [data-stf="skipped"]{background:var(--st-skipped)} [data-stf="todo"]{background:var(--st-todo)} [data-stf="running"]{background:var(--st-running)} [data-stf="queued"]{background:var(--st-queued)}
+[data-soft="passed"]{background:var(--soft-passed);color:var(--st-passed)} [data-soft="failed"]{background:var(--soft-failed);color:var(--st-failed)} [data-soft="skipped"]{background:var(--soft-skipped);color:var(--st-skipped)} [data-soft="todo"]{background:var(--soft-todo);color:var(--st-todo)} [data-soft="running"]{background:var(--soft-running);color:var(--st-running)} [data-soft="queued"]{background:var(--soft-queued);color:var(--st-queued)}
 
-/* ---- tree ---- */
-.children { margin-left: 9px; padding-left: 15px; border-left: 1px solid var(--guide); }
-.row {
-  position: relative; display: flex; align-items: center; gap: 8px;
-  padding: 3px 10px 3px 8px; border-radius: 7px; margin-left: -8px;
-  border-left: 2px solid transparent;
-}
-.row.clickable { cursor: pointer; }
-.row.clickable:hover { background: var(--surface); }
-.row.status-failed { border-left-color: color-mix(in srgb, var(--failed) 55%, transparent); }
-.row.status-running { border-left-color: color-mix(in srgb, var(--running) 55%, transparent); }
-.twist { width: .9em; flex: 0 0 auto; color: var(--muted); font-size: 11px; }
-.glyph { width: 1.1em; flex: 0 0 auto; text-align: center; }
-.name { flex: 1 1 auto; white-space: pre-wrap; word-break: break-word; }
-.name.file { font-family: system-ui, -apple-system, sans-serif; font-weight: 650; letter-spacing: -.01em; }
-.tally { color: var(--muted); font-size: 12px; }
-.status-passed > .glyph, .row.status-passed .glyph { color: var(--passed); }
-.status-failed .glyph { color: var(--failed); }
-.status-skipped .glyph { color: var(--skipped); }
-.status-todo .glyph { color: var(--todo); }
-.status-running .glyph { color: var(--running); }
-.status-queued .glyph { color: var(--queued); }
-.row.status-running .glyph { animation: pulse 1.2s ease-in-out infinite; }
-@keyframes pulse { 50% { opacity: .35; } }
+/* motion */
+@keyframes pspin { to { transform: rotate(360deg); } }
+@keyframes ppulse { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
+[data-spin="true"] { display: inline-block; animation: pspin 1s linear infinite; }
+[data-pulse="true"] { animation: ppulse 1.5s ease-in-out infinite; }
+@media (prefers-reduced-motion: reduce) { [data-spin="true"], [data-pulse="true"] { animation: none; } }
 
-/* ---- diagnostics ---- */
-.diag {
-  margin: 6px 0 8px 6px; padding: 12px 14px; background: var(--surface);
-  border: 1px solid var(--border); border-left: 3px solid var(--border);
-  border-radius: 8px; overflow-x: auto; box-shadow: var(--shadow);
-}
-.diag.has-error { border-left-color: var(--failed); }
-.diag section + section { margin-top: 12px; }
-.diag .label {
-  font-family: system-ui, -apple-system, sans-serif;
-  color: var(--muted); font-size: 10px; font-weight: 700; text-transform: uppercase;
-  letter-spacing: .09em; margin-bottom: 5px;
-}
-.diag pre { margin: 0; white-space: pre-wrap; word-break: break-word; font-size: 12.5px; }
-.diag pre.err { color: var(--failed); }
-.empty {
-  font-family: system-ui, -apple-system, sans-serif;
-  color: var(--muted); padding: 64px 24px; text-align: center; font-size: 15px;
-}
-.empty code { font-family: ui-monospace, monospace; background: var(--surface-2); padding: 2px 6px; border-radius: 5px; }
-@media (prefers-reduced-motion: reduce) { * { animation: none !important; transition: none !important; } }
+/* app shell */
+.app { height: 100%; display: flex; flex-direction: column; }
+.app[data-dense="false"] { --rh: 34px; --fs: 13.5px; --ind: 20px; }
+.app[data-dense="true"]  { --rh: 26px; --fs: 12.5px; --ind: 15px; }
+.loading { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 13px; }
+
+/* header */
+.hdr { flex: none; background: var(--panel); border-bottom: 1px solid var(--line); position: sticky; top: 0; z-index: 5; }
+.hdr-row { display: flex; align-items: center; gap: 16px; padding: 15px 18px 13px; flex-wrap: wrap; }
+.verdict { display: inline-flex; align-items: center; gap: 9px; padding: 8px 15px 8px 12px; border-radius: 12px; }
+.verdict-glyph { font-size: 17px; font-weight: 800; line-height: 1; }
+.verdict-text { display: flex; flex-direction: column; line-height: 1.15; }
+.verdict-main { font-size: 15px; font-weight: 700; letter-spacing: .01em; }
+.verdict-sub { font-size: 11px; opacity: .85; }
+.chips { display: flex; gap: 7px; align-items: center; flex-wrap: wrap; }
+.chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+.chip-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
+.chip-label { opacity: .7; font-weight: 500; }
+.tools { margin-left: auto; display: flex; gap: 9px; align-items: center; }
+.search { position: relative; display: flex; align-items: center; }
+.search svg { position: absolute; left: 11px; color: var(--faint); pointer-events: none; }
+.search input { background: var(--panel-2); border: 1px solid var(--line); color: var(--fg); font-size: 13px; padding: 8px 12px 8px 32px; border-radius: 10px; width: 188px; outline: none; }
+.btn { background: var(--panel-2); border: 1px solid var(--line); color: var(--dim); border-radius: 10px; padding: 8px 11px; font-size: 12px; cursor: pointer; transition: background .13s, color .13s; }
+.btn:hover { background: var(--raise); color: var(--fg); }
+.hdr-bar-row { padding: 0 18px 13px; display: flex; align-items: center; gap: 14px; }
+.bar { flex: 1; min-width: 220px; height: 9px; display: flex; gap: 2px; border-radius: 999px; overflow: hidden; background: var(--panel-2); }
+.bar > span { height: 100%; }
+
+/* tree */
+.tree { flex: 1; overflow: auto; min-height: 0; padding: 8px 10px 28px; }
+.row { display: flex; align-items: center; gap: 8px; min-height: var(--rh); padding: 0 12px; border-radius: 9px; }
+.row[data-clickable="true"] { cursor: pointer; }
+.row:hover { background: var(--row-hover); }
+.row[data-fail="true"] { background: var(--fail-tint); }
+.guides { display: flex; flex: none; align-self: stretch; }
+.guide { width: var(--ind); align-self: stretch; border-left: 1px solid var(--line); }
+.caret { width: 16px; flex: none; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 10px; }
+.dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
+.cglyph { font-size: 13px; font-weight: 700; width: 14px; flex: none; text-align: center; }
+.name { font-size: var(--fs); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.name[data-kind="file"] { font-family: var(--mono); font-weight: 700; }
+.name[data-kind="suite"] { font-weight: 600; }
+.name[data-kind="test"] { font-weight: 450; }
+.diagbadge { flex: none; font-size: 10px; font-weight: 600; border-radius: 6px; padding: 1px 6px; }
+.spacer { flex: 1; min-width: 10px; }
+.pills { display: inline-flex; gap: 5px; flex: none; margin-right: 9px; }
+.pill { font-size: 11px; font-weight: 700; border-radius: 999px; padding: 1px 8px; font-variant-numeric: tabular-nums; }
+.dur { flex: none; color: var(--faint); font-size: 11.5px; font-family: var(--mono); min-width: 54px; text-align: right; font-variant-numeric: tabular-nums; }
+
+/* diagnostics */
+.diag { border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: var(--panel-2); }
+.diag-sec { display: flex; }
+.diag-sec + .diag-sec { border-top: 1px solid var(--line); }
+.diag-bar { width: 3px; flex: none; }
+.diag-body { flex: 1; min-width: 0; }
+.diag-head { display: flex; align-items: center; gap: 7px; padding: 8px 13px; }
+.diag-icon { font-weight: 800; font-size: 12px; }
+.diag-title { font-size: 11px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--dim); }
+.diag-msg { padding: 0 14px; }
+.diag-msg span { font-size: 13px; font-weight: 600; }
+.diag pre { margin: 0; font-family: var(--mono); font-size: 11.5px; line-height: 1.55; }
+.diag pre.stack { padding: 2px 14px 13px; color: var(--dim); overflow-x: auto; white-space: pre; }
+.diag pre.text { padding: 2px 14px 13px; color: var(--fg); overflow-x: auto; white-space: pre-wrap; word-break: break-word; }
+.diag pre.text.err { color: var(--fg); }
+.diag-list { padding: 2px 14px 12px; display: flex; flex-direction: column; gap: 6px; }
+.diag-item { font-size: 12.5px; color: var(--fg); display: flex; gap: 9px; align-items: baseline; }
+.diag-level { font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; flex: none; border-radius: 5px; padding: 1px 6px; }
+.diag-item .txt { font-family: var(--mono); font-size: 12px; }
+
+/* full-tree states */
+.state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 13px; padding: 66px 20px; text-align: center; }
+.state-icon { width: 60px; height: 60px; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 26px; }
+.state-title { font-size: 16px; color: var(--fg); font-weight: 600; }
+.state-sub { font-size: 13px; color: var(--faint); max-width: 380px; line-height: 1.6; }
+.state-cmd { background: var(--panel-2); border: 1px solid var(--line); color: var(--dim); padding: 9px 14px; border-radius: 10px; font-family: var(--mono); font-size: 12px; max-width: 92%; overflow-x: auto; }
+.btn-primary { background: var(--accent); border: none; color: var(--accent-ink); border-radius: 10px; padding: 9px 17px; font-size: 13px; font-weight: 600; cursor: pointer; }
+
+/* footer */
+.footer { flex: none; border-top: 1px solid var(--line); background: var(--panel); padding: 8px 18px; display: flex; align-items: center; gap: 10px; color: var(--faint); font-size: 11px; }
+.footer .brand { font-weight: 700; color: var(--dim); }
+.legend { margin-left: auto; display: inline-flex; gap: 13px; }
+.legend > span { display: inline-flex; gap: 5px; align-items: center; }
+.legend .ldot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
 `;
 
 export interface HeaderOptions {
@@ -135,7 +161,7 @@ export function htmlHeader(clientJs: string, opts: HeaderOptions = {}): string {
 <style>${STYLES}</style>
 </head>
 <body>
-<div id="root"><div class="empty">Loading test report…</div></div>
+<div id="root"><div class="loading">Loading report…</div></div>
 <script>${clientJs}</script>
 <script>document.addEventListener('DOMContentLoaded',function(){try{window.__reportersRenderEmbedded&&window.__reportersRenderEmbedded()}catch(e){console.error(e)}});</script>
 <script type="application/x-ndjson" id="events">


### PR DESCRIPTION
Recreates the designer's chosen **Panel** direction (Linear/Vitest-style developer instrument) as production React/DOM in `@reporters/web`, wired to the real `node:test` reporter data. Faithful to the handoff's tokens, type roles, status language, and interactions.

## What changed
- **`template.ts`** — replaced `STYLES` with the full Panel design system: exact color tokens, light/dark driven by `data-theme` + `prefers-color-scheme` fallback (honoring `?theme=` override), status data-attribute helpers (`data-stc`/`data-stf`/`data-soft`), cozy/compact density vars, `prefers-reduced-motion` handling, and custom scrollbars. `htmlHeader`/`HTML_FOOTER`/`safeEventLine` unchanged.
- **`TreeView.tsx`** — full rewrite:
  - Flat-list rendering of only-visible rows (fast for large runs).
  - Worst-child status rollup for containers; proportional verdict bar, stat chips, count pills, verdict badge, footer legend.
  - Smart defaults: files expand unless entirely queued; suites expand only with a failed/running descendant; failed tests' diagnostics open by default.
  - Filter (case-insensitive substring, ancestors stay visible + auto-expand) with the no-results screen; cozy/compact toggle; collapse-all; keyboard tree nav (Enter/Space/←/→) with `role="tree"` semantics.
  - Sectioned, severity-aware diagnostics: Error / stdout / stderr / diagnostics / reason.
  - Empty/waiting + viewer-error states.
- **`viewer.tsx`** — routes streaming / load-error / ready through the component so the hosted viewer shows the waiting screen while polling and the error screen when `?src=` is missing/unreachable (transient failures after data arrives keep polling).

## Notes / decisions
- Kept React — already bundled and self-contained (no network requests; satisfies the strict-CSP/offline constraint), and the integration test asserts `react` in the output.
- Dropped the prototype's **Demo** state switcher — per the handoff, production state is data-driven.

## Verification
- `node --test` in `packages/web`: **16/16 pass**.
- Built the reporter and generated a real embedded report from `tests/example.js` + `tests/example.mjs`; screenshotted dark, light, and the viewer-error state — all match the design.

Screenshots (dark / light / viewer-error) available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)