### PR TITLE
fix(sink): never fail the run when uploading the report fails

### DIFF
--- a/packages/sink/src/gist.ts
+++ b/packages/sink/src/gist.ts
@@ -51,7 +51,9 @@ export function gist(opts: GistOptions = {}): Sink {
   }
 
   return remoteSink({
-    flushMs: opts.flushMs,
+    // Every upload is a gist revision (a git commit), so default to a gentler
+    // cadence than the engine's 2s — it also keeps secondary rate limits away.
+    flushMs: opts.flushMs ?? 10_000,
     async start() {
       if (!opts.token && process.env.GITHUB_ACTIONS !== 'true') {
         disabled = true;
@@ -85,7 +87,14 @@ export function gist(opts: GistOptions = {}): Sink {
     },
     async upload(body) {
       if (disabled) return;
-      await request('PATCH', `/gists/${id}`, { files: { [filename]: { content: body.toString('utf8') } } });
+      try {
+        await request('PATCH', `/gists/${id}`, { files: { [filename]: { content: body.toString('utf8') } } });
+      } catch (err) {
+        // Best-effort delivery: an upload failure (e.g. a secondary rate
+        // limit) must not fail the run — and retrying would make it worse.
+        disabled = true;
+        process.stderr.write(`\n@reporters/sink: uploading the report failed (${(err as Error).message}) — giving up\n`);
+      }
     },
     viewerUrl() {
       if (!rawUrl) return undefined;

--- a/packages/sink/src/s3.ts
+++ b/packages/sink/src/s3.ts
@@ -55,6 +55,7 @@ export interface S3Options {
  */
 export function s3(opts: S3Options): Sink {
   const key = opts.key ?? `reporters/${process.env.GITHUB_RUN_ID ?? randomUUID()}.ndjson`;
+  let disabled = false;
   let getUrl: string | undefined;
   let putObject: ((body: Buffer) => Promise<void>) | undefined;
 
@@ -79,7 +80,14 @@ export function s3(opts: S3Options): Sink {
       );
     },
     async upload(body) {
-      await putObject!(body);
+      if (disabled) return;
+      try {
+        await putObject!(body);
+      } catch (err) {
+        // Best-effort delivery: an upload failure must not fail the run.
+        disabled = true;
+        process.stderr.write(`\n@reporters/sink: uploading the report failed (${(err as Error).message}) — giving up\n`);
+      }
     },
     viewerUrl() {
       if (!getUrl) return undefined;

--- a/packages/sink/tests/gist.test.ts
+++ b/packages/sink/tests/gist.test.ts
@@ -135,3 +135,26 @@ test('viewerUrl is undefined before start', () => {
   const sink = gist({ token: 't0k' });
   assert.strictEqual(sink.viewerUrl!(), undefined);
 });
+
+test('a failed upload gives up quietly instead of failing the run', async () => {
+  const requests: { method: string }[] = [];
+  const fetchImpl = (async (_url: unknown, init: any) => {
+    requests.push({ method: init.method });
+    if (init.method === 'POST') {
+      return { ok: true, status: 201, json: async () => ({ id: 'g1', owner: { login: 'molow' } }) };
+    }
+    return { ok: false, status: 403, json: async () => ({}) };
+  }) as unknown as typeof fetch;
+  const sink = gist({ token: 't0k', fetchImpl });
+  await sink.start!();
+  sink.write('{"a":1}\n');
+  const err = await captureStderr(async () => {
+    await sink.flush!();
+    await sink.close();
+  });
+  assert.match(err, /uploading the report failed/);
+  assert.match(err, /403/);
+  sink.write('{"b":2}\n');
+  await sink.flush!();
+  assert.strictEqual(requests.filter((r) => r.method === 'PATCH').length, 1, 'gives up after the first failure');
+});

--- a/packages/sink/tests/s3.test.ts
+++ b/packages/sink/tests/s3.test.ts
@@ -110,3 +110,30 @@ test('region, endpoint and credentials are passed through to the client', async 
   assert.deepStrictEqual(configs[0], { region: 'eu-west-1', endpoint: 'https://minio.example', credentials });
   await sink.close();
 });
+
+test('a failed upload gives up quietly instead of failing the run', async (t) => {
+  const fake = fakeSdk();
+  let attempts = 0;
+  fake.sdk.S3Client.prototype.send = async () => { attempts += 1; throw new Error('AccessDenied'); };
+  const original = internals.loadSdk;
+  internals.loadSdk = async () => fake.sdk;
+  t.after(() => { internals.loadSdk = original; });
+
+  const sink = s3({ bucket: 'b', key: 'k.ndjson' });
+  await sink.start!();
+  sink.write('{"a":1}\n');
+  const originalWrite = process.stderr.write.bind(process.stderr);
+  let captured = '';
+  process.stderr.write = ((chunk: string | Buffer) => { captured += String(chunk); return true; }) as typeof process.stderr.write;
+  try {
+    await sink.flush!();
+    sink.write('{"b":2}\n');
+    await sink.flush!();
+    await sink.close();
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+  assert.match(captured, /uploading the report failed/);
+  assert.match(captured, /AccessDenied/);
+  assert.strictEqual(attempts, 1, 'gives up after the first failure');
+});


### PR DESCRIPTION
## Summary

PR #213's CI exposed a crash that exists on `main` since #211: a gist **PATCH** hit GitHub's secondary rate limit (403), the rejection escaped through `sink.close()` inside mux's `finally`, and the whole test run died with an unhandled `error` event. #211 made gist *creation* best-effort but left *upload* failures fatal.

## Fix

- **Both sinks' uploads are now best-effort**: on the first failure they print one stderr notice (`uploading the report failed (…) — giving up`) and disable — no retries (hammering a rate limit makes it worse), no thrown errors, run unaffected.
- **gist default flush cadence: 2s → 10s** — every upload is a gist *revision* (a git commit), so 2s was both noisy (dozens of revisions per run) and rate-limit-prone, especially with 3 matrix jobs sharing one token.

## Testing

New regression tests for both sinks (upload failure → stderr notice, no throw through flush/close, exactly one attempt). 22/22 sink tests, 100% coverage, lint clean.

Note: #213 (single root test run) is blocked on this — it should be rebased once this merges; it also reduces gist traffic 12× which further helps the rate limit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)