### PR TITLE
chore: route this repo's tests through @reporters/mux

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -64,4 +64,12 @@ export default [
       'max-classes-per-file': 'off',
     },
   },
+  {
+    // Routes import workspace reporters whose entry points are built dist output,
+    // absent at lint time (their source packages are ignored above).
+    files: ['mux.config.mjs'],
+    rules: {
+      'import/no-unresolved': 'off',
+    },
+  },
 ];

--- a/mux.config.mjs
+++ b/mux.config.mjs
@@ -1,0 +1,12 @@
+import { httpServer } from '@reporters/web/sink';
+import live from '@reporters/live';
+
+export default {
+  local: [
+    { reporter: live, sink: 'stdout' },
+    { reporter: '@reporters/web', sink: httpServer() },
+  ],
+  ci: [
+    { reporter: '@reporters/gh', sink: 'stdout' },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "mono": "c8 node scripts/mono-run.js",
     "build": "yarn mono build",
-    "test": "yarn mono build && yarn mono test",
+    "test": "yarn mono build && REPORTERS_OPEN=0 yarn mono test",
     "test:clean-snapshots": "rm -rf packages/**/.snapshots",
     "test:update-snapshots": "SNAP_UPDATE=1 yarn test",
     "lint": "eslint ."
@@ -28,6 +28,10 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.5",
+    "@reporters/gh": "workspace:^",
+    "@reporters/live": "workspace:^",
+    "@reporters/mux": "workspace:^",
+    "@reporters/web": "workspace:^",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/packages/bail/package.json
+++ b/packages/bail/package.json
@@ -13,7 +13,7 @@
     "./index.js"
   ],
   "scripts": {
-    "test": "node --test-reporter=../gh/index.js --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "bugs": {
     "url": "https://github.com/MoLow/reporters/issues"

--- a/packages/gh/package.json
+++ b/packages/gh/package.json
@@ -18,7 +18,7 @@
     "./index.js"
   ],
   "scripts": {
-    "test": "node --test-reporter=./index.js --test-reporter-destination=stdout --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "bugs": {
     "url": "https://github.com/MoLow/reporters/issues"

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -19,7 +19,7 @@
     "./gh_core.js"
   ],
   "scripts": {
-    "test": "node --test-reporter=../gh/index.js --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "bugs": {
     "url": "https://github.com/MoLow/reporters/issues"

--- a/packages/junit/package.json
+++ b/packages/junit/package.json
@@ -14,7 +14,7 @@
     "./index.js"
   ],
   "scripts": {
-    "test": "node --test-reporter=../gh/index.js --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "bugs": {
     "url": "https://github.com/MoLow/reporters/issues"

--- a/packages/live/package.json
+++ b/packages/live/package.json
@@ -28,7 +28,7 @@
     "build": "tsup",
     "prepack": "tsup",
     "pretest": "tsup",
-    "test": "node --test-reporter=../gh/index.js --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "dependencies": {
     "ink": "^6.0.0",

--- a/packages/mocha/package.json
+++ b/packages/mocha/package.json
@@ -14,7 +14,7 @@
     "./index.js"
   ],
   "scripts": {
-    "test": "node --test-reporter=../gh/index.js --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "bugs": {
     "url": "https://github.com/MoLow/reporters/issues"

--- a/packages/mux/package.json
+++ b/packages/mux/package.json
@@ -26,7 +26,7 @@
     "build": "rm -rf dist && tsup",
     "prepack": "rm -rf dist && tsup",
     "pretest": "rm -rf dist && tsup",
-    "test": "node --test-reporter=../live/dist/index.js --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "devDependencies": {
     "@reporters/tree-core": "workspace:^",

--- a/packages/silent/package.json
+++ b/packages/silent/package.json
@@ -13,7 +13,7 @@
     "./index.js"
   ],
   "scripts": {
-    "test": "node --test-reporter=../gh/index.js --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "bugs": {
     "url": "https://github.com/MoLow/reporters/issues"

--- a/packages/slow/package.json
+++ b/packages/slow/package.json
@@ -13,7 +13,7 @@
     "./index.js"
   ],
   "scripts": {
-    "test": "node --test-reporter=../gh/index.js --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "bugs": {
     "url": "https://github.com/MoLow/reporters/issues"

--- a/packages/testwatch/package.json
+++ b/packages/testwatch/package.json
@@ -15,7 +15,7 @@
     "nodeVersion.js"
   ],
   "scripts": {
-    "test": "node --test-reporter=../gh/index.js --test tests/index.test.js",
+    "test": "node --test-reporter=@reporters/mux --test tests/index.test.js",
     "test:watch": "testwatch tests/index"
   },
   "bugs": {

--- a/packages/tree-core/package.json
+++ b/packages/tree-core/package.json
@@ -24,7 +24,7 @@
   "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsup",
-    "test": "node --test-reporter=../gh/index.js --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "devDependencies": {
     "tsup": "^8.5.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -31,7 +31,7 @@
     "build": "rm -rf dist && tsup",
     "prepack": "rm -rf dist && tsup",
     "pretest": "rm -rf dist && tsup",
-    "test": "node --test-reporter=../gh/index.js --test"
+    "test": "node --test-reporter=@reporters/mux --test"
   },
   "devDependencies": {
     "@reporters/mux": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -448,7 +448,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@reporters/gh@workspace:packages/gh":
+"@reporters/gh@workspace:^, @reporters/gh@workspace:packages/gh":
   version: 0.0.0-use.local
   resolution: "@reporters/gh@workspace:packages/gh"
   dependencies:
@@ -472,7 +472,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@reporters/live@workspace:packages/live":
+"@reporters/live@workspace:^, @reporters/live@workspace:packages/live":
   version: 0.0.0-use.local
   resolution: "@reporters/live@workspace:packages/live"
   dependencies:
@@ -536,7 +536,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@reporters/web@workspace:packages/web":
+"@reporters/web@workspace:^, @reporters/web@workspace:packages/web":
   version: 0.0.0-use.local
   resolution: "@reporters/web@workspace:packages/web"
   dependencies:
@@ -3623,6 +3623,10 @@ __metadata:
   resolution: "reporters@workspace:."
   dependencies:
     "@eslint/eslintrc": "npm:^3.3.5"
+    "@reporters/gh": "workspace:^"
+    "@reporters/live": "workspace:^"
+    "@reporters/mux": "workspace:^"
+    "@reporters/web": "workspace:^"
     "@types/node": "npm:^22.10.0"
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"


### PR DESCRIPTION
## What

Dogfood [`@reporters/mux`](packages/mux) as the test-runner reporter for this monorepo, per `TODOS.md` → *"Use mux in this repo"*.

A new root [`mux.config.mjs`](mux.config.mjs) defines two profiles:

| Profile | Routes |
|---|---|
| `local` | `@reporters/live` → `stdout` + `@reporters/web` → `httpServer()` |
| `ci` | `@reporters/gh` → `stdout` |

The profile auto-resolves: `ci` under GitHub Actions, else `local`. CI stays on `@reporters/gh` as requested.

## Changes

- **`mux.config.mjs`** — the two-profile config (`.mjs` since root is `type: commonjs`).
- **All 12 packages' `test` scripts** → `--test-reporter=@reporters/mux` (resolves via the workspace symlink in root `node_modules`).
- **Root `package.json`** — `REPORTERS_OPEN=0` on the `test` script so a full `yarn test` serves the web viewer *without* opening a browser per package; a single-package run (`yarn workspace @reporters/x test`) still opens it. Also adds `@reporters/{gh,live,mux,web}: workspace:^` devDeps so the config import resolves and lints.
- **`eslint.config.mjs`** — disables `import/no-unresolved` for `mux.config.mjs` only (it imports built `dist` entry points of workspace packages, absent at lint time — the same reason those TS packages are already eslint-ignored).

## Verification

- `yarn lint` — 0 errors (5 pre-existing `no-console`/`func-names` warnings unchanged).
- `yarn test` — every package runs cleanly through mux, covering both generator reporters (live/web) and stream reporters (gh); mux's own 34 tests pass.
- The only failures are 4 snapshot tests each in `gh`/`github`, which **fail identically on unchanged `main`** with the local Node v26.2.0 — internal test-runner stack-trace line-number drift (`test:1366` local vs `test:1382` in the committed snapshots). Pre-existing and environmental; unrelated to this change. CI runs the pinned Node matrix + the daily update-snapshots workflow.

The `--test-reporter` only controls how results are *displayed* — orthogonal to what tests assert — so this is a dev-experience change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)