### PR TITLE
feat: @reporters/sink — gist + s3 delivery sinks for viewing CI runs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,6 +24,8 @@ jobs:
       - run: yarn install --immutable
       - run: yarn lint
       - run: yarn test
+        env:
+          GH_TOKEN: ${{ secrets.GIST_TOKEN }}
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,1 +1,1 @@
-{"packages/github":"2.0.1","packages/junit":"2.0.1","packages/silent":"2.0.0","packages/bail":"2.0.1","packages/testwatch":"2.0.0","packages/slow":"2.0.1","packages/mocha":"2.0.1","packages/gh":"2.0.2","packages/live":"1.0.0","packages/web":"1.0.0","packages/mux":"0.0.0"}
+{"packages/github":"2.0.1","packages/junit":"2.0.1","packages/silent":"2.0.0","packages/bail":"2.0.1","packages/testwatch":"2.0.0","packages/slow":"2.0.1","packages/mocha":"2.0.1","packages/gh":"2.0.2","packages/live":"1.0.0","packages/web":"1.0.0","packages/mux":"0.0.0","packages/sink":"0.0.0"}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Available reporters:
 
 - [bail](https://www.npmjs.com/package/@reporters/bail) - bail on first failure
 - [mux](https://www.npmjs.com/package/@reporters/mux) - route/combine reporters per environment (e.g. `live` locally, `gh` on CI) and send each to its own sink
+- [sink](https://www.npmjs.com/package/@reporters/sink) - delivery sinks for `mux`: upload a run's NDJSON to a GitHub gist or S3 for the hosted viewer
 - [gh](https://www.npmjs.com/package/@reporters/gh) - all-in-one GitHub Actions reporter (readable log + annotations + summary in one)
 - [github](https://www.npmjs.com/package/@reporters/github) - GitHub Actions annotations + job summary only (pair with another reporter for the log)
 - [jUnit](https://www.npmjs.com/package/@reporters/junit) - report to jUnit 

--- a/mux.config.mjs
+++ b/mux.config.mjs
@@ -1,4 +1,5 @@
 import { httpServer } from '@reporters/web/sink';
+import { gist } from '@reporters/sink';
 import live from '@reporters/live';
 
 export default {
@@ -8,5 +9,6 @@ export default {
   ],
   ci: [
     { reporter: '@reporters/gh', sink: 'stdout' },
+    { reporter: '@reporters/web', sink: gist() },
   ],
 };

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@reporters/gh": "workspace:^",
     "@reporters/live": "workspace:^",
     "@reporters/mux": "workspace:^",
+    "@reporters/sink": "workspace:^",
     "@reporters/web": "workspace:^",
     "@types/node": "^22.10.0",
     "@types/react": "^19.0.0",

--- a/packages/mux/src/index.ts
+++ b/packages/mux/src/index.ts
@@ -43,9 +43,10 @@ export async function runRoutes(
     const reporter = await resolveReporter(route.reporter);
     const sink = resolveSink(route.sink);
     if (sink.start) await sink.start();
-    if (sink.viewerUrl && shouldOpen(route.open, env)) {
-      const url = sink.viewerUrl();
-      if (url) open(url);
+    const url = sink.viewerUrl?.();
+    if (url) {
+      internals.announce(url, env);
+      if (shouldOpen(route.open, env)) open(url);
     }
     // `Readable#compose` drives both a generator-function reporter and a
     // Transform-stream reporter uniformly — the same primitive node:test uses

--- a/packages/mux/src/index.ts
+++ b/packages/mux/src/index.ts
@@ -42,20 +42,20 @@ export async function runRoutes(
   await Promise.all(routes.map(async (route, i) => {
     const reporter = await resolveReporter(route.reporter);
     const sink = resolveSink(route.sink);
-    if (sink.start) await sink.start();
-    const url = sink.viewerUrl?.();
-    if (url) {
-      internals.announce(url, env);
-      if (shouldOpen(route.open, env)) open(url);
-    }
     // `Readable#compose` drives both a generator-function reporter and a
     // Transform-stream reporter uniformly — the same primitive node:test uses
     // internally — handling backpressure and error propagation for us.
     const stage = typeof reporter === 'function'
       ? (src: AsyncIterable<TestEvent>) => reporter(src, route.options)
       : reporter;
-    const output = Readable.from(streams[i]).compose(stage) as unknown as AsyncIterable<string | Buffer>;
     try {
+      if (sink.start) await sink.start();
+      const url = sink.viewerUrl?.();
+      if (url) {
+        internals.announce(url, env);
+        if (shouldOpen(route.open, env)) open(url);
+      }
+      const output = Readable.from(streams[i]).compose(stage) as unknown as AsyncIterable<string | Buffer>;
       for await (const chunk of output) await sink.write(chunk);
       if (sink.flush) await sink.flush();
     } finally {

--- a/packages/mux/src/open.ts
+++ b/packages/mux/src/open.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process';
+import { appendFileSync } from 'node:fs';
 import { isCI } from './profile.ts';
 
 /**
@@ -32,5 +33,18 @@ function openInBrowser(url: string): void {
 }
 /* c8 ignore stop */
 
-/** Indirection so tests can observe the open without launching a browser. */
-export const internals = { openInBrowser };
+/**
+ * Surface a sink's viewer URL: always a stderr hint, and on GitHub Actions
+ * (GITHUB_STEP_SUMMARY set) also a "View report" link in the job summary.
+ */
+export function announce(url: string, env: NodeJS.ProcessEnv = process.env): void {
+  process.stderr.write(`\n@reporters/mux: report at ${url}\n`);
+  if (env.GITHUB_STEP_SUMMARY) {
+    try {
+      appendFileSync(env.GITHUB_STEP_SUMMARY, `\n[View report](${url})\n`);
+    } catch { /* summary unavailable — the stderr hint already landed */ }
+  }
+}
+
+/** Indirection so tests can observe opens/announces without side effects. */
+export const internals = { openInBrowser, announce };

--- a/packages/mux/tests/index.test.ts
+++ b/packages/mux/tests/index.test.ts
@@ -65,12 +65,32 @@ test('runRoutes flushes a sink that implements flush() after the reporter comple
   assert.deepStrictEqual(events2, ['w:F:test:pass', 'w:F:test:pass', 'flush', 'close']);
 });
 
-test('runRoutes opens the sink viewer URL when the gate allows it', async () => {
+test('runRoutes opens the sink viewer URL when the gate allows it', async (t) => {
+  const { internals } = await import('../src/open.ts');
+  const originalAnnounce = internals.announce;
+  internals.announce = () => {};
+  t.after(() => { internals.announce = originalAnnounce; });
+
   const opened: string[] = [];
   const viewerSink: Sink = { write() {}, async close() {}, viewerUrl: () => 'http://localhost:1234/' };
   const config: MuxConfig = { local: [{ reporter: tagReporter('V'), sink: viewerSink }] };
   await runRoutes(source(), config, {}, (url) => opened.push(url));
   assert.deepStrictEqual(opened, ['http://localhost:1234/']);
+});
+
+test('runRoutes announces a sink viewer url even when the open gate is closed', async (t) => {
+  const { internals } = await import('../src/open.ts');
+  const announced: string[] = [];
+  const originalAnnounce = internals.announce;
+  internals.announce = (url: string) => { announced.push(url); };
+  t.after(() => { internals.announce = originalAnnounce; });
+
+  const opened: string[] = [];
+  const viewerSink: Sink = { write() {}, async close() {}, viewerUrl: () => 'http://localhost:1/' };
+  const config: MuxConfig = { local: [{ reporter: tagReporter('A'), sink: viewerSink }] };
+  await runRoutes(source(), config, { REPORTERS_OPEN: '0' }, (url) => opened.push(url));
+  assert.deepStrictEqual(announced, ['http://localhost:1/'], 'announced despite the closed gate');
+  assert.deepStrictEqual(opened, [], 'not opened');
 });
 
 // A Transform-based reporter (the shape @reporters/gh uses): objectMode in, string out.

--- a/packages/mux/tests/index.test.ts
+++ b/packages/mux/tests/index.test.ts
@@ -65,6 +65,18 @@ test('runRoutes flushes a sink that implements flush() after the reporter comple
   assert.deepStrictEqual(events2, ['w:F:test:pass', 'w:F:test:pass', 'flush', 'close']);
 });
 
+test('a sink start() failure still closes the sink (and rejects the run)', async () => {
+  let closed = false;
+  const sink: Sink = {
+    async start() { throw new Error('start boom'); },
+    write() {},
+    async close() { closed = true; },
+  };
+  const config: MuxConfig = { local: [{ reporter: tagReporter('S'), sink }] };
+  await assert.rejects(() => runRoutes(source(), config, { REPORTERS_OPEN: '0' }), /start boom/);
+  assert.strictEqual(closed, true);
+});
+
 test('runRoutes opens the sink viewer URL when the gate allows it', async (t) => {
   const { internals } = await import('../src/open.ts');
   const originalAnnounce = internals.announce;

--- a/packages/mux/tests/open.test.ts
+++ b/packages/mux/tests/open.test.ts
@@ -1,6 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { shouldOpen, openCommand } from '../src/open.ts';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { shouldOpen, openCommand, announce } from '../src/open.ts';
 
 test('shouldOpen: on locally, off in CI, route can opt out, env forces', () => {
   assert.strictEqual(shouldOpen(undefined, {}), true);
@@ -15,4 +18,34 @@ test('openCommand is platform-specific', () => {
   assert.deepStrictEqual(openCommand('u', 'darwin'), ['open', ['u']]);
   assert.deepStrictEqual(openCommand('u', 'linux'), ['xdg-open', ['u']]);
   assert.deepStrictEqual(openCommand('u', 'win32'), ['cmd', ['/c', 'start', '', 'u']]);
+});
+
+function captureStderr(fn: () => void): string {
+  const original = process.stderr.write.bind(process.stderr);
+  let captured = '';
+  process.stderr.write = ((chunk: string | Buffer) => { captured += String(chunk); return true; }) as typeof process.stderr.write;
+  try {
+    fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return captured;
+}
+
+test('announce prints a stderr hint with the viewer url', () => {
+  const out = captureStderr(() => announce('https://v.example/?src=x', {}));
+  assert.match(out, /@reporters\/mux: report at https:\/\/v\.example\/\?src=x/);
+});
+
+test('announce appends a View report link to the GitHub step summary', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'mux-announce-'));
+  const summary = join(dir, 'summary.md');
+  captureStderr(() => announce('https://v.example/?src=x', { GITHUB_STEP_SUMMARY: summary }));
+  assert.match(readFileSync(summary, 'utf8'), /\[View report\]\(https:\/\/v\.example\/\?src=x\)/);
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test('announce ignores an unwritable step summary (the stderr hint already landed)', () => {
+  const out = captureStderr(() => announce('https://v.example/?src=x', { GITHUB_STEP_SUMMARY: '/nonexistent-dir/summary.md' }));
+  assert.match(out, /report at/);
 });

--- a/packages/sink/README.md
+++ b/packages/sink/README.md
@@ -1,0 +1,93 @@
+# @reporters/sink
+
+Delivery sinks for [`@reporters/mux`](https://www.npmjs.com/package/@reporters/mux):
+upload a `node:test` run's NDJSON somewhere a browser can fetch it, so the hosted
+viewer at **https://molow.github.io/reporters/** can render CI runs — live-ish
+while the run streams (periodic re-upload), durable after.
+
+```js
+// mux.config.js
+import { gist, s3 } from '@reporters/sink';
+
+export default {
+  ci: [
+    { reporter: '@reporters/gh',  sink: 'stdout' },
+    { reporter: '@reporters/web', sink: gist() },
+    // or, in your own bucket:
+    // { reporter: '@reporters/web', sink: s3({ bucket: 'ci-reports' }) },
+  ],
+};
+```
+
+When a sink exposes a viewer URL, `@reporters/mux` prints it to stderr and — on
+GitHub Actions — adds a **View report** link to the job summary.
+
+## `gist(options?)`
+
+Creates a (secret, by default) gist and PATCHes it as the run grows. The viewer
+polls the gist's raw URL. **Only active on GitHub Actions** — anywhere else it
+prints one error to stderr and does nothing (pass `token` explicitly to use it
+elsewhere), so an eagerly-evaluated config never breaks a local run.
+
+> **Token:** the workflow's built-in `GITHUB_TOKEN` is an app installation
+> token and **cannot create gists**. Create a (classic) personal access token
+> with the `gist` scope, store it as a repository secret, and expose it to the
+> test step:
+>
+> ```yaml
+> - run: yarn test
+>   env:
+>     GH_TOKEN: ${{ secrets.GIST_TOKEN }}
+> ```
+>
+> Without a usable token the sink prints an error and skips; a failed gist
+> creation is also skipped, not fatal — delivery is best-effort and never
+> fails the run.
+
+- `token` — defaults to `GITHUB_TOKEN` / `GH_TOKEN`.
+- `public` (default `false`), `filename` (`run.ndjson`), `description`,
+  `viewerBase`, `flushMs` (2000).
+
+## `s3(options)`
+
+Uploads to S3 or any S3-compatible store and signs a presigned GET the viewer
+reads back. Requires the AWS SDK (an optional peer dependency):
+
+```bash
+npm i @aws-sdk/client-s3 @aws-sdk/s3-request-presigner
+```
+
+- `bucket` (required); `key` — defaults to
+  `reporters/${GITHUB_RUN_ID ?? randomUUID()}.ndjson`.
+- `region`, `endpoint` (R2 / MinIO / GCS), `credentials` — default to the SDK's
+  provider chain (env, OIDC, instance role).
+- `expiresIn` — presigned GET expiry in seconds (default 7 days).
+- `viewerBase`, `flushMs` (2000).
+
+The hosted viewer fetches the presigned GET **cross-origin**, so the bucket
+needs a CORS rule for it:
+
+```json
+[{
+  "AllowedOrigins": ["https://molow.github.io"],
+  "AllowedMethods": ["GET", "HEAD"],
+  "AllowedHeaders": ["Range"],
+  "ExposeHeaders": ["Content-Range", "Accept-Ranges", "Content-Length"]
+}]
+```
+
+## `remoteSink(options)`
+
+The engine both are built on — bring your own transport:
+
+```ts
+remoteSink({
+  start?: () => Promise<void>,           // one-time setup
+  upload: (body: Buffer) => Promise<void>, // re-upload the full growing buffer
+  viewerUrl: () => string | undefined,   // where a human views the run
+  flushMs?: number,                       // re-upload cadence (default 2000)
+})
+```
+
+Uploads are coalesced (never overlapping, only when the buffer changed) and a
+final upload runs on close, so the last bytes always land.

--- a/packages/sink/package.json
+++ b/packages/sink/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "@reporters/sink",
+  "version": "0.0.0",
+  "description": "Delivery sinks for `@reporters/mux`: upload a run's NDJSON to a GitHub gist or S3 for the hosted viewer",
+  "type": "module",
+  "keywords": [
+    "node:test",
+    "test",
+    "reporter",
+    "reporters",
+    "sink",
+    "gist",
+    "s3"
+  ],
+  "files": [
+    "./dist"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "rm -rf dist && tsup",
+    "prepack": "rm -rf dist && tsup",
+    "pretest": "rm -rf dist && tsup",
+    "test": "node --test-reporter=@reporters/mux --test"
+  },
+  "peerDependencies": {
+    "@aws-sdk/client-s3": "^3.0.0",
+    "@aws-sdk/s3-request-presigner": "^3.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@aws-sdk/client-s3": {
+      "optional": true
+    },
+    "@aws-sdk/s3-request-presigner": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@aws-sdk/client-s3": "^3.700.0",
+    "@aws-sdk/s3-request-presigner": "^3.700.0",
+    "@reporters/mux": "workspace:^",
+    "tsup": "^8.5.0",
+    "typescript": "^5.7.0"
+  },
+  "bugs": {
+    "url": "https://github.com/MoLow/reporters/issues"
+  },
+  "homepage": "https://github.com/MoLow/reporters/tree/main/packages/sink",
+  "repository": "https://github.com/MoLow/reporters.git",
+  "author": "Moshe Atlow",
+  "license": "MIT"
+}

--- a/packages/sink/src/gist.ts
+++ b/packages/sink/src/gist.ts
@@ -1,0 +1,95 @@
+import type { Sink } from '@reporters/mux';
+import { remoteSink } from './remote.ts';
+
+const API = 'https://api.github.com';
+const DEFAULT_VIEWER = 'https://molow.github.io/reporters/';
+
+export interface GistOptions {
+  /** Defaults to `GITHUB_TOKEN` / `GH_TOKEN`; passing one explicitly also
+   *  enables the sink outside GitHub Actions. */
+  token?: string;
+  /** Create a public gist (default: secret). */
+  public?: boolean;
+  filename?: string;
+  description?: string;
+  viewerBase?: string;
+  flushMs?: number;
+  /** Injectable for tests. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Uploads the run's NDJSON to a GitHub gist. Needs a gist-scoped PAT (the
+ * Actions-installed GITHUB_TOKEN cannot create gists). Delivery is best-effort
+ * and only active on GitHub Actions — outside Actions (unless a token is
+ * passed explicitly), without a token, or when creation fails, it prints one
+ * stderr error and does nothing else: configs are evaluated eagerly for every
+ * profile, so this must never break a run. The viewer polls the sha-less raw
+ * URL, which always serves the latest revision.
+ */
+export function gist(opts: GistOptions = {}): Sink {
+  const filename = opts.filename ?? 'run.ndjson';
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  let disabled = false;
+  let token: string | undefined;
+  let id: string | undefined;
+  let rawUrl: string | undefined;
+
+  async function request(method: string, path: string, body: unknown): Promise<{ id: string; owner: { login: string } }> {
+    const res = await fetchImpl(`${API}${path}`, {
+      method,
+      headers: {
+        authorization: `Bearer ${token}`,
+        accept: 'application/vnd.github+json',
+        'content-type': 'application/json',
+        'user-agent': '@reporters/sink',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) throw new Error(`gist ${method} ${path} failed with ${res.status}`);
+    return res.json() as Promise<{ id: string; owner: { login: string } }>;
+  }
+
+  return remoteSink({
+    flushMs: opts.flushMs,
+    async start() {
+      if (!opts.token && process.env.GITHUB_ACTIONS !== 'true') {
+        disabled = true;
+        process.stderr.write('\n@reporters/sink: the gist sink only works on GitHub Actions (pass a token to use it elsewhere) — skipping\n');
+        return;
+      }
+      token = opts.token ?? process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+      if (!token) {
+        disabled = true;
+        process.stderr.write('\n@reporters/sink: gist sink needs a GitHub token (GITHUB_TOKEN / GH_TOKEN or the token option) — skipping\n');
+        return;
+      }
+      try {
+        const created = await request('POST', '/gists', {
+          public: opts.public ?? false,
+          description: opts.description ?? 'node:test run — @reporters/web',
+          // The API 422s on empty AND whitespace-only file content; seed with a
+          // benign JSON line the viewer ignores (replaced by the first upload).
+          files: { [filename]: { content: '{}\n' } },
+        });
+        id = created.id;
+        // The response's raw_url is pinned to a commit sha; the sha-less form
+        // always serves the latest revision, which is what the viewer polls.
+        rawUrl = `https://gist.githubusercontent.com/${created.owner.login}/${created.id}/raw/${filename}`;
+      } catch (err) {
+        // Delivering the report is best-effort — a failed creation (e.g. a
+        // token without the gist scope) must not fail the test run.
+        disabled = true;
+        process.stderr.write(`\n@reporters/sink: creating the gist failed (${(err as Error).message}) — skipping\n`);
+      }
+    },
+    async upload(body) {
+      if (disabled) return;
+      await request('PATCH', `/gists/${id}`, { files: { [filename]: { content: body.toString('utf8') } } });
+    },
+    viewerUrl() {
+      if (!rawUrl) return undefined;
+      return `${opts.viewerBase ?? DEFAULT_VIEWER}?src=${encodeURIComponent(rawUrl)}`;
+    },
+  });
+}

--- a/packages/sink/src/index.ts
+++ b/packages/sink/src/index.ts
@@ -1,2 +1,3 @@
 export { remoteSink, type RemoteSinkOptions } from './remote.ts';
 export { gist, type GistOptions } from './gist.ts';
+export { s3, type S3Options, type Sdk } from './s3.ts';

--- a/packages/sink/src/index.ts
+++ b/packages/sink/src/index.ts
@@ -1,1 +1,2 @@
 export { remoteSink, type RemoteSinkOptions } from './remote.ts';
+export { gist, type GistOptions } from './gist.ts';

--- a/packages/sink/src/index.ts
+++ b/packages/sink/src/index.ts
@@ -1,0 +1,1 @@
+export { remoteSink, type RemoteSinkOptions } from './remote.ts';

--- a/packages/sink/src/remote.ts
+++ b/packages/sink/src/remote.ts
@@ -1,0 +1,62 @@
+import type { Sink } from '@reporters/mux';
+
+export interface RemoteSinkOptions {
+  /** One-time setup before any upload (create the gist / sign the GET url). */
+  start?: () => Promise<void>;
+  /** Re-upload the full growing buffer. Called on a timer and once at the end. */
+  upload: (body: Buffer) => Promise<void>;
+  /** The hosted-viewer URL, already `?src=<encoded>`; valid after `start`. */
+  viewerUrl: () => string | undefined;
+  /** Periodic re-upload cadence in ms (default 2000). */
+  flushMs?: number;
+}
+
+/**
+ * The engine the delivery sinks build on: buffers writes in memory and
+ * re-uploads the whole buffer live-ish — on a timer while the run streams, and
+ * once more on close so the last bytes always land. Uploads are coalesced:
+ * never more than one in flight, and only when the buffer changed.
+ */
+export function remoteSink(opts: RemoteSinkOptions): Sink {
+  let buffer = Buffer.alloc(0);
+  let dirty = false;
+  let inflight: Promise<void> | undefined;
+  let timer: NodeJS.Timeout | undefined;
+
+  async function uploadNow(): Promise<void> {
+    if (!dirty || inflight) return;
+    dirty = false;
+    inflight = opts.upload(buffer);
+    try {
+      await inflight;
+    } catch (err) {
+      dirty = true;
+      throw err;
+    } finally {
+      inflight = undefined;
+    }
+  }
+
+  return {
+    async start() {
+      await opts.start?.();
+      timer = setInterval(() => { uploadNow().catch(() => { /* retried next tick / on close */ }); }, opts.flushMs ?? 2000);
+      timer.unref?.();
+    },
+    write(chunk) {
+      buffer = Buffer.concat([buffer, Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)]);
+      dirty = true;
+    },
+    async flush() {
+      await uploadNow();
+    },
+    async close() {
+      if (timer) clearInterval(timer);
+      if (inflight) await inflight.catch(() => { /* the final upload below retries */ });
+      await uploadNow();
+    },
+    viewerUrl() {
+      return opts.viewerUrl();
+    },
+  };
+}

--- a/packages/sink/src/s3.ts
+++ b/packages/sink/src/s3.ts
@@ -1,0 +1,89 @@
+import { randomUUID } from 'node:crypto';
+import type { Sink } from '@reporters/mux';
+import { remoteSink } from './remote.ts';
+
+const DEFAULT_VIEWER = 'https://molow.github.io/reporters/';
+const WEEK_SECONDS = 604800;
+
+export interface Sdk {
+  S3Client: new (config: Record<string, unknown>) => { send(command: unknown): Promise<unknown> };
+  PutObjectCommand: new (input: Record<string, unknown>) => unknown;
+  GetObjectCommand: new (input: Record<string, unknown>) => unknown;
+  getSignedUrl: (client: unknown, command: unknown, options: { expiresIn: number }) => Promise<string>;
+}
+
+async function loadSdk(): Promise<Sdk> {
+  try {
+    const [client, presigner] = await Promise.all([
+      import('@aws-sdk/client-s3'),
+      import('@aws-sdk/s3-request-presigner'),
+    ]);
+    return {
+      S3Client: client.S3Client,
+      PutObjectCommand: client.PutObjectCommand,
+      GetObjectCommand: client.GetObjectCommand,
+      getSignedUrl: presigner.getSignedUrl,
+    } as unknown as Sdk;
+  /* c8 ignore start -- only reachable when the optional peer isn't installed */
+  } catch {
+    throw new Error('@reporters/sink: install @aws-sdk/client-s3 and @aws-sdk/s3-request-presigner to use the s3 sink');
+  }
+  /* c8 ignore stop */
+}
+
+/** Indirection so tests inject a fake SDK without network or the real client. */
+export const internals = { loadSdk };
+
+export interface S3Options {
+  bucket: string;
+  /** Object key; defaults to `reporters/${GITHUB_RUN_ID ?? randomUUID()}.ndjson`. */
+  key?: string;
+  region?: string;
+  /** S3-compatible stores (R2 / MinIO / GCS). */
+  endpoint?: string;
+  /** Defaults to the AWS SDK's default provider chain (env, OIDC, instance role). */
+  credentials?: { accessKeyId: string; secretAccessKey: string; sessionToken?: string };
+  /** Presigned GET expiry in seconds (default 7 days). */
+  expiresIn?: number;
+  viewerBase?: string;
+  flushMs?: number;
+}
+
+/**
+ * Uploads the run's NDJSON to an S3(-compatible) bucket via the AWS SDK and
+ * signs a presigned GET the hosted viewer reads it back through.
+ */
+export function s3(opts: S3Options): Sink {
+  const key = opts.key ?? `reporters/${process.env.GITHUB_RUN_ID ?? randomUUID()}.ndjson`;
+  let getUrl: string | undefined;
+  let putObject: ((body: Buffer) => Promise<void>) | undefined;
+
+  return remoteSink({
+    flushMs: opts.flushMs,
+    async start() {
+      const sdk = await internals.loadSdk();
+      const client = new sdk.S3Client({
+        ...(opts.region ? { region: opts.region } : {}),
+        ...(opts.endpoint ? { endpoint: opts.endpoint } : {}),
+        ...(opts.credentials ? { credentials: opts.credentials } : {}),
+      });
+      putObject = async (body) => {
+        await client.send(new sdk.PutObjectCommand({
+          Bucket: opts.bucket, Key: key, Body: body, ContentType: 'application/x-ndjson',
+        }));
+      };
+      getUrl = await sdk.getSignedUrl(
+        client,
+        new sdk.GetObjectCommand({ Bucket: opts.bucket, Key: key }),
+        { expiresIn: opts.expiresIn ?? WEEK_SECONDS },
+      );
+    },
+    async upload(body) {
+      await putObject!(body);
+    },
+    viewerUrl() {
+      if (!getUrl) return undefined;
+      return `${opts.viewerBase ?? DEFAULT_VIEWER}?src=${encodeURIComponent(getUrl)}`;
+    },
+  });
+}

--- a/packages/sink/tests/gist.test.ts
+++ b/packages/sink/tests/gist.test.ts
@@ -1,0 +1,137 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { gist } from '../src/gist.ts';
+
+interface Recorded { method: string; url: string; headers: Record<string, string>; body: any }
+
+function fakeGithub() {
+  const requests: Recorded[] = [];
+  const fetchImpl = (async (url: unknown, init: any) => {
+    requests.push({
+      method: init.method, url: String(url), headers: init.headers, body: JSON.parse(init.body),
+    });
+    return {
+      ok: true,
+      status: init.method === 'POST' ? 201 : 200,
+      json: async () => ({ id: 'abc123', owner: { login: 'molow' } }),
+    };
+  }) as unknown as typeof fetch;
+  return { requests, fetchImpl };
+}
+
+/** Pin the gate-relevant env vars for one test; restores afterwards. */
+function withEnv(t: { after: (fn: () => void) => void }, vars: Record<string, string | undefined>) {
+  const saved = Object.keys(vars).map((key) => [key, process.env[key]] as const);
+  for (const [key, value] of Object.entries(vars)) {
+    if (value === undefined) delete process.env[key]; else process.env[key] = value;
+  }
+  t.after(() => {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key]; else process.env[key] = value;
+    }
+  });
+}
+
+async function captureStderr(fn: () => Promise<unknown> | unknown): Promise<string> {
+  const original = process.stderr.write.bind(process.stderr);
+  let captured = '';
+  process.stderr.write = ((chunk: string | Buffer) => { captured += String(chunk); return true; }) as typeof process.stderr.write;
+  try {
+    await fn();
+  } finally {
+    process.stderr.write = original;
+  }
+  return captured;
+}
+
+test('an explicit token enables the sink anywhere: creates a secret gist, sha-less raw viewer url', async (t) => {
+  withEnv(t, { GITHUB_ACTIONS: undefined });
+  const { requests, fetchImpl } = fakeGithub();
+  const sink = gist({ token: 't0k', fetchImpl });
+  await sink.start!();
+  const create = requests[0];
+  assert.strictEqual(create.method, 'POST');
+  assert.strictEqual(create.url, 'https://api.github.com/gists');
+  assert.strictEqual(create.headers.authorization, 'Bearer t0k');
+  assert.ok(create.headers['user-agent'], 'GitHub requires a user-agent');
+  assert.strictEqual(create.body.public, false);
+  assert.match(create.body.files['run.ndjson'].content, /\S/, 'the API 422s on empty or whitespace-only content');
+  assert.doesNotThrow(() => JSON.parse(create.body.files['run.ndjson'].content), 'the seed must be a line the viewer can ignore');
+  assert.strictEqual(
+    sink.viewerUrl!(),
+    `https://molow.github.io/reporters/?src=${encodeURIComponent('https://gist.githubusercontent.com/molow/abc123/raw/run.ndjson')}`,
+  );
+  await sink.close();
+});
+
+test('flush PATCHes the accumulated ndjson into the gist file', async () => {
+  const { requests, fetchImpl } = fakeGithub();
+  const sink = gist({ token: 't0k', fetchImpl, filename: 'r.ndjson' });
+  await sink.start!();
+  sink.write('{"type":"test:pass"}\n');
+  await sink.flush!();
+  const patch = requests.find((r) => r.method === 'PATCH')!;
+  assert.strictEqual(patch.url, 'https://api.github.com/gists/abc123');
+  assert.strictEqual(patch.body.files['r.ndjson'].content, '{"type":"test:pass"}\n');
+  await sink.close();
+});
+
+test('outside GitHub Actions (no explicit token) it errors to stderr and no-ops', async (t) => {
+  withEnv(t, { GITHUB_ACTIONS: undefined, GITHUB_TOKEN: undefined, GH_TOKEN: undefined });
+  const { requests, fetchImpl } = fakeGithub();
+  const sink = gist({ fetchImpl });
+  const err = await captureStderr(() => sink.start!());
+  assert.match(err, /only works on GitHub Actions/);
+  sink.write('{"a":1}\n');
+  await sink.flush!();
+  await sink.close();
+  assert.strictEqual(requests.length, 0, 'zero API calls when disabled');
+  assert.strictEqual(sink.viewerUrl!(), undefined);
+});
+
+test('on GitHub Actions the env token is picked up', async (t) => {
+  withEnv(t, { GITHUB_ACTIONS: 'true', GITHUB_TOKEN: 'envtok', GH_TOKEN: undefined });
+  const { requests, fetchImpl } = fakeGithub();
+  const sink = gist({ fetchImpl });
+  await sink.start!();
+  assert.strictEqual(requests[0].headers.authorization, 'Bearer envtok');
+  await sink.close();
+});
+
+test('on GitHub Actions without any token it errors to stderr and no-ops', async (t) => {
+  withEnv(t, { GITHUB_ACTIONS: 'true', GITHUB_TOKEN: undefined, GH_TOKEN: undefined });
+  const { requests, fetchImpl } = fakeGithub();
+  const sink = gist({ fetchImpl });
+  const err = await captureStderr(() => sink.start!());
+  assert.match(err, /needs a GitHub token/);
+  await sink.flush!();
+  await sink.close();
+  assert.strictEqual(requests.length, 0);
+  assert.strictEqual(sink.viewerUrl!(), undefined);
+});
+
+test('a failed gist creation disables the sink instead of failing the run', async () => {
+  const fetchImpl = (async () => ({ ok: false, status: 403, json: async () => ({}) })) as unknown as typeof fetch;
+  const sink = gist({ token: 'installation-token', fetchImpl });
+  const err = await captureStderr(() => sink.start!());
+  assert.match(err, /creating the gist failed/);
+  assert.match(err, /403/);
+  sink.write('{"a":1}\n');
+  await sink.flush!();
+  await sink.close();
+  assert.strictEqual(sink.viewerUrl!(), undefined);
+});
+
+test('GH_TOKEN is used when GITHUB_TOKEN is absent', async (t) => {
+  withEnv(t, { GITHUB_ACTIONS: 'true', GITHUB_TOKEN: undefined, GH_TOKEN: 'ghtok' });
+  const { requests, fetchImpl } = fakeGithub();
+  const sink = gist({ fetchImpl });
+  await sink.start!();
+  assert.strictEqual(requests[0].headers.authorization, 'Bearer ghtok');
+  await sink.close();
+});
+
+test('viewerUrl is undefined before start', () => {
+  const sink = gist({ token: 't0k' });
+  assert.strictEqual(sink.viewerUrl!(), undefined);
+});

--- a/packages/sink/tests/remote.test.ts
+++ b/packages/sink/tests/remote.test.ts
@@ -1,0 +1,104 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { remoteSink } from '../src/remote.ts';
+
+const tick = (ms: number) => new Promise((resolve) => { setTimeout(resolve, ms); });
+
+test('flush uploads the accumulated buffer and viewerUrl passes through', async () => {
+  const uploads: string[] = [];
+  const sink = remoteSink({
+    upload: async (body) => { uploads.push(body.toString()); },
+    viewerUrl: () => 'https://viewer.example/?src=x',
+  });
+  sink.write('a');
+  sink.write(Buffer.from('b'));
+  await sink.flush!();
+  assert.deepStrictEqual(uploads, ['ab']);
+  assert.strictEqual(sink.viewerUrl!(), 'https://viewer.example/?src=x');
+  await sink.close();
+});
+
+test('flush skips when nothing changed since the last upload', async () => {
+  const uploads: string[] = [];
+  const sink = remoteSink({
+    upload: async (body) => { uploads.push(body.toString()); },
+    viewerUrl: () => undefined,
+  });
+  sink.write('x');
+  await sink.flush!();
+  await sink.flush!();
+  assert.deepStrictEqual(uploads, ['x']);
+  await sink.close();
+});
+
+test('start runs setup, then the timer re-uploads as the buffer grows', async () => {
+  const uploads: string[] = [];
+  let started = false;
+  const sink = remoteSink({
+    start: async () => { started = true; },
+    upload: async (body) => { uploads.push(body.toString()); },
+    viewerUrl: () => undefined,
+    flushMs: 20,
+  });
+  await sink.start!();
+  assert.strictEqual(started, true);
+  sink.write('live');
+  await tick(60);
+  assert.ok(uploads.includes('live'), `timer uploaded; got ${JSON.stringify(uploads)}`);
+  await sink.close();
+});
+
+test('close clears the timer and does a final upload of unflushed bytes', async () => {
+  const uploads: string[] = [];
+  const sink = remoteSink({
+    upload: async (body) => { uploads.push(body.toString()); },
+    viewerUrl: () => undefined,
+    flushMs: 60_000,
+  });
+  await sink.start!();
+  sink.write('tail');
+  await sink.close();
+  assert.deepStrictEqual(uploads, ['tail']);
+});
+
+test('uploads never overlap; the final upload carries everything', async () => {
+  let active = 0;
+  let maxActive = 0;
+  const uploads: string[] = [];
+  const sink = remoteSink({
+    upload: async (body) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await tick(40);
+      uploads.push(body.toString());
+      active -= 1;
+    },
+    viewerUrl: () => undefined,
+    flushMs: 10,
+  });
+  await sink.start!();
+  sink.write('one');
+  await tick(25);
+  sink.write('two');
+  await sink.close();
+  assert.strictEqual(maxActive, 1, 'no concurrent uploads');
+  assert.strictEqual(uploads[uploads.length - 1], 'onetwo');
+});
+
+test('a failed upload re-marks the buffer dirty so the next flush retries', async () => {
+  const uploads: string[] = [];
+  let fail = true;
+  const sink = remoteSink({
+    upload: async (body) => {
+      if (fail) throw new Error('net down');
+      uploads.push(body.toString());
+    },
+    viewerUrl: () => undefined,
+  });
+  sink.write('data');
+  await assert.rejects(() => sink.flush!(), /net down/);
+  fail = false;
+  await sink.flush!();
+  assert.deepStrictEqual(uploads, ['data']);
+  await sink.close();
+});

--- a/packages/sink/tests/s3.test.ts
+++ b/packages/sink/tests/s3.test.ts
@@ -1,0 +1,112 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { s3, internals, type Sdk } from '../src/s3.ts';
+
+function fakeSdk() {
+  const sent: { input: Record<string, unknown> }[] = [];
+  const configs: Record<string, unknown>[] = [];
+  class S3Client {
+    config: unknown;
+
+    constructor(config: Record<string, unknown>) { this.config = config; configs.push(config); }
+
+    async send(command: { input: Record<string, unknown> }) { sent.push(command); }
+  }
+  class PutObjectCommand {
+    input: Record<string, unknown>;
+
+    constructor(input: Record<string, unknown>) { this.input = input; }
+  }
+  class GetObjectCommand {
+    input: Record<string, unknown>;
+
+    constructor(input: Record<string, unknown>) { this.input = input; }
+  }
+  const getSignedUrl = async (_client: unknown, command: { input: Record<string, unknown> }, options: { expiresIn: number }) => (
+    `https://bucket.s3.example/${command.input.Key}?sig=abc&expires=${options.expiresIn}`
+  );
+  return { sent, configs, sdk: { S3Client, PutObjectCommand, GetObjectCommand, getSignedUrl } as unknown as Sdk };
+}
+
+function withFakeSdk(t: { after: (fn: () => void) => void }) {
+  const fake = fakeSdk();
+  const original = internals.loadSdk;
+  internals.loadSdk = async () => fake.sdk;
+  t.after(() => { internals.loadSdk = original; });
+  return fake;
+}
+
+test('start signs a GET url; flush uploads the buffer via PutObject', async (t) => {
+  const { sent } = withFakeSdk(t);
+  const sink = s3({ bucket: 'ci-reports', key: 'runs/1.ndjson' });
+  assert.strictEqual(sink.viewerUrl!(), undefined);
+  await sink.start!();
+  assert.strictEqual(
+    sink.viewerUrl!(),
+    `https://molow.github.io/reporters/?src=${encodeURIComponent('https://bucket.s3.example/runs/1.ndjson?sig=abc&expires=604800')}`,
+  );
+  sink.write('{"a":1}\n');
+  await sink.flush!();
+  const put = sent.find((c) => c.input.Body)!;
+  assert.strictEqual(put.input.Bucket, 'ci-reports');
+  assert.strictEqual(put.input.Key, 'runs/1.ndjson');
+  assert.strictEqual(put.input.ContentType, 'application/x-ndjson');
+  assert.strictEqual(String(put.input.Body), '{"a":1}\n');
+  await sink.close();
+});
+
+test('the key defaults to the GitHub run id when present', async (t) => {
+  withFakeSdk(t);
+  const saved = process.env.GITHUB_RUN_ID;
+  process.env.GITHUB_RUN_ID = '9876';
+  t.after(() => {
+    if (saved === undefined) delete process.env.GITHUB_RUN_ID; else process.env.GITHUB_RUN_ID = saved;
+  });
+  const sink = s3({ bucket: 'b' });
+  await sink.start!();
+  assert.match(sink.viewerUrl!()!, /reporters%2F9876\.ndjson/);
+  await sink.close();
+});
+
+test('the key falls back to a uuid without a run id', async (t) => {
+  withFakeSdk(t);
+  const saved = process.env.GITHUB_RUN_ID;
+  delete process.env.GITHUB_RUN_ID;
+  t.after(() => { if (saved !== undefined) process.env.GITHUB_RUN_ID = saved; });
+  const sink = s3({ bucket: 'b' });
+  await sink.start!();
+  assert.match(decodeURIComponent(sink.viewerUrl!()!), /reporters\/[0-9a-f]{8}-[0-9a-f-]{27}\.ndjson/);
+  await sink.close();
+});
+
+test('expiresIn and viewerBase are honored', async (t) => {
+  withFakeSdk(t);
+  const sink = s3({
+    bucket: 'b', key: 'k.ndjson', expiresIn: 60, viewerBase: 'https://viewer.example/',
+  });
+  await sink.start!();
+  assert.strictEqual(
+    sink.viewerUrl!(),
+    `https://viewer.example/?src=${encodeURIComponent('https://bucket.s3.example/k.ndjson?sig=abc&expires=60')}`,
+  );
+  await sink.close();
+});
+
+test('the default loadSdk resolves the real AWS SDK (installed as a dev dependency)', async () => {
+  const sdk = await internals.loadSdk();
+  assert.strictEqual(typeof sdk.S3Client, 'function');
+  assert.strictEqual(typeof sdk.PutObjectCommand, 'function');
+  assert.strictEqual(typeof sdk.GetObjectCommand, 'function');
+  assert.strictEqual(typeof sdk.getSignedUrl, 'function');
+});
+
+test('region, endpoint and credentials are passed through to the client', async (t) => {
+  const { configs } = withFakeSdk(t);
+  const credentials = { accessKeyId: 'ak', secretAccessKey: 'sk' };
+  const sink = s3({
+    bucket: 'b', key: 'k.ndjson', region: 'eu-west-1', endpoint: 'https://minio.example', credentials,
+  });
+  await sink.start!();
+  assert.deepStrictEqual(configs[0], { region: 'eu-west-1', endpoint: 'https://minio.example', credentials });
+  await sink.close();
+});

--- a/packages/sink/tsconfig.json
+++ b/packages/sink/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["node"],
+    "paths": {
+      "@reporters/mux": ["../mux/src/index.ts"],
+      "@reporters/tree-core": ["../tree-core/src/index.ts"]
+    }
+  },
+  "include": ["src"]
+}

--- a/packages/sink/tsup.config.ts
+++ b/packages/sink/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: { index: 'src/index.ts' },
+  format: ['esm'],
+  platform: 'node',
+  target: 'node20',
+  dts: true,
+  clean: true,
+  external: [/^@aws-sdk\//],
+});

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,6 +25,7 @@
     "packages/mocha": {},
     "packages/live": {},
     "packages/web": {},
-    "packages/mux": {}
+    "packages/mux": {},
+    "packages/sink": {}
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,6 +51,275 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@aws-sdk/checksums@npm:^3.1000.11":
+  version: 3.1000.11
+  resolution: "@aws-sdk/checksums@npm:3.1000.11"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/ec087be084ad96be3e422abf8ee29f786882949141ebc23dc6073d3433f57ff5db64597836f57878139cee9543c4b00719139c1e72d3a6abede07a415cd392d2
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/client-s3@npm:^3.700.0":
+  version: 3.1078.0
+  resolution: "@aws-sdk/client-s3@npm:3.1078.0"
+  dependencies:
+    "@aws-sdk/checksums": "npm:^3.1000.11"
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/credential-provider-node": "npm:^3.972.61"
+    "@aws-sdk/middleware-sdk-s3": "npm:^3.972.57"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.38"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/fetch-http-handler": "npm:^5.6.2"
+    "@smithy/node-http-handler": "npm:^4.9.2"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/e81de5e5a61fa41d9b8f51454ee3a329044b9efaf2d002384492dc5a3e8260cd8e996feb7e7b88cbec1fe0f735bc81e9c87e6f015a69aa899f2c871613478cac
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/core@npm:^3.974.26":
+  version: 3.974.26
+  resolution: "@aws-sdk/core@npm:3.974.26"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@aws-sdk/xml-builder": "npm:^3.972.33"
+    "@aws/lambda-invoke-store": "npm:^0.2.2"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/signature-v4": "npm:^5.6.1"
+    "@smithy/types": "npm:^4.15.1"
+    bowser: "npm:^2.11.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3e2f10c874b87cac48ccba38b4ec4bb7e2d1869f21a526044f4d32ed793eaab7dd4ed49f7ad02eb8a37a9042e2df24b08f8b6af645207522920416a10df62a2a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-env@npm:^3.972.52":
+  version: 3.972.52
+  resolution: "@aws-sdk/credential-provider-env@npm:3.972.52"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/1626bd328408a7c511386715f3a7071243787605a6f846a1299d8bc72db7cd70181bd4623d38035b3e84986c88e2ceef0f870e511725d4effea33f3050d8fa64
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-http@npm:^3.972.54":
+  version: 3.972.54
+  resolution: "@aws-sdk/credential-provider-http@npm:3.972.54"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/fetch-http-handler": "npm:^5.6.2"
+    "@smithy/node-http-handler": "npm:^4.9.2"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/600fbf04df77194b9fccffb61245b3f9f29218a61ebc5b0745d6cc01322697739cf298eafd91760a28780c11b6018347b566f8a045e602cd5a8f999e93dc37fa
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-ini@npm:^3.972.59":
+  version: 3.972.59
+  resolution: "@aws-sdk/credential-provider-ini@npm:3.972.59"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/credential-provider-env": "npm:^3.972.52"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.54"
+    "@aws-sdk/credential-provider-login": "npm:^3.972.58"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.52"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.58"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.58"
+    "@aws-sdk/nested-clients": "npm:^3.997.26"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/credential-provider-imds": "npm:^4.4.5"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/a3875f6b37942bfbac9dac1e57d7b9a5d642dfcbc8333014a66895377e47a21e2238709d97a9da0eb7bfdaf37307479a08ff30a0451a2ad7f984c8c89255e67e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-login@npm:^3.972.58":
+  version: 3.972.58
+  resolution: "@aws-sdk/credential-provider-login@npm:3.972.58"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/nested-clients": "npm:^3.997.26"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/9c3da8d17733920d765322d8fcea3d8b597989e35918662b6245482f65f33f900c7b549dece1da55171249b36664b3a7748b4d1d7512d243f22a0ac30ff566ba
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-node@npm:^3.972.61":
+  version: 3.972.61
+  resolution: "@aws-sdk/credential-provider-node@npm:3.972.61"
+  dependencies:
+    "@aws-sdk/credential-provider-env": "npm:^3.972.52"
+    "@aws-sdk/credential-provider-http": "npm:^3.972.54"
+    "@aws-sdk/credential-provider-ini": "npm:^3.972.59"
+    "@aws-sdk/credential-provider-process": "npm:^3.972.52"
+    "@aws-sdk/credential-provider-sso": "npm:^3.972.58"
+    "@aws-sdk/credential-provider-web-identity": "npm:^3.972.58"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/credential-provider-imds": "npm:^4.4.5"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/eb86129c9b1f3fc96b504fbcf9d9405f3f7ec24cb10a59dd1a28b5fa1ecef908e8e3aa9df0f1939950ccc9669dbf8664d30f091cf4c7b79423dab9188a1d5367
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-process@npm:^3.972.52":
+  version: 3.972.52
+  resolution: "@aws-sdk/credential-provider-process@npm:3.972.52"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/65b5772ec0e6ea1dd9be3819278aa10361abb3e79df4022316f60aff2ed2492db5b1ecc8ebc08727beede323b6b605b8a61e60b70a6c43b360370f09352b32b3
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-sso@npm:^3.972.58":
+  version: 3.972.58
+  resolution: "@aws-sdk/credential-provider-sso@npm:3.972.58"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/nested-clients": "npm:^3.997.26"
+    "@aws-sdk/token-providers": "npm:3.1078.0"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/d12aa015435d99e08d7959c46ea3624141178e833d135b52ead89691526b3103e6b0e578bf62be85bb6a57c9f6018e77c420f64236379604f20c91042b71967c
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/credential-provider-web-identity@npm:^3.972.58":
+  version: 3.972.58
+  resolution: "@aws-sdk/credential-provider-web-identity@npm:3.972.58"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/nested-clients": "npm:^3.997.26"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3c4e185fac1ff6cc81494c4f0b8c9344c99935499c2f53c63e69276ff039ca4d336b0afae83223acb48230adc5f322d8b5807be13981f1a651a89965c0e100fb
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/middleware-sdk-s3@npm:^3.972.57":
+  version: 3.972.57
+  resolution: "@aws-sdk/middleware-sdk-s3@npm:3.972.57"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.38"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4462e0235e71712058cb180348b339a6b8ed0a233e1bbf2b64fb750dffacd27c7665668b337563dcf5ce59dc962d3c4b5977c59722c42ec731e8d315fd7115e7
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/nested-clients@npm:^3.997.26":
+  version: 3.997.26
+  resolution: "@aws-sdk/nested-clients@npm:3.997.26"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.38"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/fetch-http-handler": "npm:^5.6.2"
+    "@smithy/node-http-handler": "npm:^4.9.2"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/38c23c3f98926e4491aae973df851d503ca16bbd97b613d84aedbb391e6835e0ddba22c60a1b96047a1a3dda3ecd2175500d701076b5bd7446bb9a44a3a9989a
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/s3-request-presigner@npm:^3.700.0":
+  version: 3.1078.0
+  resolution: "@aws-sdk/s3-request-presigner@npm:3.1078.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/signature-v4-multi-region": "npm:^3.996.38"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/72918d1518e0897fb9980aba1c8da9486e0107bd3a85415f88ce609150ada4120b56b70db2833ce66bf2e8879d2c429b8498390db4093776b7ab108f2bf244ea
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/signature-v4-multi-region@npm:^3.996.38":
+  version: 3.996.38
+  resolution: "@aws-sdk/signature-v4-multi-region@npm:3.996.38"
+  dependencies:
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/signature-v4": "npm:^5.6.1"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3cd2a7f751e02becc7230de6a549d85b785cb5ffecf5c3c4cc2c498a2dbd7e08969d149a5b669ba36af618c97a353c30b9b3441666682d8fb19b54589aea4396
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/token-providers@npm:3.1078.0":
+  version: 3.1078.0
+  resolution: "@aws-sdk/token-providers@npm:3.1078.0"
+  dependencies:
+    "@aws-sdk/core": "npm:^3.974.26"
+    "@aws-sdk/nested-clients": "npm:^3.997.26"
+    "@aws-sdk/types": "npm:^3.973.15"
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/90ab6dd1460e0c0083305146d830d76faead11ab170a9d8d274c0157a323b45e0a45959b8f22cf6bf3ca0230eb3f731e0eab13fba755b20377495adee28fff38
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/types@npm:^3.973.15":
+  version: 3.973.15
+  resolution: "@aws-sdk/types@npm:3.973.15"
+  dependencies:
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3e20ce06e83e6749c379cd822a2b00bca17ee0431d69ec96b5b086c65e33c91ea484d02d10758eef79caa67af2e5623c2e454be6083d2609f20b9b447f661e5e
+  languageName: node
+  linkType: hard
+
+"@aws-sdk/xml-builder@npm:^3.972.33":
+  version: 3.972.33
+  resolution: "@aws-sdk/xml-builder@npm:3.972.33"
+  dependencies:
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/58d9b21b16cb81180e90f2af9f28fba070086d08e84473fd1cb0bb5afd502ec1e847436ddf73fc08934512e867389f246d31bd0d61d280e10937e0f775710989
+  languageName: node
+  linkType: hard
+
+"@aws/lambda-invoke-store@npm:^0.2.2":
+  version: 0.2.4
+  resolution: "@aws/lambda-invoke-store@npm:0.2.4"
+  checksum: 10c0/29d874d7c1a2d971e0c02980594204f89cda718f215f2fc52b6c56eacbdad1fa5f6ce1b358e5811f5cd35d04c76299a67a8aff95318446af2bdfb4910f213e13
+  languageName: node
+  linkType: hard
+
 "@bcoe/v8-coverage@npm:^1.0.1":
   version: 1.0.2
   resolution: "@bcoe/v8-coverage@npm:1.0.2"
@@ -508,6 +777,26 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@reporters/sink@workspace:packages/sink":
+  version: 0.0.0-use.local
+  resolution: "@reporters/sink@workspace:packages/sink"
+  dependencies:
+    "@aws-sdk/client-s3": "npm:^3.700.0"
+    "@aws-sdk/s3-request-presigner": "npm:^3.700.0"
+    "@reporters/mux": "workspace:^"
+    tsup: "npm:^8.5.0"
+    typescript: "npm:^5.7.0"
+  peerDependencies:
+    "@aws-sdk/client-s3": ^3.0.0
+    "@aws-sdk/s3-request-presigner": ^3.0.0
+  peerDependenciesMeta:
+    "@aws-sdk/client-s3":
+      optional: true
+    "@aws-sdk/s3-request-presigner":
+      optional: true
+  languageName: unknown
+  linkType: soft
+
 "@reporters/slow@workspace:packages/slow":
   version: 0.0.0-use.local
   resolution: "@reporters/slow@workspace:packages/slow"
@@ -736,6 +1025,69 @@ __metadata:
   version: 0.34.49
   resolution: "@sinclair/typebox@npm:0.34.49"
   checksum: 10c0/16b7d87f039a49b68c10bb4cdcae2ce5242b2472228851fd6483731616aba4ef977690aa517b230a8d20da8185bb416eb34e326f30568b3963c1cf26b05d1ad8
+  languageName: node
+  linkType: hard
+
+"@smithy/core@npm:^3.29.0":
+  version: 3.29.0
+  resolution: "@smithy/core@npm:3.29.0"
+  dependencies:
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/4d1dfa9935bd7aecd53c70f8dcf340736cbd9e5893da65d4bf8ece038d62bdbc09ce9e8beef4bd35b808470d5408eaefd4cccba7dbffdb945526679846325081
+  languageName: node
+  linkType: hard
+
+"@smithy/credential-provider-imds@npm:^4.4.5":
+  version: 4.4.5
+  resolution: "@smithy/credential-provider-imds@npm:4.4.5"
+  dependencies:
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/c7847f74af51fd5bde047ffc30bfe32f04b8f54b2dc3631b28b009c593300ae7e9769c35acb11e1ee402941c4e3a31426aa5ba035deb21f850921739eb2d5030
+  languageName: node
+  linkType: hard
+
+"@smithy/fetch-http-handler@npm:^5.6.2":
+  version: 5.6.2
+  resolution: "@smithy/fetch-http-handler@npm:5.6.2"
+  dependencies:
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/adcc1bab05e2aad9d2e28adc359821dfdae1b76987cd0434b1003214b2e9453bbab666b989d9c070e184b1e2431ba1ba125af61fcdc92961f507b12170364d2d
+  languageName: node
+  linkType: hard
+
+"@smithy/node-http-handler@npm:^4.9.2":
+  version: 4.9.2
+  resolution: "@smithy/node-http-handler@npm:4.9.2"
+  dependencies:
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/b619c3f79a762538a6ebf34a84abb60ac77ccbdf577449daf7358b2bb04ce791ca90a1ceeffbfde66a87165cceeabe1c92cec11b1a1eecaef2f8277480cb63d0
+  languageName: node
+  linkType: hard
+
+"@smithy/signature-v4@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "@smithy/signature-v4@npm:5.6.1"
+  dependencies:
+    "@smithy/core": "npm:^3.29.0"
+    "@smithy/types": "npm:^4.15.1"
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/3442a4d98f339851daf7305f104b8a95cc0295e5bc3f6fe5462d29611764d6f485051f024803859821f36ce9c2ce75a405267ba8d0daabec04224372116ba6c8
+  languageName: node
+  linkType: hard
+
+"@smithy/types@npm:^4.15.1":
+  version: 4.15.1
+  resolution: "@smithy/types@npm:4.15.1"
+  dependencies:
+    tslib: "npm:^2.6.2"
+  checksum: 10c0/65cb70240fa13f37274796b065be48d86cccd182ec97e7b1a0da234e2c9bd5ee686b4f5f111c930fe2209a2a6f168b9a045d59fb80c5545f4bff885ba350afa2
   languageName: node
   linkType: hard
 
@@ -1043,6 +1395,13 @@ __metadata:
   version: 2.3.0
   resolution: "binary-extensions@npm:2.3.0"
   checksum: 10c0/75a59cafc10fb12a11d510e77110c6c7ae3f4ca22463d52487709ca7f18f69d886aa387557cc9864fbdb10153d0bdb4caacabf11541f55e89ed6e18d12ece2b5
+  languageName: node
+  linkType: hard
+
+"bowser@npm:^2.11.0":
+  version: 2.14.1
+  resolution: "bowser@npm:2.14.1"
+  checksum: 10c0/bb69b55ba7f0456e3dc07d0cfd9467f985581f640ba8fd426b08754a6737ee0d6cf3b50607941e5255f04c83075b952ece0599f978dd4d20f1e95461104c5ffd
   languageName: node
   linkType: hard
 
@@ -4297,6 +4656,13 @@ __metadata:
     minimist: "npm:^1.2.6"
     strip-bom: "npm:^3.0.0"
   checksum: 10c0/5b4f301a2b7a3766a986baf8fc0e177eb80bdba6e396792ff92dc23b5bca8bb279fc96517dcaaef63a3b49bebc6c4c833653ec58155780bc906bdbcf7dda0ef5
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.6.2":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -777,7 +777,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@reporters/sink@workspace:packages/sink":
+"@reporters/sink@workspace:^, @reporters/sink@workspace:packages/sink":
   version: 0.0.0-use.local
   resolution: "@reporters/sink@workspace:packages/sink"
   dependencies:
@@ -3985,6 +3985,7 @@ __metadata:
     "@reporters/gh": "workspace:^"
     "@reporters/live": "workspace:^"
     "@reporters/mux": "workspace:^"
+    "@reporters/sink": "workspace:^"
     "@reporters/web": "workspace:^"
     "@types/node": "npm:^22.10.0"
     "@types/react": "npm:^19.0.0"


### PR DESCRIPTION
## Summary

Adds **`@reporters/sink`** — delivery sinks that upload a run's NDJSON somewhere a browser can fetch it, so the hosted viewer (`https://molow.github.io/reporters/?src=<url>`) can render **CI runs**: live-ish while the run streams (coalesced periodic re-upload), durable after.

```js
// mux.config.js
import { gist, s3 } from '@reporters/sink';

export default {
  ci: [
    { reporter: '@reporters/gh',  sink: 'stdout' },
    { reporter: '@reporters/web', sink: gist() },
    // or: { reporter: '@reporters/web', sink: s3({ bucket: 'ci-reports' }) },
  ],
};
```

## What's included

**`@reporters/sink`** (new published package, zero runtime deps):
- **`remoteSink`** — the shared engine: in-memory buffer, coalesced periodic re-upload (default 2s, never overlapping, only when changed), final flush on close so the last bytes always land.
- **`gist()`** — creates a secret gist and PATCHes it as the run grows; the viewer polls the sha-less raw URL. **GitHub-Actions-only with soft-fail**: outside Actions, without a token, or when creation fails, it prints one stderr error and does nothing — delivery is best-effort and never fails the test run. ⚠️ Requires a **gist-scoped classic PAT** (the built-in `GITHUB_TOKEN` is an installation token and cannot create gists) — see the README.
- **`s3()`** — PutObject uploads via the AWS SDK (**optional peer dependency**, lazy-imported with a clear install hint) + a presigned GET for the viewer. Key defaults to `reporters/${GITHUB_RUN_ID ?? randomUUID()}.ndjson`; works with S3-compatible stores via `endpoint`. README documents the bucket CORS rule the cross-origin viewer needs.

**`@reporters/mux`:**
- `announce()` — every sink viewer URL is printed as a stderr hint, and on GitHub Actions a **“View report”** link is appended to the job summary (`GITHUB_STEP_SUMMARY`); independent of the browser open-gate.
- `fix`: a sink whose `start()` fails now still gets `close()`d (start moved inside the route's try/finally).

**Repo wiring:** release-please registration, READMEs, and this repo's own `mux.config.mjs` ci profile now routes `@reporters/web` → `gist()`. The workflow exposes `GH_TOKEN: ${{ secrets.GIST_TOKEN }}` — until that secret is created the sink soft-skips with a one-line notice, so CI is unaffected.

## Action needed to activate the CI report

Create a repository secret **`GIST_TOKEN`** containing a classic PAT with the `gist` scope. Once present, every CI run uploads its report and links it from the job summary.

## Design notes

- URL shortening was considered and rejected (links are surfaced as markdown; a presigned URL is a bearer token — don't hand it to third-party shorteners).
- Deferred: a true-live relay service; an embedded-HTML artifact sink.

## Testing

- sink: 19 tests (engine coalescing/retry/final-flush; gist gate/soft-fail/request shapes with an injected fetch; s3 via an injected SDK seam + a real-SDK load test). mux: 39 tests. All no-network.
- Full monorepo build/lint/immutable-install clean. Verified the AWS SDK stays external in the bundle (dynamic-import specifier preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
