### PR TITLE
fix(web): honor REPORTERS_OPEN instead of REPORTERS_WEB_OPEN

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -16,7 +16,7 @@ The NDJSON is rendered by the tree viewer, reached three ways:
   also starts a local server for the viewer and opens your browser to a
   live-updating view (it polls the growing NDJSON over HTTP Range — no
   `file://`/CORS limits). It never opens in CI. Force it on/off with the `open`
-  option (2nd reporter arg) or `REPORTERS_WEB_OPEN=1|0`:
+  option (2nd reporter arg) or `REPORTERS_OPEN=1|0`:
 
   ```bash
   # opens a live browser view by default on a TTY; never in CI

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -4,7 +4,7 @@ import { soleFileDestination, shouldOpen, internals } from './open.ts';
 
 export interface WebOptions {
   /** Serve a live browser view of the run and open it. Defaults to detecting an
-   *  interactive terminal (a TTY, not CI); `REPORTERS_WEB_OPEN=1|0` also overrides. */
+   *  interactive terminal (a TTY, not CI); `REPORTERS_OPEN=1|0` also overrides. */
   open?: boolean;
 }
 
@@ -19,7 +19,7 @@ function hint(message: string): void {
  *
  * Run standalone on a dev machine it also serves a live browser view and opens
  * it, the same way it behaves through `@reporters/mux`'s `httpServer()` sink.
- * Control this with the `open` option or `REPORTERS_WEB_OPEN=1|0`; it never opens
+ * Control this with the `open` option or `REPORTERS_OPEN=1|0`; it never opens
  * in CI by default. Through mux the reporter is a pure emitter and the sink owns
  * viewing.
  */

--- a/packages/web/src/open.ts
+++ b/packages/web/src/open.ts
@@ -23,7 +23,7 @@ export function isCI(env: NodeJS.ProcessEnv = process.env): boolean {
 
 /**
  * Whether to open a live browser view. An explicit `open` option wins; then the
- * `REPORTERS_WEB_OPEN=1|0` env override; otherwise the default is to open on an
+ * `REPORTERS_OPEN=1|0` env override; otherwise the default is to open on an
  * interactive terminal (a TTY) and not in CI.
  */
 export function shouldOpen(
@@ -32,7 +32,7 @@ export function shouldOpen(
   isTTY: boolean = Boolean(process.stdout.isTTY),
 ): boolean {
   if (open !== undefined) return open;
-  const flag = env.REPORTERS_WEB_OPEN;
+  const flag = env.REPORTERS_OPEN;
   if (flag === '1' || flag === 'true') return true;
   if (flag === '0' || flag === 'false') return false;
   return isTTY && !isCI(env);

--- a/packages/web/tests/open.test.ts
+++ b/packages/web/tests/open.test.ts
@@ -23,8 +23,8 @@ test('shouldOpen: explicit option wins, then env, then TTY (off in CI)', () => {
   assert.strictEqual(shouldOpen(true, { CI: 'true' }, false), true);
   assert.strictEqual(shouldOpen(false, {}, true), false);
   // env override when no option
-  assert.strictEqual(shouldOpen(undefined, { REPORTERS_WEB_OPEN: '1' }, false), true);
-  assert.strictEqual(shouldOpen(undefined, { REPORTERS_WEB_OPEN: '0' }, true), false);
+  assert.strictEqual(shouldOpen(undefined, { REPORTERS_OPEN: '1' }, false), true);
+  assert.strictEqual(shouldOpen(undefined, { REPORTERS_OPEN: '0' }, true), false);
   // default: on for a TTY, off without one and off in CI
   assert.strictEqual(shouldOpen(undefined, {}, true), true);
   assert.strictEqual(shouldOpen(undefined, {}, false), false);


### PR DESCRIPTION
## Problem

`@reporters/web` opened its live browser view through its **own** `REPORTERS_WEB_OPEN` gate ([web/src/open.ts](packages/web/src/open.ts)), independent of mux's `REPORTERS_OPEN`. So `REPORTERS_OPEN=0` — used by the monorepo's root `test` script to keep a full `yarn test` quiet — silenced mux's *sink* open but **not** the web reporter's self-open, so a browser still spawned per package.

## Fix

Unify both mechanisms on a single env var: the web reporter now reads **`REPORTERS_OPEN`**. One switch controls opening across `@reporters/mux` and `@reporters/web`.

Verified end-to-end (web run through mux):
- `REPORTERS_OPEN=1` → opens (1 tab)
- `REPORTERS_OPEN=0` → nothing opens

## Docs

- [web/README.md](packages/web/README.md) — `REPORTERS_WEB_OPEN` → `REPORTERS_OPEN`.
- Doc comments in [web/src/index.ts](packages/web/src/index.ts) and [web/src/open.ts](packages/web/src/open.ts) updated.
- `mux/README.md` already documented `REPORTERS_OPEN`. Swept all docs — no `REPORTERS_WEB_OPEN` references remain. (`live`'s `REPORTERS_LIVE_PLAIN` is a separate, unrelated var, left as-is.)

## Tests

- `@reporters/web`: 34 passed (updated `open.test.ts` to the new var).
- `@reporters/mux`: 34 passed.
- `yarn lint`: 0 errors.

Note: this renames a documented env var (`REPORTERS_WEB_OPEN` → `REPORTERS_OPEN`) that the web reporter reads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)