### PR TITLE
feat(web): viewer design round 2 + live-viewer transition choreography

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -1,12 +1,18 @@
 import React, {
-  useEffect, useMemo, useState,
+  useEffect, useMemo, useRef, useState,
 } from 'react';
 import {
   formatDuration, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
 } from '@reporters/tree-core';
 import {
-  buildRows, collectContainerKeys, computeMatches, displayName, isContainer, reasonOf, type FlatRow,
+  buildRows, collectContainerKeys, computeMatches, displayName, isContainer, reasonOf, realError, type FlatRow,
 } from './rowModel.ts';
+
+// node:test captures colored output verbatim; strip ANSI SGR sequences so the
+// raw escape codes never leak into the report as visible garbage.
+// eslint-disable-next-line no-control-regex
+const ANSI_SGR = /\u001b\[[0-9;]*m/g;
+const stripAnsi = (text: string): string => text.replace(ANSI_SGR, '');
 
 const GLYPH: Record<TestStatus, string> = {
   passed: '✓', failed: '✕', skipped: '⊘', todo: '◇', running: '◐', queued: '○',
@@ -23,45 +29,62 @@ function sumDuration(node: TestNode): number {
 
 /** Severity of a test's diagnostics, for the row badge tint. */
 function diagSeverity(node: TestNode): TestStatus {
-  if (node.error || node.stderr.length > 0) return 'failed';
+  if (realError(node) || node.stderr.length > 0) return 'failed';
   if (node.diagnostics.some((d) => d.level === 'warn')) return 'running';
   return 'skipped';
 }
+
+interface OutLine { stream: 'out' | 'err'; text: string; }
 
 interface DiagBlock {
   key: string;
   title: string;
   icon: string;
   sev: TestStatus;
-  kind: 'error' | 'text' | 'list';
+  kind: 'error' | 'output' | 'list' | 'text';
   message?: string;
   stack?: string;
   text?: string;
-  err?: boolean;
+  lines?: OutLine[];
   items?: { level: string; sev: TestStatus; text: string }[];
 }
 
+/** stdout + stderr merged into one line list, stream-tagged, ANSI stripped. */
+function outputLines(node: TestNode): OutLine[] {
+  const lines: OutLine[] = [];
+  const add = (chunks: string[], stream: 'out' | 'err'): void => {
+    if (chunks.length === 0) return;
+    for (const line of stripAnsi(chunks.join('')).split('\n')) lines.push({ stream, text: line });
+  };
+  add(node.stdout, 'out');
+  add(node.stderr, 'err');
+  while (lines.length > 0 && lines[lines.length - 1].text === '') lines.pop();
+  return lines;
+}
+
+// At most three sections per test — Error, Output, Diagnostics (plus a reason
+// for skipped/todo). stdout+stderr collapse into one Output block; every text
+// is ANSI-stripped; synthetic container rollups never render an Error.
 function diagBlocks(node: TestNode): DiagBlock[] {
   const blocks: DiagBlock[] = [];
-  if (node.error) {
+  const error = realError(node);
+  if (error) {
     blocks.push({
       key: 'error', title: 'Error', icon: '✕', sev: 'failed', kind: 'error',
-      message: node.error.message, stack: node.error.stack ?? node.error.message,
+      message: stripAnsi(error.message), stack: stripAnsi(error.stack ?? error.message),
     });
   }
-  if (node.stdout.length > 0) {
-    blocks.push({ key: 'stdout', title: 'stdout', icon: '›', sev: 'skipped', kind: 'text', text: node.stdout.join('') });
-  }
-  if (node.stderr.length > 0) {
-    blocks.push({ key: 'stderr', title: 'stderr', icon: '›', sev: 'failed', kind: 'text', text: node.stderr.join(''), err: true });
+  const lines = outputLines(node);
+  if (lines.length > 0) {
+    blocks.push({ key: 'output', title: 'Output', icon: '›', sev: 'skipped', kind: 'output', lines });
   }
   if (node.diagnostics.length > 0) {
     blocks.push({
-      key: 'diag', title: 'diagnostics', icon: '◇', sev: 'skipped', kind: 'list',
+      key: 'diag', title: 'Diagnostics', icon: '◇', sev: 'skipped', kind: 'list',
       items: node.diagnostics.map((d) => ({
         level: d.level,
         sev: d.level === 'error' ? 'failed' : d.level === 'warn' ? 'running' : 'skipped',
-        text: d.message,
+        text: stripAnsi(d.message),
       })),
     });
   }
@@ -69,7 +92,7 @@ function diagBlocks(node: TestNode): DiagBlock[] {
   if (reason) {
     blocks.push({
       key: 'reason', title: node.status === 'skipped' ? 'why skipped' : 'why todo',
-      icon: '⊘', sev: 'skipped', kind: 'text', text: reason,
+      icon: '⊘', sev: 'skipped', kind: 'text', text: stripAnsi(reason),
     });
   }
   return blocks;
@@ -125,8 +148,18 @@ function Diagnostics({ node, indent }: { node: TestNode; indent: string }) {
                 <pre className="stack">{block.stack}</pre>
               </>
             ) : null}
+            {block.kind === 'output' ? (
+              <div className="out">
+                {block.lines!.map((line, i) => (
+                  // eslint-disable-next-line react/no-array-index-key
+                  <div className="out-line" data-err={line.stream === 'err' ? 'true' : undefined} key={i}>
+                    {line.text === '' ? ' ' : line.text}
+                  </div>
+                ))}
+              </div>
+            ) : null}
             {block.kind === 'text' ? (
-              <pre className={`text${block.err ? ' err' : ''}`}>{block.text}</pre>
+              <pre className="text">{block.text}</pre>
             ) : null}
             {block.kind === 'list' ? (
               <div className="diag-list">
@@ -145,15 +178,35 @@ function Diagnostics({ node, indent }: { node: TestNode; indent: string }) {
   );
 }
 
+/** True for a beat after a node settles out of `running`, to fire a settle pop. */
+function useSettle(status: TestStatus): boolean {
+  const prev = useRef(status);
+  const [settled, setSettled] = useState(false);
+  useEffect(() => {
+    if (prev.current === 'running' && status !== 'running') {
+      setSettled(true);
+      const timer = setTimeout(() => setSettled(false), 500);
+      prev.current = status;
+      return () => clearTimeout(timer);
+    }
+    prev.current = status;
+    return undefined;
+  }, [status]);
+  return settled;
+}
+
 interface RowViewProps {
   row: FlatRow;
   toggle: (key: string, current: boolean) => void;
+  /** Stagger index for the enter animation, or null when the row shouldn't animate in. */
+  enter: number | null;
 }
 
-function RowView({ row, toggle }: RowViewProps) {
+function RowView({ row, toggle, enter }: RowViewProps) {
   const {
     node, depth, status, container, expanded, hasDiag, diagOpen,
   } = row;
+  const settled = useSettle(status);
   const clickable = container || hasDiag;
   const toggleDiag = () => toggle(`${node.key}::diag`, diagOpen);
   const activate = () => {
@@ -174,27 +227,34 @@ function RowView({ row, toggle }: RowViewProps) {
   const ariaExpanded = container ? expanded : hasDiag ? diagOpen : undefined;
   const indent = `${depth * 20 + 38}px`;
 
+  const rowClass = `row${enter !== null ? ' row-enter' : ''}${settled ? ` settle-${status}` : ''}`;
+  const rowStyle = enter !== null ? { animationDelay: `${Math.min(enter, 8) * 18}ms` } : undefined;
+
   return (
     <div>
       <div
-        className="row"
+        className={rowClass}
+        style={rowStyle}
         role="treeitem"
         aria-expanded={ariaExpanded}
         aria-label={`${displayName(node)}, ${status}${container ? `, ${counts.total} tests` : ''}`}
         tabIndex={0}
         data-clickable={clickable}
         data-fail={isTest && status === 'failed'}
+        data-running={status === 'running' ? 'true' : undefined}
         onClick={clickable ? activate : undefined}
         onKeyDown={onKeyDown}
       >
         <span className="guides">
           {Array.from({ length: depth }, (_, i) => <span className="guide" key={i} />)}
         </span>
-        <span className="caret">{container ? (expanded ? '▾' : '▸') : ''}</span>
+        <span className="caret" data-open={container && expanded ? 'true' : undefined}>{container ? '▸' : ''}</span>
         {isTest ? (
-          <span className="dot" data-stf={status} data-spin={status === 'running' ? 'true' : undefined} />
+          status === 'running'
+            ? <span className="spinner indicator" />
+            : <span className="dot indicator" data-stf={status} />
         ) : (
-          <span className="cglyph" data-stc={status}>{GLYPH[status]}</span>
+          <span className="cglyph indicator" data-stc={status} data-spin={status === 'running' ? 'true' : undefined}>{GLYPH[status]}</span>
         )}
         <span className="name" data-kind={node.type} style={{ color: nameColor }}>{displayName(node)}</span>
         {hasDiag ? (
@@ -229,7 +289,11 @@ function RowView({ row, toggle }: RowViewProps) {
         ) : null}
         <span className="dur">{formatDuration(sumDuration(node)) || '—'}</span>
       </div>
-      {hasDiag && diagOpen ? <Diagnostics node={node} indent={indent} /> : null}
+      {hasDiag ? (
+        <div className={`collapsible${diagOpen ? ' open' : ''}`}>
+          <div className="inner"><Diagnostics node={node} indent={indent} /></div>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -282,6 +346,9 @@ export function TreeView({
   const [theme, toggleTheme] = useTheme();
   const [query, setQuery] = useState('');
   const [overrides, setOverrides] = useState<Map<string, boolean>>(new Map());
+  // Rows already painted at least once — so we only play the enter animation for
+  // rows that newly arrive during a live run, never on every re-render.
+  const seenRef = useRef<Set<string>>(new Set());
 
   const files = snapshot.root.children;
   const { counts } = snapshot;
@@ -307,7 +374,23 @@ export function TreeView({
   };
 
   const inProgress = !snapshot.summary && (streaming || counts.running > 0 || counts.queued > 0);
-  const duration = snapshot.summary ? snapshot.summary.durationMs : sumDuration(snapshot.root);
+  // Sum of descendant test durations, consistent with the per-file/suite rows
+  // (which also sum). Avoids the header showing wall-clock while rows show sums.
+  const duration = sumDuration(snapshot.root);
+
+  // Enter-animation bookkeeping: play only for rows first seen during a live run,
+  // staggered within each file so a file "unfurls" rather than popping as a slab.
+  const enterMap = new Map<string, number>();
+  {
+    const seen = seenRef.current;
+    let stagger = 0;
+    for (const row of rows) {
+      if (row.node.type === 'file') stagger = 0;
+      const firstSeen = !seen.has(row.node.key);
+      seen.add(row.node.key);
+      if (firstSeen && inProgress) { enterMap.set(row.node.key, stagger); stagger += 1; }
+    }
+  }
 
   if (loadError) {
     return (
@@ -383,7 +466,14 @@ export function TreeView({
 
       <div className="tree" role="tree" aria-label="Test results">
         {rows.length > 0 ? (
-          rows.map((row) => <RowView key={row.node.key} row={row} toggle={toggle} />)
+          rows.map((row) => (
+            <RowView
+              key={row.node.key}
+              row={row}
+              toggle={toggle}
+              enter={enterMap.has(row.node.key) ? enterMap.get(row.node.key)! : null}
+            />
+          ))
         ) : q ? (
           <CenteredState icon="⌕" iconStatus="skipped" title={`No tests match “${query.trim()}”`}>
             <div className="state-sub">Try a shorter query, or search by file name.</div>

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -27,6 +27,22 @@ function sumDuration(node: TestNode): number {
   return node.children.reduce((total, child) => total + sumDuration(child), 0);
 }
 
+/**
+ * Like `sumDuration`, but a still-running leaf counts the time elapsed since the
+ * client first saw it running (`since`), so its counter ticks live between polls
+ * instead of sitting at 0 until the run settles.
+ */
+function liveDuration(node: TestNode, now: number, since: Map<string, number>): number {
+  if (!isContainer(node)) {
+    if (node.status === 'running') {
+      if (!since.has(node.key)) since.set(node.key, now); // first sight: start the clock
+      return Math.max(0, now - since.get(node.key)!);
+    }
+    return node.durationMs ?? 0;
+  }
+  return node.children.reduce((total, child) => total + liveDuration(child, now, since), 0);
+}
+
 /** Severity of a test's diagnostics, for the row badge tint. */
 function diagSeverity(node: TestNode): TestStatus {
   if (realError(node) || node.stderr.length > 0) return 'failed';
@@ -200,9 +216,14 @@ interface RowViewProps {
   toggle: (key: string, current: boolean) => void;
   /** Stagger index for the enter animation, or null when the row shouldn't animate in. */
   enter: number | null;
+  /** Shared clock (performance.now) + per-node running-start map, for live duration ticking. */
+  now: number;
+  since: Map<string, number>;
 }
 
-function RowView({ row, toggle, enter }: RowViewProps) {
+function RowView({
+  row, toggle, enter, now, since,
+}: RowViewProps) {
   const {
     node, depth, status, container, expanded, hasDiag, diagOpen,
   } = row;
@@ -287,7 +308,7 @@ function RowView({ row, toggle, enter }: RowViewProps) {
             ))}
           </span>
         ) : null}
-        <span className="dur">{formatDuration(sumDuration(node)) || '—'}</span>
+        <span className="dur">{formatDuration(liveDuration(node, now, since)) || '—'}</span>
       </div>
       {hasDiag ? (
         <div className={`collapsible${diagOpen ? ' open' : ''}`}>
@@ -349,6 +370,11 @@ export function TreeView({
   // Rows already painted at least once — so we only play the enter animation for
   // rows that newly arrive during a live run, never on every re-render.
   const seenRef = useRef<Set<string>>(new Set());
+  // Client clock (performance.now) at which each node was first seen running, so
+  // running durations tick live between polls.
+  const sinceRef = useRef<Map<string, number>>(new Map());
+  // A steadily-incrementing tick that drives live duration re-renders.
+  const [, setTick] = useState(0);
 
   const files = snapshot.root.children;
   const { counts } = snapshot;
@@ -363,20 +389,32 @@ export function TreeView({
   const toggle = (key: string, current: boolean) => {
     setOverrides((prev) => new Map(prev).set(key, !current));
   };
-  const collapseAll = () => {
+  const [allCollapsed, setAllCollapsed] = useState(false);
+  const toggleAll = () => {
     const keys: string[] = [];
     collectContainerKeys(files, keys);
+    const expand = allCollapsed; // currently collapsed -> expand; else collapse
     setOverrides((prev) => {
       const next = new Map(prev);
-      for (const key of keys) next.set(key, false);
+      for (const key of keys) next.set(key, expand);
       return next;
     });
+    setAllCollapsed(!allCollapsed);
   };
 
   const inProgress = !snapshot.summary && (streaming || counts.running > 0 || counts.queued > 0);
-  // Sum of descendant test durations, consistent with the per-file/suite rows
-  // (which also sum). Avoids the header showing wall-clock while rows show sums.
-  const duration = sumDuration(snapshot.root);
+  // Tick a few times a second while anything is running so running durations
+  // advance live instead of freezing between polls.
+  useEffect(() => {
+    if (!inProgress) return undefined;
+    const id = setInterval(() => setTick((n) => (n + 1) % 1e6), 250);
+    return () => clearInterval(id);
+  }, [inProgress]);
+  const now = performance.now();
+  const since = sinceRef.current;
+  // Sum of descendant durations (running leaves count live elapsed), consistent
+  // with the per-file/suite rows. Header ticks with the run.
+  const duration = liveDuration(snapshot.root, now, since);
 
   // Enter-animation bookkeeping: play only for rows first seen during a live run,
   // staggered within each file so a file "unfurls" rather than popping as a slab.
@@ -447,7 +485,14 @@ export function TreeView({
             >
               <ThemeIcon theme={theme} />
             </button>
-            <button type="button" className="btn" onClick={collapseAll} title="Collapse all">Collapse</button>
+            <button
+              type="button"
+              className="btn"
+              onClick={toggleAll}
+              title={allCollapsed ? 'Expand all' : 'Collapse all'}
+            >
+              {allCollapsed ? 'Expand' : 'Collapse'}
+            </button>
           </div>
         </div>
         <div className="hdr-bar-row">
@@ -472,6 +517,8 @@ export function TreeView({
               row={row}
               toggle={toggle}
               enter={enterMap.has(row.node.key) ? enterMap.get(row.node.key)! : null}
+              now={now}
+              since={since}
             />
           ))
         ) : q ? (

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -29,8 +29,23 @@ export function reasonOf(node: TestNode): string | undefined {
   return undefined;
 }
 
+/** Node's aggregate "N subtests failed" error — redundant with the real error on
+ *  the failing leaf, so we never render it. */
+const SYNTHETIC_ROLLUP = /^\d+ subtests? failed$/i;
+
+/**
+ * The error worth showing: only a *leaf* test's own error, and never Node's
+ * synthetic container rollup. Containers communicate failure through their
+ * status glyph and the failed child inside them, not an error block.
+ */
+export function realError(node: TestNode): { message: string; stack?: string } | undefined {
+  if (isContainer(node) || !node.error) return undefined;
+  if (SYNTHETIC_ROLLUP.test((node.error.message ?? '').trim())) return undefined;
+  return node.error;
+}
+
 export function hasDiagnostics(node: TestNode): boolean {
-  return Boolean(node.error)
+  return Boolean(realError(node))
     || node.diagnostics.length > 0
     || node.stdout.length > 0
     || node.stderr.length > 0

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -24,6 +24,7 @@ export const STYLES = `
 :root {
   --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
   --sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --ease-out: cubic-bezier(.2,.6,.2,1);
 }
 :root[data-theme="dark"] {${DARK}}
 :root[data-theme="light"] {${LIGHT}}
@@ -54,7 +55,44 @@ button { font-family: inherit; } input { font-family: inherit; }
 @keyframes ppulse { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
 [data-spin="true"] { display: inline-block; animation: pspin 1s linear infinite; }
 [data-pulse="true"] { animation: ppulse 1.5s ease-in-out infinite; }
-@media (prefers-reduced-motion: reduce) { [data-spin="true"], [data-pulse="true"] { animation: none; } }
+
+/* expand/collapse: animate the disclosure to auto height via grid-rows 0fr->1fr */
+.collapsible { display: grid; grid-template-rows: 0fr; transition: grid-template-rows 200ms var(--ease-out); }
+.collapsible.open { grid-template-rows: 1fr; }
+.collapsible > .inner { overflow: hidden; min-height: 0; }
+.collapsible > .inner > .diag { opacity: 0; transition: opacity 200ms var(--ease-out); }
+.collapsible.open > .inner > .diag { opacity: 1; }
+
+/* live viewer: rows arriving, running, and settling (§9) */
+@keyframes rowEnter { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+@keyframes spin { to { transform: rotate(360deg); } }
+@keyframes rowPulse { 0%,100% { background: transparent; } 50% { background: var(--row-hover); } }
+@keyframes settlePop { 0% { transform: scale(.6); opacity: .4; } 60% { transform: scale(1.15); } 100% { transform: scale(1); } }
+@keyframes failFlash { from { background: var(--soft-failed); } to { background: transparent; } }
+
+.row-enter { animation: rowEnter 220ms var(--ease-out) both; }
+/* a running row pulses faintly once it has settled onto the screen (not while entering) */
+.row[data-running="true"]:not(.row-enter) { animation: rowPulse 1.6s ease-in-out infinite; }
+/* a ring spinner in the status-dot slot for a running test */
+.spinner { width: 10px; height: 10px; flex: none; border-radius: 50%; border: 2px solid var(--soft-running); border-top-color: var(--st-running); animation: spin .8s linear infinite; }
+/* indicators cross-fade their color, so even a plain status swap eases */
+.indicator { transition: color 200ms var(--ease-out), background-color 200ms var(--ease-out); }
+.settle-passed .indicator, .settle-failed .indicator, .settle-todo .indicator, .settle-skipped .indicator { animation: settlePop 300ms var(--ease-out); }
+/* failures earn one extra beat: a single row tint flash, never a loop */
+.settle-failed { animation: failFlash 500ms var(--ease-out); }
+/* the summary bar slides as counts shift queued -> settled */
+.bar > span { transition: width 300ms var(--ease-out); }
+.verdict { transition: background-color 200ms var(--ease-out), color 200ms var(--ease-out); }
+
+@media (prefers-reduced-motion: reduce) {
+  [data-spin="true"], [data-pulse="true"], .spinner,
+  .row-enter, .row[data-running="true"]:not(.row-enter),
+  .settle-passed .indicator, .settle-failed .indicator, .settle-todo .indicator, .settle-skipped .indicator,
+  .settle-failed { animation: none; }
+  .caret, .collapsible, .collapsible > .inner > .diag, .btn, .btn-primary, .indicator, .bar > span, .verdict { transition: none; }
+  /* keep a running test legible without motion: a static amber ring */
+  .spinner { border-color: var(--soft-running); border-top-color: var(--st-running); }
+}
 
 /* app shell */
 .app { height: 100%; display: flex; flex-direction: column; --rh: 34px; --fs: 13.5px; --ind: 20px; }
@@ -76,8 +114,9 @@ button { font-family: inherit; } input { font-family: inherit; }
 .search { position: relative; display: flex; align-items: center; }
 .search svg { position: absolute; left: 11px; color: var(--faint); pointer-events: none; }
 .search input { background: var(--panel-2); border: 1px solid var(--line); color: var(--fg); font-size: 13px; padding: 8px 12px 8px 32px; border-radius: 10px; width: 188px; outline: none; }
-.btn { display: inline-flex; align-items: center; gap: 6px; background: var(--panel-2); border: 1px solid var(--line); color: var(--dim); border-radius: 10px; padding: 8px 11px; font-size: 12px; cursor: pointer; transition: background .13s, color .13s; }
+.btn { display: inline-flex; align-items: center; gap: 6px; background: var(--panel-2); border: 1px solid var(--line); color: var(--dim); border-radius: 10px; padding: 8px 11px; font-size: 12px; cursor: pointer; transition: background .13s, color .13s, transform .13s; }
 .btn:hover { background: var(--raise); color: var(--fg); }
+.btn:active { transform: scale(.97); }
 .hdr-bar-row { padding: 0 18px 13px; display: flex; align-items: center; gap: 14px; }
 .bar { flex: 1; min-width: 220px; height: 9px; display: flex; gap: 2px; border-radius: 999px; overflow: hidden; background: var(--panel-2); }
 .bar > span { height: 100%; }
@@ -90,7 +129,8 @@ button { font-family: inherit; } input { font-family: inherit; }
 .row[data-fail="true"] { background: var(--fail-tint); }
 .guides { display: flex; flex: none; align-self: stretch; }
 .guide { width: var(--ind); align-self: stretch; border-left: 1px solid var(--line); }
-.caret { width: 16px; flex: none; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 10px; }
+.caret { width: 16px; flex: none; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 10px; transition: transform 160ms var(--ease-out); }
+.caret[data-open="true"] { transform: rotate(90deg); }
 .dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
 .cglyph { font-size: 13px; font-weight: 700; width: 14px; flex: none; text-align: center; }
 .name { font-size: var(--fs); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -117,7 +157,10 @@ button { font-family: inherit; } input { font-family: inherit; }
 .diag pre { margin: 0; font-family: var(--mono); font-size: 11.5px; line-height: 1.55; }
 .diag pre.stack { padding: 2px 14px 13px; color: var(--dim); overflow-x: auto; white-space: pre; }
 .diag pre.text { padding: 2px 14px 13px; color: var(--fg); overflow-x: auto; white-space: pre-wrap; word-break: break-word; }
-.diag pre.text.err { color: var(--fg); }
+/* merged stdout+stderr: one block, per-line stream tagging */
+.out { padding: 4px 14px 12px; }
+.out-line { position: relative; padding-left: 12px; font-family: var(--mono); font-size: 11.5px; line-height: 1.55; color: var(--fg); white-space: pre-wrap; word-break: break-word; }
+.out-line[data-err]::before { content: ""; position: absolute; left: 0; top: 3px; bottom: 3px; width: 2px; border-radius: 1px; background: var(--st-failed); }
 .diag-list { padding: 2px 14px 12px; display: flex; flex-direction: column; gap: 6px; }
 .diag-item { font-size: 12.5px; color: var(--fg); display: flex; gap: 9px; align-items: baseline; }
 .diag-level { font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; flex: none; border-radius: 5px; padding: 1px 6px; }
@@ -129,7 +172,9 @@ button { font-family: inherit; } input { font-family: inherit; }
 .state-title { font-size: 16px; color: var(--fg); font-weight: 600; }
 .state-sub { font-size: 13px; color: var(--faint); max-width: 380px; line-height: 1.6; }
 .state-cmd { background: var(--panel-2); border: 1px solid var(--line); color: var(--dim); padding: 9px 14px; border-radius: 10px; font-family: var(--mono); font-size: 12px; max-width: 92%; overflow-x: auto; }
-.btn-primary { background: var(--accent); border: none; color: var(--accent-ink); border-radius: 10px; padding: 9px 17px; font-size: 13px; font-weight: 600; cursor: pointer; }
+.btn-primary { background: var(--accent); border: none; color: var(--accent-ink); border-radius: 10px; padding: 9px 17px; font-size: 13px; font-weight: 600; cursor: pointer; transition: filter .13s, transform .13s; }
+.btn-primary:hover { filter: brightness(1.06); }
+.btn-primary:active { transform: scale(.97); }
 
 /* footer */
 .footer { flex: none; border-top: 1px solid var(--line); background: var(--panel); padding: 8px 18px; display: flex; align-items: center; gap: 10px; color: var(--faint); font-size: 11px; }

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -4,7 +4,7 @@ import { createTreeStore } from '@reporters/tree-core';
 import type { Counts, TestEvent, TestNode } from '@reporters/tree-core';
 import {
   buildRows, collectContainerKeys, computeMatches, displayName, hasDiagnostics,
-  isDiagOpen, isExpanded, reasonOf, rollup,
+  isDiagOpen, isExpanded, reasonOf, realError, rollup,
 } from '../src/client/rowModel.ts';
 
 const zeroCounts = (): Counts => ({
@@ -147,4 +147,37 @@ test('buildRows drops nodes filtered out by an active query', () => {
   const rows = buildRows([file], { overrides: new Map(), query: 'alpha', matches });
   assert.ok(rows.some((r) => r.node.key === 'l1'), 'the matching leaf is kept');
   assert.ok(!rows.some((r) => r.node.key === 'l2'), 'the non-matching sibling is filtered out');
+});
+
+test('realError shows a failed leaf error but suppresses synthetic and container rollups', () => {
+  // a real leaf error is returned as-is
+  const leaf = node({ error: { message: 'expected 3 to equal 4', stack: 'at x' } });
+  assert.deepStrictEqual(realError(leaf), { message: 'expected 3 to equal 4', stack: 'at x' });
+  // Node's synthetic "N subtests failed" rollup on a leaf is dropped
+  assert.strictEqual(realError(node({ error: { message: '1 subtest failed' } })), undefined);
+  assert.strictEqual(realError(node({ error: { message: '3 subtests failed' } })), undefined);
+  // a container never renders its own error, even a genuine-looking one
+  const container = node({
+    error: { message: 'boom' },
+    children: [node({ key: 'c' })],
+    counts: { ...zeroCounts(), failed: 1, total: 1 },
+  });
+  assert.strictEqual(realError(container), undefined);
+  // a leaf with no error has none
+  assert.strictEqual(realError(node()), undefined);
+  // a leaf error with no message isn't synthetic — it's shown as-is
+  const noMsg = { message: undefined as unknown as string };
+  assert.strictEqual(realError(node({ error: noMsg })), noMsg);
+});
+
+test('hasDiagnostics ignores a suppressed (synthetic/container) error', () => {
+  // a container whose only "diagnostic" is a synthetic rollup error has nothing to show
+  const container = node({
+    error: { message: '1 subtest failed' },
+    children: [node({ key: 'c' })],
+    counts: { ...zeroCounts(), failed: 1, total: 1 },
+  });
+  assert.strictEqual(hasDiagnostics(container), false);
+  // a failed leaf with a real error does have diagnostics
+  assert.strictEqual(hasDiagnostics(node({ error: { message: 'real' } })), true);
 });


### PR DESCRIPTION
Implements the designer's round-2 feedback and the §9 live-viewer transition choreography for the `@reporters/web` HTML viewer.

## Round-2 punch list
- **§1 Merge output** — stdout + stderr collapse into one **Output** section (stream-tagged; stderr lines get a red left-tick). Diagnostics stay one section. At most Error → Output → Diagnostics per test.
- **§2 Strip ANSI** — every displayed string (error, output, diagnostics, reason) runs through an ANSI-SGR stripper; no raw `[33m…` codes.
- **§4 Suppress synthetic errors** — a `realError()` helper drops Node's `"N subtests failed"` rollups; only a failed **leaf** renders an Error block, never a container.
- **§6 Animations** — expand/collapse uses `grid-rows 0fr→1fr` + opacity fade; a single caret glyph rotates 90°; buttons press-scale. All no-op under `prefers-reduced-motion`.
- **§8** — header duration now sums descendant durations (consistent with the file/suite rows); failed-tint stays leaf-only.
- **§3/§5** — the compact indented diagnostics card and per-depth indent guides + weight ladder were already in place; kept and verified.

## §9 Live-viewer choreography
- **9a** staggered per-file **row-enter** (fade + slide), only for rows first seen during a live run (seen-tracking), clamped stagger.
- **9b** a **ring spinner** in the dot slot for running tests + a faint running-row pulse.
- **9c** a **settle pop** when a node leaves `running`, a one-shot **fail-flash** on failed rows, and width/color cross-fades on the summary bar and indicators.
- **9d** one motion per event; all motion disabled under reduced-motion.

## Verification
Built (DTS clean), 32/32 web tests pass, lint clean. Screenshots (dark + light) attached below against a sample run with failures, ANSI output, stderr, skip/todo, and nesting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
