### PR TITLE
fix(tree-core): carry duration rounding into the next unit

### DIFF
--- a/packages/tree-core/src/format.ts
+++ b/packages/tree-core/src/format.ts
@@ -5,13 +5,13 @@ const HOUR = 60 * MINUTE;
 export function formatDuration(ms: number | undefined): string {
   if (ms == null) return '';
   if (ms < SECOND) return `${Math.round(ms)}ms`;
-  if (ms < MINUTE) {
-    const rounded = Math.round((ms / SECOND) * 10) / 10;
-    return `${rounded % 1 === 0 ? rounded.toFixed(0) : rounded}s`;
-  }
-  if (ms < HOUR) {
-    return `${Math.floor(ms / MINUTE)}m ${Math.round((ms % MINUTE) / SECOND)}s`;
-  }
+  // Round to the tier's display precision FIRST, then decompose, so a value
+  // that rounds past the tier carries into the next unit ("2m", never "1m 60s").
+  const tenths = Math.round((ms / SECOND) * 10) / 10;
+  if (tenths < 60) return `${tenths % 1 === 0 ? tenths.toFixed(0) : tenths}s`;
+  const seconds = Math.round(ms / SECOND);
+  if (seconds < HOUR / SECOND) return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
   // Hours and beyond (h + m); keeps long-running suites readable.
-  return `${Math.floor(ms / HOUR)}h ${Math.round((ms % HOUR) / MINUTE)}m`;
+  const minutes = Math.round(ms / MINUTE);
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
 }

--- a/packages/tree-core/tests/helpers.test.ts
+++ b/packages/tree-core/tests/helpers.test.ts
@@ -32,6 +32,14 @@ test('formatDuration renders ms, seconds and minutes', () => {
   assert.strictEqual(formatDuration(undefined), '');
 });
 
+test('formatDuration carries boundary rounding into the next unit', () => {
+  assert.strictEqual(formatDuration(59949), '59.9s');
+  assert.strictEqual(formatDuration(59950), '1m 0s'); // rounds to 60s → carried
+  assert.strictEqual(formatDuration(119700), '2m 0s'); // not "1m 60s"
+  assert.strictEqual(formatDuration(3599500), '1h 0m'); // not "59m 60s"
+  assert.strictEqual(formatDuration(7170000), '2h 0m'); // not "1h 60m"
+});
+
 test('toWireEvent keeps only known fields and is JSON-safe', () => {
   const wire = toWireEvent({
     type: 'test:pass',


### PR DESCRIPTION
## Summary
`formatDuration` (used by the web viewer's duration column and verdict, and the live/tree reporters) rounded each unit independently, so values just under a tier boundary rendered impossible durations:

- `59950` → `"60s"` (now `"1m 0s"`)
- `119700` → `"1m 60s"` (now `"2m 0s"`)
- `3599500` → `"59m 60s"` (now `"1h 0m"`)
- `7170000` → `"1h 60m"` (now `"2h 0m"`)

The fix rounds to the tier's display precision first and then decomposes, so rounding that lands exactly on a boundary carries into the next unit.

## Test plan
- [x] New boundary-carry cases in `packages/tree-core/tests/helpers.test.ts`
- [x] `node --test packages/tree-core/tests/*.test.ts` — 48/48 pass
- [x] `node --test packages/live/tests/*.test.ts` (downstream consumer) — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)