### PR TITLE
fix(web): use the live viewer URL in the load-error hint

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -313,7 +313,8 @@ export function TreeView({
             {' '}that points at a reachable test log. It’s missing or the URL didn’t respond.
           </div>
           <code className="state-cmd">
-            …/viewer.html<span data-stc="todo">?src=https://ci.example/run-8821.ndjson</span>
+            {window.location.origin + window.location.pathname}
+            <span data-stc="todo">?src=https://ci.example/run-8821.ndjson</span>
           </code>
           {onRetry ? <button type="button" className="btn-primary" onClick={onRetry}>Retry</button> : null}
         </CenteredState>


### PR DESCRIPTION
## Summary
The web viewer's load-error state (shown when `?src=` is missing or unreachable) hardcoded a fake `…/viewer.html` placeholder in the example URL. This derives the base from the actual page location (`origin + pathname`) so the hint reflects where the viewer is really hosted.

Uses `origin + pathname` rather than `location.href` because in this error state a broken `?src=` is often already in the query string — appending another `?src=` example to it would be malformed.

## Changes
- `packages/web/src/client/TreeView.tsx`: render the current viewer URL instead of the `…/viewer.html` placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)