### PR TITLE
fix(web): open the standalone live view even without a file destination

### DIFF
--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -17,20 +17,18 @@ function hint(message: string): void {
  * JSON-safe wire line per event — to whatever `--test-reporter-destination`
  * points at.
  *
- * Run standalone on a dev machine (with a file destination) it also serves a
- * live browser view and opens it, the same way it behaves through
- * `@reporters/mux`'s `httpServer()` sink. Control this with the `open` option or
- * `REPORTERS_WEB_OPEN=1|0`; it never opens in CI by default. Through mux the
- * reporter is a pure emitter and the sink owns viewing.
+ * Run standalone on a dev machine it also serves a live browser view and opens
+ * it, the same way it behaves through `@reporters/mux`'s `httpServer()` sink.
+ * Control this with the `open` option or `REPORTERS_WEB_OPEN=1|0`; it never opens
+ * in CI by default. Through mux the reporter is a pure emitter and the sink owns
+ * viewing.
  */
 export default async function* web(
   source: AsyncIterable<TestEvent>,
   options: WebOptions = {},
 ): AsyncGenerator<string> {
   const dest = soleFileDestination();
-  // Serve only when there's somewhere for the yielded NDJSON to live (a file
-  // destination) so the terminal isn't spammed — unless serving is forced on.
-  const serve = shouldOpen(options.open) && (Boolean(dest) || options.open === true);
+  const serve = shouldOpen(options.open);
 
   let server: ViewerServer | undefined;
   if (serve) {
@@ -42,7 +40,9 @@ export default async function* web(
   for await (const event of source) {
     const line = serializeWireLine(event);
     server?.push(line);
-    yield line;
+    // Emit to the destination as usual. When serving with no file destination
+    // (a live terminal view) skip stdout so the browser is the only view.
+    if (dest || !server) yield line;
   }
 
   if (!server) return;

--- a/packages/web/tests/reporter.test.ts
+++ b/packages/web/tests/reporter.test.ts
@@ -11,7 +11,8 @@ const events: TestEvent[] = [
 
 async function collect(): Promise<string[]> {
   const out: string[] = [];
-  for await (const chunk of web(events)) out.push(chunk);
+  // open:false keeps it a pure emitter regardless of the ambient TTY.
+  for await (const chunk of web(events, { open: false })) out.push(chunk);
   return out;
 }
 
@@ -33,7 +34,7 @@ test('web emits no HTML and every line ends with a newline', async () => {
   }
 });
 
-test('web with open:true serves a live view, opens the browser, and still emits NDJSON', async () => {
+test('web with open:true and no file destination serves + opens, and keeps stdout quiet', async () => {
   const origOpen = internals.openInBrowser;
   let opened: string | undefined;
   internals.openInBrowser = (u) => { opened = u; };
@@ -41,10 +42,29 @@ test('web with open:true serves a live view, opens the browser, and still emits 
     const out: string[] = [];
     // stdin isn't a TTY under `node --test`, so the server shuts down at the end.
     for await (const chunk of web(events, { open: true })) out.push(chunk);
-    assert.strictEqual(out.length, 2); // NDJSON still yielded to the destination
+    // No file destination → the browser is the only view; nothing is written to stdout.
+    assert.strictEqual(out.length, 0);
     assert.match(opened!, /^http:\/\/127\.0\.0\.1:\d+\/\?src=\/run\.ndjson$/);
   } finally {
     internals.openInBrowser = origOpen;
+  }
+});
+
+test('web with open:true and a file destination serves + opens AND writes NDJSON to the file', async () => {
+  const origOpen = internals.openInBrowser;
+  const origArgv = process.execArgv;
+  let opened: string | undefined;
+  internals.openInBrowser = (u) => { opened = u; };
+  process.execArgv = [...origArgv, '--test-reporter-destination=run.ndjson'];
+  try {
+    const out: string[] = [];
+    for await (const chunk of web(events, { open: true })) out.push(chunk);
+    // A file destination exists → NDJSON is still emitted (to the file) while serving.
+    assert.strictEqual(out.length, 2);
+    assert.match(opened!, /\/\?src=\/run\.ndjson$/);
+  } finally {
+    internals.openInBrowser = origOpen;
+    process.execArgv = origArgv;
   }
 });
 


### PR DESCRIPTION
## Problem

After the mux/NDJSON redesign, running the reporter standalone with no destination:

```bash
node --test-reporter=@reporters/web --test tests/timing.test.ts
```

did **not** open a browser. The serve gate required a `--test-reporter-destination` file (`shouldOpen(open) && (Boolean(dest) || open === true)`), so with output going to stdout there was no `dest` and serving was skipped.

## Fix

Serve whenever `shouldOpen` is true (a TTY, not CI, or the explicit `open` option). When there is **no** file destination, suppress the stdout NDJSON so the browser is the only view rather than spamming the terminal with JSON:

- **standalone, TTY, no destination** → opens a live browser view; terminal stays quiet (just the stderr hint).
- **standalone, TTY, file destination** → opens the view **and** writes NDJSON to the file.
- **CI / non-TTY / `open: false`** → pure NDJSON emitter, opens nothing (unchanged).
- **through mux** → still a pure emitter; the `httpServer()` sink owns viewing (unchanged).

## Tests

100% coverage on `web/src/index.ts` retained; added cases for the no-destination (stdout-quiet) and with-destination serve paths. Build (DTS), lint, and the full web suite pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
