### PR TITLE
fix(live): split TTY behavior into independent output/input levers

### DIFF
--- a/packages/live/README.md
+++ b/packages/live/README.md
@@ -12,12 +12,20 @@ node --test --test-reporter=@reporters/live --test
 - **Live** — tests appear as they start and complete in real execution order.
 - **Full tree, always expanded** — you always see every test; only per-test
   diagnostics (errors, stdout/stderr, `diagnostic()` messages) collapse.
-- **Interactive review** — after the run it stays open so you can browse:
+- **Interactive review** — when stdin is a TTY it stays open after the run so
+  you can browse:
   - `↑`/`↓` (or `k`/`j`) — move between tests that have diagnostics
   - `space` / `enter` — toggle the selected test's diagnostics
   - `q` / `Ctrl+C` — close
-- **CI-friendly** — outside a TTY it prints a plain-text tree at the end instead
-  of ANSI. Force that anywhere with `REPORTERS_LIVE_PLAIN=1`.
+- **CI-friendly** — output and input are decided independently:
+  - **stdout is a TTY** → live tree; otherwise a fully expanded plain-text tree
+    printed once at the end.
+  - **stdin is a TTY** → stays open for review; otherwise exits as soon as the
+    run ends.
+
+  So `npm run test` (TTY stdout, no interactive stdin) shows the live tree and
+  then exits, while a plain pipe or CI prints text and exits. Set
+  `REPORTERS_LIVE_PLAIN=1` to force plain text and exit-when-done everywhere.
 
 > [!NOTE]
 > Under the default process isolation, Node buffers each test file's events

--- a/packages/live/src/App.tsx
+++ b/packages/live/src/App.tsx
@@ -14,7 +14,7 @@ function flatten(node: TestNode, out: TestNode[]): TestNode[] {
   return out;
 }
 
-export function App({ store }: { store: TreeStore }) {
+export function App({ store, interactive = true }: { store: TreeStore; interactive?: boolean }) {
   const snapshot = useSyncExternalStore(store.subscribe, store.getSnapshot);
   const [frame, setFrame] = useState(0);
   const [elapsed, setElapsed] = useState(0);
@@ -44,7 +44,7 @@ export function App({ store }: { store: TreeStore }) {
   const [selected, setSelected] = useState(0);
   const [overrides, setOverrides] = useState<Map<string, boolean>>(new Map());
   const index = Math.min(selected, Math.max(flat.length - 1, 0));
-  const selectedKey = flat[index]?.key;
+  const selectedKey = interactive ? flat[index]?.key : undefined;
 
   useInput((input, key) => {
     if ((key.ctrl && input === 'c') || input === 'q') {
@@ -64,17 +64,19 @@ export function App({ store }: { store: TreeStore }) {
         });
       }
     }
-  }, { isActive: Boolean(process.stdin.isTTY) });
+  }, { isActive: interactive });
 
   return (
     <Box flexDirection="column">
       {snapshot.root.children.map((file) => (
-        <TreeNode key={file.key} node={file} depth={0} frame={frame} selectedKey={selectedKey} overrides={overrides} />
+        <TreeNode key={file.key} node={file} depth={0} frame={frame} selectedKey={selectedKey} overrides={overrides} interactive={interactive} />
       ))}
       <Box marginTop={1}>
         <Header counts={counts} done={done} success={success} duration={duration} frame={frame} />
       </Box>
-      <Text dimColor>↑/↓ move · space toggle diagnostics · q or Ctrl+C to close</Text>
+      {interactive && (
+        <Text dimColor>↑/↓ move · space toggle diagnostics · q or Ctrl+C to close</Text>
+      )}
     </Box>
   );
 }

--- a/packages/live/src/TreeNode.tsx
+++ b/packages/live/src/TreeNode.tsx
@@ -45,17 +45,18 @@ interface TreeNodeProps {
   frame: number;
   selectedKey: string | undefined;
   overrides: Map<string, boolean>;
+  interactive: boolean;
 }
 
 export function TreeNode({
-  node, depth, frame, selectedKey, overrides,
+  node, depth, frame, selectedKey, overrides, interactive,
 }: TreeNodeProps) {
   const running = node.status === 'running';
   const symbol = running ? SPINNER_FRAMES[frame % SPINNER_FRAMES.length] : SYMBOLS[node.status];
   const label = node.type === 'file' ? basename(node.file) : node.name;
   const selected = node.key === selectedKey;
   const hasDiag = nodeHasDiagnostics(node);
-  const showDiag = diagnosticsOpen(node, overrides);
+  const showDiag = interactive ? diagnosticsOpen(node, overrides) : hasDiag;
 
   return (
     <Box flexDirection="column">
@@ -70,7 +71,7 @@ export function TreeNode({
       </Box>
       {showDiag ? <Diagnostics node={node} indent={'  '.repeat(depth + 2)} /> : null}
       {node.children.map((child) => (
-        <TreeNode key={child.key} node={child} depth={depth + 1} frame={frame} selectedKey={selectedKey} overrides={overrides} />
+        <TreeNode key={child.key} node={child} depth={depth + 1} frame={frame} selectedKey={selectedKey} overrides={overrides} interactive={interactive} />
       ))}
     </Box>
   );

--- a/packages/live/src/index.tsx
+++ b/packages/live/src/index.tsx
@@ -7,10 +7,15 @@ import { renderTreeText } from './text.ts';
 /**
  * A live, React-powered tree reporter for `node:test`.
  *
- * In a TTY it renders an Ink tree that updates in place as tests run, then stays
- * open so you can browse results — arrow keys move, space toggles a test's
- * diagnostics, q or Ctrl+C closes. Outside a TTY (CI, pipes) it prints a
- * plain-text tree at the end. Set REPORTERS_LIVE_PLAIN=1 to force plain text.
+ * Two independent levers decide how it behaves:
+ *   - Output (stdout is a TTY): render the live Ink tree, else print a fully
+ *     expanded plain-text tree once at the end.
+ *   - Input (stdin is a TTY): after the run, keep the view open so you can
+ *     browse — arrow keys move, space toggles a test's diagnostics, q / Ctrl+C
+ *     closes — else exit as soon as the run ends.
+ * So `npm run test` (stdout is a TTY, stdin isn't) shows the live tree and then
+ * exits, while a plain pipe / CI prints text and exits. REPORTERS_LIVE_PLAIN=1
+ * forces both levers off (plain text, exit when done).
  *
  * Note: under the default process isolation Node buffers each file's events
  * until that file's turn to report, so files fill in as they complete. For true
@@ -18,22 +23,28 @@ import { renderTreeText } from './text.ts';
  */
 export default async function* live(source: AsyncIterable<TestEvent>): AsyncGenerator<string> {
   const store = createTreeStore();
-  const interactive = Boolean(process.stdout.isTTY) && process.env.REPORTERS_LIVE_PLAIN !== '1';
+  const plain = process.env.REPORTERS_LIVE_PLAIN === '1';
+  const renderApp = Boolean(process.stdout.isTTY) && !plain;
+  const waitForInput = Boolean(process.stdin.isTTY) && !plain;
 
-  if (!interactive) {
+  if (!renderApp) {
     for await (const event of source) store.apply(toWireEvent(event));
     yield `${renderTreeText(store.getSnapshot())}\n`;
     return;
   }
 
   // We own the terminal. Ctrl+C / q exit the process from within <App/>.
-  render(<App store={store} />, { patchConsole: false, exitOnCtrlC: false });
+  const app = render(<App store={store} interactive={waitForInput} />, { patchConsole: false, exitOnCtrlC: false });
   // Consume the whole stream (breaking early would destroy Node's reporter
   // pipeline and raise ABORT_ERR).
   for await (const event of source) store.apply(toWireEvent(event));
-  // The run has finished. Keep the interactive view open for review — the user
-  // browses results and quits with q / Ctrl+C (handled in <App/> via
-  // process.exit). Block so the process doesn't exit and close the window.
-  // (In CI / non-TTY we took the plain-text path above and never get here.)
-  await new Promise<never>(() => {});
+
+  if (waitForInput) {
+    // Keep the view open for review; the user quits with q / Ctrl+C (handled in
+    // <App/> via process.exit). Block so the process doesn't close the window.
+    await new Promise<never>(() => {});
+  }
+  // No stdin to drive navigation: leave the final frame on screen and let the
+  // generator return so Node finishes the run and sets the exit code.
+  app.unmount();
 }

--- a/packages/live/tests/integration.test.ts
+++ b/packages/live/tests/integration.test.ts
@@ -8,8 +8,8 @@ const here = dirname(fileURLToPath(import.meta.url));
 const reporter = join(here, '..', 'dist', 'index.js');
 const example = join(here, '..', '..', '..', 'tests', 'example.js');
 
-function run() {
-  const env = { ...process.env, REPORTERS_LIVE_PLAIN: '1' };
+function run(extraEnv: Record<string, string> = {}) {
+  const env = { ...process.env, REPORTERS_LIVE_PLAIN: '1', ...extraEnv };
   delete env.NODE_TEST_CONTEXT;
   return spawnSync(
     process.execPath,
@@ -26,5 +26,15 @@ test('the built reporter renders a tree and reflects failures in the exit code',
   assert.match(out, /✖/);
   assert.match(out, /passed/);
   assert.match(out, /failed/);
+  assert.notStrictEqual(child.status, 0, 'a run with failing tests should exit non-zero');
+});
+
+test('without a TTY it prints a fully expanded tree and exits rather than blocking', () => {
+  const child = run({ REPORTERS_LIVE_PLAIN: '' });
+  const out = child.stdout ?? '';
+  assert.match(out, /example\.js/);
+  assert.match(out, /✔ is ok/);
+  assert.match(out, /passed/);
+  assert.notStrictEqual(child.status, null, 'the process must terminate on its own');
   assert.notStrictEqual(child.status, 0, 'a run with failing tests should exit non-zero');
 });

--- a/scripts/mono-run.js
+++ b/scripts/mono-run.js
@@ -20,7 +20,9 @@ function runCommand(dir) {
     }
     const args = ['workspace', name, ...cmd];
     console.log(`Running "yarn ${args.join(' ')}" in ${name}`);
-    const child = spawnSync('yarn', args, { stdio: 'inherit' });
+    // Don't forward a TTY stdin: it would make interactive reporters (e.g.
+    // @reporters/live) hold the terminal open waiting for keystrokes.
+    const child = spawnSync('yarn', args, { stdio: ['ignore', 'inherit', 'inherit'] });
     if (child.status !== 0) {
       process.exitCode = 1;
     }


### PR DESCRIPTION
## Summary

The live reporter derived all behavior from a single `interactive` flag keyed off `process.stdout.isTTY`. Under `npm run test` at the workspace root, stdout is a TTY and stdin is inherited, so it rendered the Ink app and then **blocked forever** waiting for `q`/`Ctrl+C` — hanging the whole run in CI/pipelines.

This splits the behavior into two independent levers:

- **Output** (`process.stdout.isTTY`) → render the live Ink tree, otherwise print a fully expanded plain-text tree once at the end.
- **Input** (`process.stdin.isTTY`) → keep the view open for review after the run, otherwise exit as soon as it ends.

So `npm run test` (TTY stdout, no interactive stdin) shows the live tree and then exits, while a plain pipe/CI prints text and exits. `REPORTERS_LIVE_PLAIN=1` forces both levers off.

When input is disabled the app is a static snapshot: no row is selectable and every node's diagnostics are expanded.

`scripts/mono-run.js` no longer forwards a TTY stdin (`stdio: ['ignore', 'inherit', 'inherit']`) to child test processes, so workspace runs reliably take the non-interactive path.

## Test plan

- `packages/live` tests pass, including a new case asserting the reporter prints an expanded tree and terminates on its own (no `REPORTERS_LIVE_PLAIN`).
- Verified manually that `npm run test` at the workspace root now shows the live tree and exits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)