### PR TITLE
feat(web): read destination from execArgv; auto-open report locally

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -10,7 +10,9 @@ node --test --test-reporter=@reporters/web --test-reporter-destination=report.ht
 ```
 
 It streams like every other reporter — it yields to whatever
-`--test-reporter-destination` points at.
+`--test-reporter-destination` points at. On a dev machine it opens the report in
+your browser as the run streams (the page auto-refreshes while it's being
+written); it never opens in CI. Control this with `REPORTERS_WEB_OPEN=1|0`.
 
 ## Modes
 
@@ -35,8 +37,7 @@ REPORTERS_WEB_MODE=ndjson node --test \
 `embedded` is the default because it needs no hosting; `ndjson` is opt-in for the
 live hosted viewer. (The mode isn't inferred from TTY/CI: the reporter writes to
 a destination, not the terminal, so those signals don't say which format you
-want.) On completion the reporter prints a hint to stderr with the report path /
-viewer URL.
+want.) The reporter also prints a hint to stderr with the report path / viewer URL.
 
 Built on the shared `@reporters/tree-core` model (also used by
 [`@reporters/live`](https://www.npmjs.com/package/@reporters/live)).

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -1,3 +1,4 @@
+import { spawn } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { resolve } from 'node:path';
@@ -16,19 +17,53 @@ function readClientBundle(): string {
 }
 
 /** Best-effort: the single file this reporter is being written to, parsed from
- *  `--test-reporter-destination`. Undefined if there are none/many (ambiguous)
- *  or the destination is a stream (stdout/stderr). */
-function soleFileDestination(): string | undefined {
+ *  `--test-reporter-destination`. It's a Node CLI option, so it lives in
+ *  execArgv (before the test files), not argv. Undefined if there are none/many
+ *  (ambiguous) or the destination is a stream (stdout/stderr). */
+export function soleFileDestination(execArgv: string[] = process.execArgv): string | undefined {
   const flag = '--test-reporter-destination';
   const dests: string[] = [];
-  const { argv } = process;
-  for (let i = 0; i < argv.length; i += 1) {
-    if (argv[i] === flag && argv[i + 1]) dests.push(argv[i + 1]);
-    else if (argv[i].startsWith(`${flag}=`)) dests.push(argv[i].slice(flag.length + 1));
+  for (let i = 0; i < execArgv.length; i += 1) {
+    if (execArgv[i] === flag && execArgv[i + 1]) dests.push(execArgv[i + 1]);
+    else if (execArgv[i].startsWith(`${flag}=`)) dests.push(execArgv[i].slice(flag.length + 1));
   }
   const files = dests.filter((d) => d && d !== 'stdout' && d !== 'stderr');
   return files.length === 1 ? files[0] : undefined;
 }
+
+export function isCI(env: NodeJS.ProcessEnv = process.env): boolean {
+  return Boolean(env.CI || env.CONTINUOUS_INTEGRATION || env.GITHUB_ACTIONS || env.GITLAB_CI || env.BUILDKITE);
+}
+
+/** Open the report automatically on a developer's machine, but not in CI.
+ *  `REPORTERS_WEB_OPEN=1|0` forces it on/off. */
+export function shouldOpen(env: NodeJS.ProcessEnv = process.env): boolean {
+  const flag = env.REPORTERS_WEB_OPEN;
+  if (flag === '1' || flag === 'true') return true;
+  if (flag === '0' || flag === 'false') return false;
+  return !isCI(env);
+}
+
+/** The platform command to open a URL in the default browser. */
+export function openCommand(url: string, platform: NodeJS.Platform = process.platform): [string, string[]] {
+  if (platform === 'darwin') return ['open', [url]];
+  if (platform === 'win32') return ['cmd', ['/c', 'start', '', url]];
+  return ['xdg-open', [url]];
+}
+
+/* c8 ignore start -- spawning a real browser isn't unit-testable */
+function openInBrowser(url: string): void {
+  const [cmd, args] = openCommand(url);
+  try {
+    const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+    child.on('error', () => { /* no browser / headless — ignore */ });
+    child.unref();
+  } catch { /* ignore */ }
+}
+/* c8 ignore stop */
+
+/** Indirection so tests can observe the open without launching a browser. */
+export const internals = { openInBrowser };
 
 function hint(message: string): void {
   process.stderr.write(`${message}\n`);
@@ -40,16 +75,13 @@ function hint(message: string): void {
  * Two modes via `REPORTERS_WEB_MODE`:
  *  - `embedded` (default): streams a single self-contained .html file (inlined
  *    React app + the NDJSON event log). Point it at a file with
- *    `--test-reporter-destination=report.html`.
+ *    `--test-reporter-destination=report.html`. On a dev machine it opens the
+ *    report in your browser as it streams (disable with `REPORTERS_WEB_OPEN=0`).
  *  - `ndjson`: streams only the raw NDJSON event log, for the hosted viewer
  *    (open the viewer with `?src=<url-to-the-ndjson>`).
  *
  * `embedded` is the default deliberately: it's fully self-contained and works
  * everywhere (offline, as a CI artifact, attached to a gist) with no hosting.
- * `ndjson` is opt-in because it only becomes a report once its file is hosted
- * and opened in the viewer. This isn't inferred from TTY / CI: the reporter
- * writes to a destination (usually a file), not to the terminal, so those
- * signals don't indicate which format is wanted.
  */
 export default async function* web(source: AsyncIterable<TestEvent>): AsyncGenerator<string> {
   const mode = process.env.REPORTERS_WEB_MODE === 'ndjson' ? 'ndjson' : 'embedded';
@@ -63,10 +95,13 @@ export default async function* web(source: AsyncIterable<TestEvent>): AsyncGener
     return;
   }
 
+  const url = dest ? pathToFileURL(resolve(dest)).href : undefined;
   yield htmlHeader(readClientBundle());
+  // Open early so the report streams live in the browser (it self-refreshes).
+  if (url && shouldOpen()) internals.openInBrowser(url);
   for await (const event of source) yield safeEventLine(serializeWireLine(event));
   yield HTML_FOOTER;
-  hint(dest
-    ? `\n@reporters/web: report written to ${pathToFileURL(resolve(dest)).href}`
+  hint(url
+    ? `\n@reporters/web: report at ${url}`
     : '\n@reporters/web: open the generated HTML report in a browser');
 }

--- a/packages/web/tests/integration.test.ts
+++ b/packages/web/tests/integration.test.ts
@@ -10,7 +10,8 @@ const reporter = join(here, '..', 'dist', 'index.js');
 const example = join(here, '..', '..', '..', 'tests', 'example.js');
 
 function runToFile(mode: string, out: string) {
-  const env = { ...process.env, REPORTERS_WEB_MODE: mode };
+  // REPORTERS_WEB_OPEN=0 so the spawned reporter doesn't launch a browser.
+  const env = { ...process.env, REPORTERS_WEB_MODE: mode, REPORTERS_WEB_OPEN: '0' };
   delete env.NODE_TEST_CONTEXT;
   spawnSync(
     process.execPath,

--- a/packages/web/tests/reporter.test.ts
+++ b/packages/web/tests/reporter.test.ts
@@ -1,6 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import web from '../src/index.ts';
+import web, {
+  soleFileDestination, isCI, shouldOpen, openCommand, internals,
+} from '../src/index.ts';
 import { htmlHeader, HTML_FOOTER, safeEventLine } from '../src/template.ts';
 import type { TestEvent } from '@reporters/tree-core';
 
@@ -77,26 +79,84 @@ test('embedded mode logs a hint to stderr', async () => {
   assert.match(await collectStderr('embedded'), /report/i);
 });
 
-async function collectStderrWithArgv(mode: string, extraArgv: string[]): Promise<string> {
-  const originalArgv = process.argv;
-  process.argv = [...originalArgv, ...extraArgv];
+async function collectStderrWithExecArgv(mode: string, extra: string[]): Promise<string> {
+  const original = process.execArgv;
+  const originalOpen = process.env.REPORTERS_WEB_OPEN;
+  process.execArgv = [...original, ...extra];
+  process.env.REPORTERS_WEB_OPEN = '0'; // don't launch a browser during tests
   try {
     return await collectStderr(mode);
   } finally {
-    process.argv = originalArgv;
+    process.execArgv = original;
+    if (originalOpen === undefined) delete process.env.REPORTERS_WEB_OPEN;
+    else process.env.REPORTERS_WEB_OPEN = originalOpen;
   }
 }
 
-test('embedded hint includes the destination file path (ignoring stdout destinations)', async () => {
-  const err = await collectStderrWithArgv('embedded', [
-    '--test-reporter-destination', 'stdout',
-    '--test-reporter-destination=report.html',
-  ]);
-  assert.match(err, /report written to file:\/\/.*report\.html/);
+test('embedded hint includes the destination file path', async () => {
+  const err = await collectStderrWithExecArgv('embedded', ['--test-reporter-destination=report.html']);
+  assert.match(err, /report at file:\/\/.*report\.html/);
 });
 
 test('ndjson hint includes the destination and the viewer URL', async () => {
-  const err = await collectStderrWithArgv('ndjson', ['--test-reporter-destination=run.ndjson']);
+  const err = await collectStderrWithExecArgv('ndjson', ['--test-reporter-destination=run.ndjson']);
   assert.match(err, /run\.ndjson/);
   assert.match(err, /molow\.github\.io\/reporters\/\?src=/);
+});
+
+test('soleFileDestination reads --test-reporter-destination from execArgv', () => {
+  assert.strictEqual(soleFileDestination(['--test-reporter-destination=report.html']), 'report.html');
+  assert.strictEqual(soleFileDestination(['--test-reporter-destination', 'out.html']), 'out.html');
+  // stream destinations are ignored; a lone real file still wins
+  assert.strictEqual(soleFileDestination(['--test-reporter-destination', 'stdout', '--test-reporter-destination=r.html']), 'r.html');
+  // ambiguous (two files) or none => undefined
+  assert.strictEqual(soleFileDestination(['--test-reporter-destination=a', '--test-reporter-destination=b']), undefined);
+  assert.strictEqual(soleFileDestination(['--test']), undefined);
+});
+
+test('isCI detects common CI environments', () => {
+  assert.strictEqual(isCI({}), false);
+  assert.strictEqual(isCI({ CI: 'true' }), true);
+  assert.strictEqual(isCI({ GITHUB_ACTIONS: 'true' }), true);
+});
+
+test('shouldOpen: on locally, off in CI, forceable via env', () => {
+  assert.strictEqual(shouldOpen({}), true);
+  assert.strictEqual(shouldOpen({ CI: 'true' }), false);
+  assert.strictEqual(shouldOpen({ CI: 'true', REPORTERS_WEB_OPEN: '1' }), true);
+  assert.strictEqual(shouldOpen({ REPORTERS_WEB_OPEN: '0' }), false);
+  assert.strictEqual(shouldOpen({ REPORTERS_WEB_OPEN: 'false' }), false);
+});
+
+test('openCommand is platform-specific', () => {
+  assert.deepStrictEqual(openCommand('u', 'darwin'), ['open', ['u']]);
+  assert.deepStrictEqual(openCommand('u', 'linux'), ['xdg-open', ['u']]);
+  assert.deepStrictEqual(openCommand('u', 'win32'), ['cmd', ['/c', 'start', '', 'u']]);
+});
+
+async function runEmbedded(open: string): Promise<string | undefined> {
+  const origArgv = process.execArgv;
+  const origOpen = process.env.REPORTERS_WEB_OPEN;
+  const origMode = process.env.REPORTERS_WEB_MODE;
+  const origFn = internals.openInBrowser;
+  let opened: string | undefined;
+  internals.openInBrowser = (u) => { opened = u; };
+  process.execArgv = [...origArgv, '--test-reporter-destination=report.html'];
+  process.env.REPORTERS_WEB_OPEN = open;
+  process.env.REPORTERS_WEB_MODE = 'embedded';
+  try {
+    // eslint-disable-next-line no-restricted-syntax, no-unused-vars
+    for await (const _chunk of web(events)) { /* drain */ }
+  } finally {
+    process.execArgv = origArgv;
+    internals.openInBrowser = origFn;
+    if (origOpen === undefined) delete process.env.REPORTERS_WEB_OPEN; else process.env.REPORTERS_WEB_OPEN = origOpen;
+    if (origMode === undefined) delete process.env.REPORTERS_WEB_MODE; else process.env.REPORTERS_WEB_MODE = origMode;
+  }
+  return opened;
+}
+
+test('embedded opens the report locally, and not when disabled', async () => {
+  assert.match((await runEmbedded('1'))!, /file:\/\/.*report\.html/);
+  assert.strictEqual(await runEmbedded('0'), undefined);
 });


### PR DESCRIPTION
Two follow-ups on the web reporter.

### 1. Read `--test-reporter-destination` from `execArgv`
It's a Node CLI option, so it lands in `process.execArgv` (before the test files), not `process.argv`. The stderr hint's path detection was reading `argv`, so it only ever worked by accident — now it reads `execArgv`.

### 2. Auto-open the report on a dev machine
When a file destination is set and we're **not in CI**, the embedded reporter opens the report in the default browser **as the run streams** — together with the self-refresh (#196) you watch it fill in live. Skipped in CI (`CI` / `GITHUB_ACTIONS` / `GITLAB_CI` / `BUILDKITE`); force either way with `REPORTERS_WEB_OPEN=1|0`.

The decision logic is pure and unit-tested (`soleFileDestination` / `isCI` / `shouldOpen` / `openCommand`, incl. per-platform open commands); the actual browser launch is injected (`internals.openInBrowser`) so tests never spawn one, and the integration tests pass `REPORTERS_WEB_OPEN=0`.

`index.ts` stays at 100% coverage. Verified: web suite 21 pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)