### PR TITLE
fix(web): stay a pure emitter under mux via symbol-declared default options

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "build": "yarn workspaces foreach --all --exclude reporters --topological-dev --parallel run build",
-    "test": "yarn build && REPORTERS_OPEN=0 c8 node --test-reporter=@reporters/mux --test 'packages/*/tests/*.test.js' 'packages/*/tests/*.test.ts'",
+    "test": "yarn build && c8 node --test-reporter=@reporters/mux --test 'packages/*/tests/*.test.{js,ts}'",
     "test:clean-snapshots": "rm -rf packages/**/.snapshots",
     "test:update-snapshots": "SNAP_UPDATE=1 yarn test",
     "lint": "eslint ."
@@ -32,7 +32,7 @@
     "@reporters/mux": "workspace:^",
     "@reporters/sink": "workspace:^",
     "@reporters/web": "workspace:^",
-    "@types/node": "^22.10.0",
+    "@types/node": "^26.1.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "c8": "^11.0.0",

--- a/packages/mux/README.md
+++ b/packages/mux/README.md
@@ -60,7 +60,12 @@ Transform-stream reporters (like `@reporters/gh`) are supported as route reporte
   `@reporters/web` accepts `{ open: boolean }`); most reporters need none.
 - `sink` — `'stdout'`, `'stderr'`, a file path, or a `Sink` object.
 - `open` — open the sink's viewer URL in a browser. Defaults to on locally, off
-  in CI. `open: false` opts out; `REPORTERS_OPEN=1|0` forces it.
+  in CI. `open: false` opts out; `REPORTERS_OPEN=1|0` forces it. This is the
+  only open gate: a reporter can declare default options for when it runs under
+  mux — attached to the reporter function under
+  `Symbol.for('reporters.mux.defaultOptions')`, merged beneath the route's
+  `options` — which is how reporters that self-open standalone (like
+  `@reporters/web`, declaring `{ open: false }`) stay pure emitters here.
 
 ### Profile resolution
 

--- a/packages/mux/src/index.ts
+++ b/packages/mux/src/index.ts
@@ -12,6 +12,20 @@ import { shouldOpen, internals } from './open.ts';
 export type { Sink, SinkSpec } from './sink.ts';
 export type { Reporter, Route, MuxConfig } from './types.ts';
 
+/**
+ * Well-known key under which a reporter function declares the options it wants
+ * by default when driven through mux (a route's own `options` win key-by-key).
+ * Lets a reporter behave differently under mux without env coupling — e.g.
+ * `@reporters/web` declares `{ open: false }` so the sink owns viewing.
+ */
+export const MUX_DEFAULT_OPTIONS = Symbol.for('reporters.mux.defaultOptions');
+
+function routeOptions(reporter: Reporter | Duplex, route: Route): unknown {
+  const defaults = (reporter as { [MUX_DEFAULT_OPTIONS]?: object })[MUX_DEFAULT_OPTIONS];
+  if (!defaults) return route.options;
+  return { ...defaults, ...(route.options as object | undefined) };
+}
+
 function isStreamReporter(value: unknown): value is Duplex {
   return typeof value === 'object' && value !== null
     && typeof (value as { pipe?: unknown }).pipe === 'function';
@@ -46,7 +60,7 @@ export async function runRoutes(
     // Transform-stream reporter uniformly — the same primitive node:test uses
     // internally — handling backpressure and error propagation for us.
     const stage = typeof reporter === 'function'
-      ? (src: AsyncIterable<TestEvent>) => reporter(src, route.options)
+      ? (src: AsyncIterable<TestEvent>) => reporter(src, routeOptions(reporter, route))
       : reporter;
     try {
       if (sink.start) await sink.start();

--- a/packages/mux/tests/index.test.ts
+++ b/packages/mux/tests/index.test.ts
@@ -8,7 +8,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 import type { TestEvent } from '@reporters/tree-core';
 import type { Sink } from '../src/sink.ts';
 import type { MuxConfig } from '../src/types.ts';
-import mux, { resolveReporter, runRoutes } from '../src/index.ts';
+import mux, { resolveReporter, runRoutes, MUX_DEFAULT_OPTIONS } from '../src/index.ts';
 
 const here = dirname(fileURLToPath(import.meta.url));
 
@@ -103,6 +103,42 @@ test('runRoutes announces a sink viewer url even when the open gate is closed', 
   await runRoutes(source(), config, { REPORTERS_OPEN: '0' }, (url) => opened.push(url));
   assert.deepStrictEqual(announced, ['http://localhost:1/'], 'announced despite the closed gate');
   assert.deepStrictEqual(opened, [], 'not opened');
+});
+
+test("runRoutes merges a reporter's declared under-mux defaults beneath route options", async () => {
+  const seen: unknown[] = [];
+  async function* declaring(src: AsyncIterable<TestEvent>, options?: unknown): AsyncGenerator<string> {
+    seen.push(options);
+    // eslint-disable-next-line no-unused-vars
+    for await (const _e of src) { /* drain */ }
+    yield '';
+  }
+  Object.assign(declaring, { [MUX_DEFAULT_OPTIONS]: { open: false, style: 'default' } });
+  const config: MuxConfig = {
+    local: [
+      { reporter: declaring, sink: memorySink() },
+      { reporter: declaring, sink: memorySink(), options: { style: 'route' } },
+    ],
+  };
+  await runRoutes(source(), config, { REPORTERS_OPEN: '0' });
+  assert.deepStrictEqual(seen, [
+    { open: false, style: 'default' },
+    { open: false, style: 'route' },
+  ], 'defaults apply when the route has no options and lose to route options key-by-key');
+});
+
+test('runRoutes passes route options through untouched for a reporter with no declared defaults', async () => {
+  const seen: unknown[] = [];
+  async function* plain(src: AsyncIterable<TestEvent>, options?: unknown): AsyncGenerator<string> {
+    seen.push(options);
+    // eslint-disable-next-line no-unused-vars
+    for await (const _e of src) { /* drain */ }
+    yield '';
+  }
+  const options = { style: 'route' };
+  const config: MuxConfig = { local: [{ reporter: plain, sink: memorySink(), options }] };
+  await runRoutes(source(), config, { REPORTERS_OPEN: '0' });
+  assert.deepStrictEqual(seen, [options]);
 });
 
 // A Transform-based reporter (the shape @reporters/gh uses): objectMode in, string out.

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -41,7 +41,7 @@ The NDJSON is rendered by the tree viewer, reached three ways:
   // mux.config.js
   import { httpServer } from '@reporters/web/sink';
   export default {
-    // pass `options: { open: false }` on the route if it shouldn't open a browser
+    // pass `open: false` on the route if it shouldn't open a browser
     local: [{ reporter: '@reporters/web', sink: httpServer() }],
   };
   ```

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -20,8 +20,8 @@ function hint(message: string): void {
  * Run standalone on a dev machine it also serves a live browser view and opens
  * it, the same way it behaves through `@reporters/mux`'s `httpServer()` sink.
  * Control this with the `open` option or `REPORTERS_OPEN=1|0`; it never opens
- * in CI by default. Through mux the reporter is a pure emitter and the sink owns
- * viewing.
+ * in CI by default. Through mux the reporter is a pure emitter and the sink
+ * owns viewing — it declares `{ open: false }` as its under-mux default options.
  */
 export default async function* web(
   source: AsyncIterable<TestEvent>,
@@ -50,3 +50,7 @@ export default async function* web(
   if (process.stdin.isTTY) return; // keep serving for review; user quits with Ctrl+C
   await server.close();
 }
+
+// Under `@reporters/mux` the sink owns viewing, so declare a pure-emitter
+// default; a route's explicit `options: { open: true }` still wins.
+Object.assign(web, { [Symbol.for('reporters.mux.defaultOptions')]: { open: false } satisfies WebOptions });

--- a/packages/web/src/open.ts
+++ b/packages/web/src/open.ts
@@ -22,9 +22,11 @@ export function isCI(env: NodeJS.ProcessEnv = process.env): boolean {
 }
 
 /**
- * Whether to open a live browser view. An explicit `open` option wins; then the
- * `REPORTERS_OPEN=1|0` env override; otherwise the default is to open on an
- * interactive terminal (a TTY) and not in CI.
+ * Whether to open a live browser view. An explicit `open` option wins (mux
+ * passes `open: false` via the reporter's declared under-mux defaults — the
+ * sink owns viewing there); then the `REPORTERS_OPEN=1|0` env override;
+ * otherwise the default is to open on an interactive terminal (a TTY) and not
+ * in CI.
  */
 export function shouldOpen(
   open: boolean | undefined,

--- a/packages/web/tests/reporter.test.ts
+++ b/packages/web/tests/reporter.test.ts
@@ -68,6 +68,11 @@ test('web with open:true and a file destination serves + opens AND writes NDJSON
   }
 });
 
+test('web declares under-mux defaults so mux drives it as a pure emitter', () => {
+  const defaults = (web as unknown as Record<symbol, unknown>)[Symbol.for('reporters.mux.defaultOptions')];
+  assert.deepStrictEqual(defaults, { open: false });
+});
+
 test('web with open:false stays a pure emitter and opens nothing', async () => {
   const origOpen = internals.openInBrowser;
   let opened = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1126,12 +1126,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^22.10.0":
-  version: 22.20.0
-  resolution: "@types/node@npm:22.20.0"
+"@types/node@npm:^26.1.0":
+  version: 26.1.0
+  resolution: "@types/node@npm:26.1.0"
   dependencies:
-    undici-types: "npm:~6.21.0"
-  checksum: 10c0/55d78223205bd5f81f043d71b7a5c8d8854b9ef44ef81291680943adb27fa5ba1f092658c87183d5bc8cf6baf6a57b81dad966eb3afa452cc301a615b6d9b20e
+    undici-types: "npm:~8.3.0"
+  checksum: 10c0/61c22ad1ef215e24138cb8b7368fb68bab9de4c123b3f23d411749b015ba1b7d22f878ad54add26a0b69068d7e07c04af665069d8571b6c6c3b9b2fb73b7bd91
   languageName: node
   linkType: hard
 
@@ -3987,7 +3987,7 @@ __metadata:
     "@reporters/mux": "workspace:^"
     "@reporters/sink": "workspace:^"
     "@reporters/web": "workspace:^"
-    "@types/node": "npm:^22.10.0"
+    "@types/node": "npm:^26.1.0"
     "@types/react": "npm:^19.0.0"
     "@types/react-dom": "npm:^19.0.0"
     c8: "npm:^11.0.0"
@@ -4826,10 +4826,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici-types@npm:~6.21.0":
-  version: 6.21.0
-  resolution: "undici-types@npm:6.21.0"
-  checksum: 10c0/c01ed51829b10aa72fc3ce64b747f8e74ae9b60eafa19a7b46ef624403508a54c526ffab06a14a26b3120d055e1104d7abe7c9017e83ced038ea5cf52f8d5e04
+"undici-types@npm:~8.3.0":
+  version: 8.3.0
+  resolution: "undici-types@npm:8.3.0"
+  checksum: 10c0/c8aa7e2fbebfce519654dafadc0ece59be888d2ccaf180fb4495da875e7b536d2456345c384069c7e6f3e9c9ab7435f074957da306f142343eee86ff8048855a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Problem

An interactive `yarn test` opened **two** browser windows: mux opens the `httpServer()` sink's viewer URL, and `@reporters/web` independently started its own viewer server and opened it too — despite its docs saying "through mux the reporter is a pure emitter and the sink owns viewing."

## Fix

A reporter function can now declare the options it wants by default when driven through mux, attached under `Symbol.for('reporters.mux.defaultOptions')`. `runRoutes` merges those beneath the route's own `options` (route options win key-by-key). `@reporters/web` declares `{ open: false }`, so under mux it never self-serves and the route-level `open` gate is the single place that opens a browser. Standalone behavior is unchanged, and `options: { open: true }` on a route remains an escape hatch.

The convention is generic (no env-var propagation, no mux special-casing of web) and gives other reporters a path to under-mux defaults, e.g. the slow-reporter options TODO.

This also lets the root `test` script drop `REPORTERS_OPEN=0`, so `yarn test` opens the report exactly once. Includes the `@types/node` ^26 bump that came with that script change.

## Tests

- mux: merges declared defaults beneath route options; passes options through untouched when no defaults are declared
- web: declares `{ open: false }` under the symbol
- Full suite green (203 tests, 100% statement coverage), lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)