### PR TITLE
fix(web): auto-refresh the embedded report while streaming

### DIFF
--- a/packages/web/src/client/embedded.tsx
+++ b/packages/web/src/client/embedded.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { createTreeStore, parseWireLines } from '@reporters/tree-core';
+import { createTreeStore, parseWireLines, type TreeStore } from '@reporters/tree-core';
 import { TreeView } from './TreeView.tsx';
 
 declare global {
@@ -10,15 +10,70 @@ declare global {
   }
 }
 
+const SCROLL_KEY = 'reporters:scroll';
+const SIG_KEY = 'reporters:sig';
+const STALL_KEY = 'reporters:stall';
+const POLL_MS = 1500;
+// Give up after this many consecutive no-growth polls — a safety valve so a
+// crashed/abandoned partial file doesn't reload forever. High enough to sit
+// through a genuinely slow test that emits no events while it runs.
+const MAX_STALL = 20;
+
+function isComplete(store: TreeStore): boolean {
+  const snap = store.getSnapshot();
+  if (snap.summary) return true;
+  const { counts } = snap;
+  return counts.total > 0 && counts.running === 0 && counts.queued === 0;
+}
+
+function stopLiveRefresh(): void {
+  sessionStorage.removeItem(SIG_KEY);
+  sessionStorage.removeItem(STALL_KEY);
+  sessionStorage.removeItem(SCROLL_KEY);
+}
+
+/**
+ * The embedded report is a static file. When it's opened while a run is still
+ * streaming into it, the browser can't see the newly appended bytes (and can't
+ * fetch() a local file to re-read itself), so we reload until the run completes.
+ * We keep reloading across quiet gaps between completions (the file doesn't grow
+ * while a slow test runs), stopping only when complete or after a long stall.
+ * The scroll position is preserved so the page doesn't jump on each reload.
+ */
+function scheduleLiveRefresh(text: string, complete: boolean): void {
+  if (complete) { stopLiveRefresh(); return; }
+
+  const signature = String(text.length);
+  const grew = sessionStorage.getItem(SIG_KEY) !== signature;
+  const stall = grew ? 0 : Number(sessionStorage.getItem(STALL_KEY) ?? '0') + 1;
+  if (stall >= MAX_STALL) { stopLiveRefresh(); return; }
+
+  sessionStorage.setItem(SIG_KEY, signature);
+  sessionStorage.setItem(STALL_KEY, String(stall));
+  window.setTimeout(() => {
+    sessionStorage.setItem(SCROLL_KEY, String(window.scrollY));
+    window.location.reload();
+  }, POLL_MS);
+}
+
 function render(): void {
   if (window.__reportersRendered) return;
   const events = document.getElementById('events');
   const mount = document.getElementById('root');
   if (!mount) return;
+
+  const text = events?.textContent ?? '';
   const store = createTreeStore();
-  for (const event of parseWireLines(events?.textContent ?? '')) store.apply(event);
+  for (const event of parseWireLines(text)) store.apply(event);
   window.__reportersRendered = true;
-  createRoot(mount).render(<TreeView snapshot={store.getSnapshot()} />);
+
+  const complete = isComplete(store);
+  createRoot(mount).render(<TreeView snapshot={store.getSnapshot()} streaming={!complete} />);
+
+  const saved = sessionStorage.getItem(SCROLL_KEY);
+  if (saved) window.scrollTo(0, Number(saved));
+
+  scheduleLiveRefresh(text, complete);
 }
 
 window.__reportersRenderEmbedded = render;

--- a/packages/web/src/client/embedded.tsx
+++ b/packages/web/src/client/embedded.tsx
@@ -13,11 +13,12 @@ declare global {
 const SCROLL_KEY = 'reporters:scroll';
 const SIG_KEY = 'reporters:sig';
 const STALL_KEY = 'reporters:stall';
-const POLL_MS = 1500;
-// Give up after this many consecutive no-growth polls — a safety valve so a
-// crashed/abandoned partial file doesn't reload forever. High enough to sit
-// through a genuinely slow test that emits no events while it runs.
-const MAX_STALL = 20;
+const POLL_MS = 300;
+// Give up after this long without any growth — a safety valve so a crashed or
+// abandoned partial file doesn't reload forever. Generous enough to sit through
+// a genuinely slow test that emits no events while it runs.
+const STALL_TIMEOUT_MS = 120000;
+const MAX_STALL = Math.ceil(STALL_TIMEOUT_MS / POLL_MS);
 
 function isComplete(store: TreeStore): boolean {
   const snap = store.getSnapshot();


### PR DESCRIPTION
Opened via `file://`, the embedded HTML report is static: the browser reads it once at load, can't see bytes appended afterward, and can't `fetch()` a local file to re-read itself — so a report opened mid-run looked frozen until a manual refresh (reported by @MoLow).

The embedded client now **reloads on an interval until the run completes** (a `test:summary`, or all tests terminal), preserving scroll position across reloads. It keeps reloading across quiet gaps between test completions (a slow test emits no events while it runs) and only gives up after a long stall, so a crashed/abandoned partial file won't reload forever.

The smoother, poll-based (`fetch` + HTTP Range) live experience remains the hosted viewer over http; this only covers the offline `file://` case.

**Verified** in a real browser (Playwright) against a live run with a long gap between completions:

```
open (mid-run):  Running · 2 passed, 1 running
+2s/+4s/+6s:     Running               (survives the gap — no freeze)
~run end:        Passing · 15.1s       (updated with no manual refresh)
after:           Passing               (stops reloading)
```

`embedded.tsx` is excluded from coverage (`.tsx`), and the completion check reuses the counts logic already covered by tree-core tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)