### PR TITLE
chore: use the gh reporter for tree-core/live/web tests

### DIFF
--- a/packages/live/package.json
+++ b/packages/live/package.json
@@ -28,7 +28,7 @@
     "build": "tsup",
     "prepack": "tsup",
     "pretest": "tsup",
-    "test": "node --test"
+    "test": "node --test-reporter=../gh/index.js --test"
   },
   "dependencies": {
     "ink": "^6.0.0",

--- a/packages/tree-core/package.json
+++ b/packages/tree-core/package.json
@@ -24,7 +24,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup",
-    "test": "node --test"
+    "test": "node --test-reporter=../gh/index.js --test"
   },
   "devDependencies": {
     "tsup": "^8.5.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -27,7 +27,7 @@
     "build": "rm -rf dist && tsup",
     "prepack": "rm -rf dist && tsup",
     "pretest": "rm -rf dist && tsup",
-    "test": "node --test"
+    "test": "node --test-reporter=../gh/index.js --test"
   },
   "devDependencies": {
     "@reporters/tree-core": "workspace:^",


### PR DESCRIPTION
The tree-core, live, and web `test` scripts still used a bare `node --test`, while every other package runs its tests through `../gh/index.js`. This makes them consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)