### PR TITLE
feat(web): replace density toggle with a dark/light mode toggle

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -83,15 +83,23 @@ function computeTheme(): 'dark' | 'light' {
   return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
-function useTheme(): void {
-  useEffect(() => {
-    const apply = () => { document.documentElement.dataset.theme = computeTheme(); };
-    apply();
-    const mq = window.matchMedia?.('(prefers-color-scheme: dark)');
-    mq?.addEventListener('change', apply);
-    return () => mq?.removeEventListener('change', apply);
-  }, []);
+function useTheme(): ['dark' | 'light', () => void] {
+  const [theme, setTheme] = useState<'dark' | 'light'>(computeTheme);
+  useEffect(() => { document.documentElement.dataset.theme = theme; }, [theme]);
+  const toggle = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
+  return [theme, toggle];
 }
+
+const ThemeIcon = ({ theme }: { theme: 'dark' | 'light' }) => (theme === 'dark' ? (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+    <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8z" />
+  </svg>
+) : (
+  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="12" cy="12" r="4.5" />
+    <path d="M12 2v2.5M12 19.5V22M4.2 4.2l1.8 1.8M18 18l1.8 1.8M2 12h2.5M19.5 12H22M4.2 19.8l1.8-1.8M18 6l1.8-1.8" strokeLinecap="round" />
+  </svg>
+));
 
 const SearchIcon = () => (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
@@ -139,11 +147,10 @@ function Diagnostics({ node, indent }: { node: TestNode; indent: string }) {
 
 interface RowViewProps {
   row: FlatRow;
-  dense: boolean;
   toggle: (key: string, current: boolean) => void;
 }
 
-function RowView({ row, dense, toggle }: RowViewProps) {
+function RowView({ row, toggle }: RowViewProps) {
   const {
     node, depth, status, container, expanded, hasDiag, diagOpen,
   } = row;
@@ -165,8 +172,7 @@ function RowView({ row, dense, toggle }: RowViewProps) {
     : isTest && (status === 'skipped' || status === 'todo' || status === 'queued') ? 'var(--dim)'
       : 'var(--fg)';
   const ariaExpanded = container ? expanded : hasDiag ? diagOpen : undefined;
-  const step = dense ? 15 : 20;
-  const indent = `${depth * step + (dense ? 30 : 38)}px`;
+  const indent = `${depth * 20 + 38}px`;
 
   return (
     <div>
@@ -273,9 +279,8 @@ export interface TreeViewProps {
 export function TreeView({
   snapshot, streaming = false, loadError = false, onRetry,
 }: TreeViewProps) {
-  useTheme();
+  const [theme, toggleTheme] = useTheme();
   const [query, setQuery] = useState('');
-  const [dense, setDense] = useState(false);
   const [overrides, setOverrides] = useState<Map<string, boolean>>(new Map());
 
   const files = snapshot.root.children;
@@ -306,7 +311,7 @@ export function TreeView({
 
   if (loadError) {
     return (
-      <div className="app" data-dense={dense}>
+      <div className="app">
         <CenteredState icon="⚠" iconStatus="failed" title="Couldn’t load the live log">
           <div className="state-sub">
             The viewer needs a <code style={{ fontFamily: 'var(--mono)', color: 'var(--st-todo)' }}>?src=</code>
@@ -327,7 +332,7 @@ export function TreeView({
   const barSegments = STATUS_ORDER.filter((s) => counts[s] > 0);
 
   return (
-    <div className="app" data-dense={dense}>
+    <div className="app">
       <header className="hdr">
         <div className="hdr-row">
           <Verdict counts={counts} inProgress={inProgress} duration={duration} />
@@ -350,8 +355,14 @@ export function TreeView({
                 aria-label="Filter tests"
               />
             </div>
-            <button type="button" className="btn" onClick={() => setDense((d) => !d)} title="Toggle density">
-              {dense ? 'Compact' : 'Cozy'}
+            <button
+              type="button"
+              className="btn"
+              onClick={toggleTheme}
+              title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+              aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+            >
+              <ThemeIcon theme={theme} />
             </button>
             <button type="button" className="btn" onClick={collapseAll} title="Collapse all">Collapse</button>
           </div>
@@ -372,7 +383,7 @@ export function TreeView({
 
       <div className="tree" role="tree" aria-label="Test results">
         {rows.length > 0 ? (
-          rows.map((row) => <RowView key={row.node.key} row={row} dense={dense} toggle={toggle} />)
+          rows.map((row) => <RowView key={row.node.key} row={row} toggle={toggle} />)
         ) : q ? (
           <CenteredState icon="⌕" iconStatus="skipped" title={`No tests match “${query.trim()}”`}>
             <div className="state-sub">Try a shorter query, or search by file name.</div>

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -57,9 +57,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 @media (prefers-reduced-motion: reduce) { [data-spin="true"], [data-pulse="true"] { animation: none; } }
 
 /* app shell */
-.app { height: 100%; display: flex; flex-direction: column; }
-.app[data-dense="false"] { --rh: 34px; --fs: 13.5px; --ind: 20px; }
-.app[data-dense="true"]  { --rh: 26px; --fs: 12.5px; --ind: 15px; }
+.app { height: 100%; display: flex; flex-direction: column; --rh: 34px; --fs: 13.5px; --ind: 20px; }
 .loading { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 13px; }
 
 /* header */
@@ -78,7 +76,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 .search { position: relative; display: flex; align-items: center; }
 .search svg { position: absolute; left: 11px; color: var(--faint); pointer-events: none; }
 .search input { background: var(--panel-2); border: 1px solid var(--line); color: var(--fg); font-size: 13px; padding: 8px 12px 8px 32px; border-radius: 10px; width: 188px; outline: none; }
-.btn { background: var(--panel-2); border: 1px solid var(--line); color: var(--dim); border-radius: 10px; padding: 8px 11px; font-size: 12px; cursor: pointer; transition: background .13s, color .13s; }
+.btn { display: inline-flex; align-items: center; gap: 6px; background: var(--panel-2); border: 1px solid var(--line); color: var(--dim); border-radius: 10px; padding: 8px 11px; font-size: 12px; cursor: pointer; transition: background .13s, color .13s; }
 .btn:hover { background: var(--raise); color: var(--fg); }
 .hdr-bar-row { padding: 0 18px 13px; display: flex; align-items: center; gap: 14px; }
 .bar { flex: 1; min-width: 220px; height: 9px; display: flex; gap: 2px; border-radius: 999px; overflow: hidden; background: var(--panel-2); }


### PR DESCRIPTION
## Summary
Removes the cozy/compact (density) toggle from the web viewer and replaces it with a manual dark/light mode toggle, per the TODO.

- **Density removed**: dropped the `dense` state, the `data-dense` attribute, the two `.app[data-dense=...]` CSS branches, and the inline dense indent math. The former "cozy" values (`--rh/--fs/--ind`) are now set directly on `.app`.
- **Theme toggle added**: `useTheme` is now stateful and returns `[theme, toggle]`. A sun/moon button in the header flips the theme. Initial value still respects the `?theme=` query param and `prefers-color-scheme`.

## Verification
- `tsc --noEmit` clean
- `npm test` — 33 passed
- Rendered an embedded report and confirmed the toggle switches between light and dark in the browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)