### PR TITLE
feat(web): render ANSI colors in the report (fancy-ansi)

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@reporters/mux": "workspace:^",
     "@reporters/tree-core": "workspace:^",
+    "fancy-ansi": "^0.1.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "tsup": "^8.5.0",

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -8,11 +8,9 @@ import {
   buildRows, collectContainerKeys, computeMatches, displayName, isContainer, reasonOf, realError, type FlatRow,
 } from './rowModel.ts';
 
-// node:test captures colored output verbatim; strip ANSI SGR sequences so the
-// raw escape codes never leak into the report as visible garbage.
-// eslint-disable-next-line no-control-regex
-const ANSI_SGR = /\u001b\[[0-9;]*m/g;
-const stripAnsi = (text: string): string => text.replace(ANSI_SGR, '');
+// node:test captures colored output verbatim; render the ANSI SGR codes as real
+// colors (mapped to the theme's --ansi-* vars) rather than stripping them.
+import { AnsiHtml } from 'fancy-ansi/react';
 
 const GLYPH: Record<TestStatus, string> = {
   passed: '✓', failed: '✕', skipped: '⊘', todo: '◇', running: '◐', queued: '○',
@@ -65,12 +63,13 @@ interface DiagBlock {
   items?: { level: string; sev: TestStatus; text: string }[];
 }
 
-/** stdout + stderr merged into one line list, stream-tagged, ANSI stripped. */
+/** stdout + stderr merged into one line list, stream-tagged (ANSI kept — the
+ *  renderer colors it). */
 function outputLines(node: TestNode): OutLine[] {
   const lines: OutLine[] = [];
   const add = (chunks: string[], stream: 'out' | 'err'): void => {
     if (chunks.length === 0) return;
-    for (const line of stripAnsi(chunks.join('')).split('\n')) lines.push({ stream, text: line });
+    for (const line of chunks.join('').split('\n')) lines.push({ stream, text: line });
   };
   add(node.stdout, 'out');
   add(node.stderr, 'err');
@@ -79,15 +78,15 @@ function outputLines(node: TestNode): OutLine[] {
 }
 
 // At most three sections per test — Error, Output, Diagnostics (plus a reason
-// for skipped/todo). stdout+stderr collapse into one Output block; every text
-// is ANSI-stripped; synthetic container rollups never render an Error.
+// for skipped/todo). stdout+stderr collapse into one Output block; text keeps
+// its ANSI (colored at render); synthetic container rollups never render an Error.
 function diagBlocks(node: TestNode): DiagBlock[] {
   const blocks: DiagBlock[] = [];
   const error = realError(node);
   if (error) {
     blocks.push({
       key: 'error', title: 'Error', icon: '✕', sev: 'failed', kind: 'error',
-      message: stripAnsi(error.message), stack: stripAnsi(error.stack ?? error.message),
+      message: error.message, stack: error.stack ?? error.message,
     });
   }
   const lines = outputLines(node);
@@ -100,7 +99,7 @@ function diagBlocks(node: TestNode): DiagBlock[] {
       items: node.diagnostics.map((d) => ({
         level: d.level,
         sev: d.level === 'error' ? 'failed' : d.level === 'warn' ? 'running' : 'skipped',
-        text: stripAnsi(d.message),
+        text: d.message,
       })),
     });
   }
@@ -108,7 +107,7 @@ function diagBlocks(node: TestNode): DiagBlock[] {
   if (reason) {
     blocks.push({
       key: 'reason', title: node.status === 'skipped' ? 'why skipped' : 'why todo',
-      icon: '⊘', sev: 'skipped', kind: 'text', text: stripAnsi(reason),
+      icon: '⊘', sev: 'skipped', kind: 'text', text: reason,
     });
   }
   return blocks;
@@ -160,8 +159,8 @@ function Diagnostics({ node, indent }: { node: TestNode; indent: string }) {
             </div>
             {block.kind === 'error' ? (
               <>
-                <div className="diag-msg"><span data-stc="failed">{block.message}</span></div>
-                <pre className="stack">{block.stack}</pre>
+                <div className="diag-msg" data-stc="failed"><AnsiHtml text={block.message!} /></div>
+                <pre className="stack"><AnsiHtml text={block.stack!} /></pre>
               </>
             ) : null}
             {block.kind === 'output' ? (
@@ -169,20 +168,20 @@ function Diagnostics({ node, indent }: { node: TestNode; indent: string }) {
                 {block.lines!.map((line, i) => (
                   // eslint-disable-next-line react/no-array-index-key
                   <div className="out-line" data-err={line.stream === 'err' ? 'true' : undefined} key={i}>
-                    {line.text === '' ? ' ' : line.text}
+                    <AnsiHtml text={line.text === '' ? ' ' : line.text} />
                   </div>
                 ))}
               </div>
             ) : null}
             {block.kind === 'text' ? (
-              <pre className="text">{block.text}</pre>
+              <pre className="text"><AnsiHtml text={block.text!} /></pre>
             ) : null}
             {block.kind === 'list' ? (
               <div className="diag-list">
                 {block.items!.map((item, i) => (
                   <div className="diag-item" key={i}>
                     <span className="diag-level" data-soft={item.sev}>{item.level}</span>
-                    <span className="txt">{item.text}</span>
+                    <span className="txt"><AnsiHtml text={item.text} /></span>
                   </div>
                 ))}
               </div>

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -7,6 +7,9 @@ const DARK = `
   --st-passed:#34d27b; --st-failed:#fb5a6a; --st-skipped:#8a93a1; --st-todo:#7c9cff; --st-running:#ffb13d; --st-queued:#5d6573;
   --soft-passed:rgba(52,210,123,.15); --soft-failed:rgba(251,90,106,.16); --soft-skipped:rgba(138,147,161,.16); --soft-todo:rgba(124,156,255,.16); --soft-running:rgba(255,177,61,.17); --soft-queued:rgba(93,101,115,.18);
   --fail-tint:rgba(251,90,106,.07);
+  --ansi-black:#5d6573; --ansi-red:#fb5a6a; --ansi-green:#34d27b; --ansi-yellow:#ffb13d; --ansi-blue:#7c9cff; --ansi-magenta:#c792ea; --ansi-cyan:#56d4dd; --ansi-white:#c4c9d4;
+  --ansi-bright-black:#8a93a1; --ansi-bright-red:#ff8087; --ansi-bright-green:#66e0a3; --ansi-bright-yellow:#ffca6a; --ansi-bright-blue:#a3b8ff; --ansi-bright-magenta:#e0aaff; --ansi-bright-cyan:#8be9fd; --ansi-bright-white:#ffffff;
+  --ansi-bold-font-weight:700; --ansi-dim-opacity:.6;
 `;
 
 const LIGHT = `
@@ -18,6 +21,9 @@ const LIGHT = `
   --st-passed:#16a34a; --st-failed:#e23744; --st-skipped:#697381; --st-todo:#3f63d6; --st-running:#bf7400; --st-queued:#97a0ad;
   --soft-passed:rgba(22,163,74,.12); --soft-failed:rgba(226,55,68,.10); --soft-skipped:rgba(105,115,129,.12); --soft-todo:rgba(63,99,214,.11); --soft-running:rgba(191,116,0,.13); --soft-queued:rgba(151,160,173,.14);
   --fail-tint:rgba(226,55,68,.05);
+  --ansi-black:#161b22; --ansi-red:#e23744; --ansi-green:#16a34a; --ansi-yellow:#bf7400; --ansi-blue:#3f63d6; --ansi-magenta:#9333ea; --ansi-cyan:#0e7490; --ansi-white:#5a636f;
+  --ansi-bright-black:#697381; --ansi-bright-red:#dc2626; --ansi-bright-green:#15803d; --ansi-bright-yellow:#a16207; --ansi-bright-blue:#2947c0; --ansi-bright-magenta:#7e22ce; --ansi-bright-cyan:#0891b2; --ansi-bright-white:#161b22;
+  --ansi-bold-font-weight:700; --ansi-dim-opacity:.6;
 `;
 
 export const STYLES = `

--- a/yarn.lock
+++ b/yarn.lock
@@ -542,6 +542,7 @@ __metadata:
   dependencies:
     "@reporters/mux": "workspace:^"
     "@reporters/tree-core": "workspace:^"
+    fancy-ansi: "npm:^0.1.3"
     react: "npm:^19.0.0"
     react-dom: "npm:^19.0.0"
     tsup: "npm:^8.5.0"
@@ -1746,6 +1747,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-html@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "escape-html@npm:1.0.3"
+  checksum: 10c0/524c739d776b36c3d29fa08a22e03e8824e3b2fd57500e5e44ecf3cc4707c34c60f9ca0781c0e33d191f2991161504c295e98f68c78fe7baa6e57081ec6ac0a3
+  languageName: node
+  linkType: hard
+
 "escape-string-regexp@npm:^2.0.0":
   version: 2.0.0
   resolution: "escape-string-regexp@npm:2.0.0"
@@ -1963,6 +1971,15 @@ __metadata:
   version: 3.1.3
   resolution: "exponential-backoff@npm:3.1.3"
   checksum: 10c0/77e3ae682b7b1f4972f563c6dbcd2b0d54ac679e62d5d32f3e5085feba20483cf28bd505543f520e287a56d4d55a28d7874299941faf637e779a1aa5994d1267
+  languageName: node
+  linkType: hard
+
+"fancy-ansi@npm:^0.1.3":
+  version: 0.1.3
+  resolution: "fancy-ansi@npm:0.1.3"
+  dependencies:
+    escape-html: "npm:^1.0.3"
+  checksum: 10c0/691fdb86bbbe12318c2908fc6b725e08c17874b84f11dd22b5833663e5c77c03c5eb1142c6c779f66ab2f60f47038a09c822ee7fe7c0f043fa3c16f1dbb83216
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow-up to the viewer design work: **render** ANSI colors instead of stripping them.

`node:test` captures colored output verbatim — assertion diffs, and any styling a test writes to stdout/stderr. The previous pass stripped the SGR codes; this renders them.

## Approach
- Uses [`fancy-ansi`](https://www.npmjs.com/package/fancy-ansi)'s React component (`AnsiHtml` from `fancy-ansi/react`) to convert ANSI to colored spans. Bundled into the self-contained viewer (no network).
- Maps the 16 ANSI colors to **theme-aware `--ansi-*` CSS variables** defined in the viewer's dark/light token sets, so colors stay legible on both backgrounds (amber/green/red tuned per theme).
- Applied everywhere text is shown: the merged **Output** block, the **Error** message + stack, and **Diagnostics** / reason. The per-line stderr red-tick is kept.

## Verification
Screenshots (dark + light) below against a run whose stdout/stderr contain real ANSI: the yellow number renders yellow, "green" renders green, the stderr "issue!!" renders red — no raw escape codes.

Build (DTS) clean, 34/34 web tests pass, lint clean. Rebased onto `main` after #205 merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
