### PR TITLE
fix(web): show real wall-clock durations instead of summing concurrent tests

### DIFF
--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -437,7 +437,15 @@ export function createTreeStore(): TreeStore {
         // this is what lets the live tree mark tests done in real time. It
         // carries testId on modern Node; older builds (no testId) fall back to
         // the declaration-ordered pass/fail stack below.
-        if (isFileLevel(data)) { sawFileWrapper = true; break; }
+        if (isFileLevel(data)) {
+          sawFileWrapper = true;
+          // The wrapper measures the file's real wall-clock — the file's
+          // concurrent tests sum to much more than the run actually took.
+          if (data.details?.duration_ms != null) {
+            ensureGroupNode(groupKey(data), data.file).durationMs = data.details.duration_ms;
+          }
+          break;
+        }
         if (data.testId == null) break;
         const status = statusFromComplete(data);
         upsertFromTestEvent(data, (node) => {
@@ -451,7 +459,15 @@ export function createTreeStore(): TreeStore {
       }
       case 'test:pass':
       case 'test:fail': {
-        if (isFileLevel(data)) { sawFileWrapper = true; declOpen.clear(); break; }
+        if (isFileLevel(data)) {
+          sawFileWrapper = true;
+          declOpen.clear();
+          if (data.details?.duration_ms != null) {
+            const group = ensureGroupNode(groupKey(data), data.file);
+            group.durationMs = group.durationMs ?? data.details.duration_ms;
+          }
+          break;
+        }
         const status = statusFromResult(type === 'test:pass' ? 'pass' : 'fail', data);
         if (data.testId != null) {
           declFinalize(status, data);
@@ -480,7 +496,15 @@ export function createTreeStore(): TreeStore {
         break;
       case 'test:summary':
         // A per-file summary trails its file's declaration block, closing it.
-        if (data.file !== undefined) declOpen.clear();
+        // It also carries the file's wall-clock, for builds whose wrapper
+        // completion lacks duration detail.
+        if (data.file !== undefined) {
+          declOpen.clear();
+          if (data.duration_ms != null) {
+            const group = ensureGroupNode(groupKey(data), data.file);
+            group.durationMs = group.durationMs ?? data.duration_ms;
+          }
+        }
         // Keep the cumulative summary for the run verdict. Under --test that's
         // the one with no file; when run without --test (a single process, no
         // file wrappers) the only summary carries the file, so accept it too.

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -190,6 +190,50 @@ test('tests appear as running from dequeue, before start/pass arrive', () => {
   assert.deepStrictEqual(file.children.map((c) => [c.name, c.status]), [['slow', 'running'], ['fast', 'running']]);
 });
 
+test('the file wrapper completion carries the file wall-clock onto the file node', () => {
+  // Concurrent tests inside a file sum to far more than the file's real
+  // duration; the wrapper's test:complete measures the actual wall-clock.
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:enqueue', data: { name: 'a.test.js', nesting: 0, file: '/x/a.test.js', testId: 1, parentId: 0 } },
+    { type: 'test:complete', data: { name: 'fast', nesting: 0, file: '/x/a.test.js', testId: 1, parentId: 0, details: { passed: true, duration_ms: 500 } } },
+    { type: 'test:complete', data: { name: 'slow', nesting: 0, file: '/x/a.test.js', testId: 2, parentId: 0, details: { passed: true, duration_ms: 600 } } },
+    { type: 'test:complete', data: { name: 'a.test.js', nesting: 0, file: '/x/a.test.js', testId: 1, parentId: 0, details: { passed: true, duration_ms: 700 } } },
+  ]);
+  const fileNode = store.getSnapshot().root.children[0];
+  assert.strictEqual(fileNode.type, 'file');
+  assert.strictEqual(fileNode.durationMs, 700);
+});
+
+test('a file wrapper pass carries the wall-clock but never overrides the completion detail', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:pass', data: { name: 't', nesting: 0, file: '/x/a.test.js', testId: 1, details: { duration_ms: 50 } } },
+    { type: 'test:pass', data: { name: 'a.test.js', nesting: 0, file: '/x/a.test.js', testId: 1, parentId: 0, details: { duration_ms: 80 } } },
+  ]);
+  assert.strictEqual(store.getSnapshot().root.children[0].durationMs, 80);
+
+  const withComplete = createTreeStore();
+  apply(withComplete, [
+    { type: 'test:pass', data: { name: 't', nesting: 0, file: '/x/a.test.js', testId: 1, details: { duration_ms: 50 } } },
+    { type: 'test:complete', data: { name: 'a.test.js', nesting: 0, file: '/x/a.test.js', testId: 1, parentId: 0, details: { passed: true, duration_ms: 70 } } },
+    { type: 'test:pass', data: { name: 'a.test.js', nesting: 0, file: '/x/a.test.js', testId: 1, parentId: 0, details: { duration_ms: 90 } } },
+    { type: 'test:summary', data: { file: '/x/a.test.js', success: true, duration_ms: 95, counts: {} } },
+  ]);
+  assert.strictEqual(withComplete.getSnapshot().root.children[0].durationMs, 70);
+});
+
+test('a per-file summary carries the file wall-clock when no wrapper completion has detail', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:dequeue', data: { name: 'a.test.js', nesting: 0, file: '/x/a.test.js', testId: 1, parentId: 0 } },
+    { type: 'test:pass', data: { name: 't', nesting: 0, file: '/x/a.test.js', testId: 1, details: { duration_ms: 50 } } },
+    { type: 'test:summary', data: { file: '/x/a.test.js', success: true, duration_ms: 90, counts: {} } },
+  ]);
+  const fileNode = store.getSnapshot().root.children[0];
+  assert.strictEqual(fileNode.durationMs, 90);
+});
+
 test('REPL-shaped events without file or nesting build under the <repl> group', () => {
   const store = createTreeStore();
   apply(store, [

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -5,7 +5,7 @@ import {
   formatDuration, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
 } from '@reporters/tree-core';
 import {
-  buildRows, collectContainerKeys, computeMatches, displayName, isContainer, reasonOf, realError, type FlatRow,
+  buildRows, collectContainerKeys, computeMatches, displayName, isContainer, liveNodeDuration, reasonOf, realError, type FlatRow,
 } from './rowModel.ts';
 
 // node:test captures colored output verbatim; render the ANSI SGR codes as real
@@ -19,27 +19,6 @@ const STATUS_ORDER: TestStatus[] = ['passed', 'failed', 'skipped', 'todo', 'runn
 const STATUS_LABEL: Record<TestStatus, string> = {
   passed: 'passed', failed: 'failed', skipped: 'skipped', todo: 'todo', running: 'running', queued: 'queued',
 };
-
-function sumDuration(node: TestNode): number {
-  if (!isContainer(node)) return node.durationMs ?? 0;
-  return node.children.reduce((total, child) => total + sumDuration(child), 0);
-}
-
-/**
- * Like `sumDuration`, but a still-running leaf counts the time elapsed since the
- * client first saw it running (`since`), so its counter ticks live between polls
- * instead of sitting at 0 until the run settles.
- */
-function liveDuration(node: TestNode, now: number, since: Map<string, number>): number {
-  if (!isContainer(node)) {
-    if (node.status === 'running') {
-      if (!since.has(node.key)) since.set(node.key, now); // first sight: start the clock
-      return Math.max(0, now - since.get(node.key)!);
-    }
-    return node.durationMs ?? 0;
-  }
-  return node.children.reduce((total, child) => total + liveDuration(child, now, since), 0);
-}
 
 /** Severity of a test's diagnostics, for the row badge tint. */
 function diagSeverity(node: TestNode): TestStatus {
@@ -307,7 +286,7 @@ function RowView({
             ))}
           </span>
         ) : null}
-        <span className="dur">{formatDuration(liveDuration(node, now, since)) || '—'}</span>
+        <span className="dur">{formatDuration(liveNodeDuration(node, now, since)) || '—'}</span>
       </div>
       {hasDiag ? (
         <div className={`collapsible${diagOpen ? ' open' : ''}`}>
@@ -411,9 +390,10 @@ export function TreeView({
   }, [inProgress]);
   const now = performance.now();
   const since = sinceRef.current;
-  // Sum of descendant durations (running leaves count live elapsed), consistent
-  // with the per-file/suite rows. Header ticks with the run.
-  const duration = liveDuration(snapshot.root, now, since);
+  // The run summary carries the real wall-clock; while still running, fall back
+  // to aggregating the files (running leaves count live elapsed, so the header
+  // ticks with the run).
+  const duration = snapshot.summary?.durationMs ?? liveNodeDuration(snapshot.root, now, since);
 
   // Enter-animation bookkeeping: play only for rows first seen during a live run,
   // staggered within each file so a file "unfurls" rather than popping as a slab.

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -16,6 +16,33 @@ export function isContainer(node: TestNode): boolean {
   return node.children.length > 0;
 }
 
+/**
+ * A node's displayed duration: the measured wall-clock when the runner
+ * reported one (a test/suite's own duration_ms, or the file wrapper's), else
+ * the sum of its children. Concurrent children overlap, so summing is only a
+ * fallback — a 40-minute run of concurrent files sums to many hours.
+ */
+export function nodeDuration(node: TestNode): number {
+  if (node.durationMs != null) return node.durationMs;
+  if (!isContainer(node)) return 0;
+  return node.children.reduce((total, child) => total + nodeDuration(child), 0);
+}
+
+/**
+ * Like `nodeDuration`, but a still-running leaf counts the time elapsed since
+ * the client first saw it running (`since`), so its counter ticks live between
+ * polls instead of sitting at 0 until the run settles.
+ */
+export function liveNodeDuration(node: TestNode, now: number, since: Map<string, number>): number {
+  if (!isContainer(node) && node.status === 'running') {
+    if (!since.has(node.key)) since.set(node.key, now); // first sight: start the clock
+    return Math.max(0, now - since.get(node.key)!);
+  }
+  if (node.durationMs != null) return node.durationMs;
+  if (!isContainer(node)) return 0;
+  return node.children.reduce((total, child) => total + liveNodeDuration(child, now, since), 0);
+}
+
 /** Container status = the worst status among descendants (severity order). */
 export function rollup(node: TestNode): TestStatus {
   if (!isContainer(node)) return node.status;

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -4,7 +4,7 @@ import { createTreeStore } from '@reporters/tree-core';
 import type { Counts, TestEvent, TestNode } from '@reporters/tree-core';
 import {
   buildRows, collectContainerKeys, computeMatches, displayName, hasDiagnostics,
-  isDiagOpen, isExpanded, reasonOf, realError, rollup,
+  isDiagOpen, isExpanded, liveNodeDuration, nodeDuration, reasonOf, realError, rollup,
 } from '../src/client/rowModel.ts';
 
 const zeroCounts = (): Counts => ({
@@ -180,4 +180,28 @@ test('hasDiagnostics ignores a suppressed (synthetic/container) error', () => {
   assert.strictEqual(hasDiagnostics(container), false);
   // a failed leaf with a real error does have diagnostics
   assert.strictEqual(hasDiagnostics(node({ error: { message: 'real' } })), true);
+});
+
+test('nodeDuration prefers a measured wall-clock over summing concurrent children', () => {
+  const child = (key: string) => node({ key, durationMs: 600_000 });
+  const measured = node({
+    key: 'file', type: 'file', durationMs: 700_000, children: [child('a'), child('b'), child('c')],
+  });
+  assert.strictEqual(nodeDuration(measured), 700_000, 'measured wall-clock wins');
+  const unmeasured = node({ key: 'suite', type: 'suite', children: [child('a'), child('b')] });
+  assert.strictEqual(nodeDuration(unmeasured), 1_200_000, 'falls back to summing when unmeasured');
+  assert.strictEqual(nodeDuration(child('leaf')), 600_000);
+  assert.strictEqual(nodeDuration(node({ key: 'q', status: 'queued' })), 0, 'an unmeasured leaf has no duration');
+});
+
+test('liveNodeDuration ticks running leaves but keeps measured containers fixed', () => {
+  const since = new Map<string, number>();
+  const running = node({ key: 'r', status: 'running' });
+  const done = node({ key: 'd', durationMs: 50 });
+  const parent = node({ key: 'p', type: 'suite', children: [running, done] });
+  assert.strictEqual(liveNodeDuration(parent, 1000, since), 50, 'first sight starts the running clock at 0');
+  assert.strictEqual(liveNodeDuration(parent, 1300, since), 350, 'running leaf ticks with elapsed time');
+  const measured = node({ key: 'm', type: 'suite', durationMs: 80, children: [done] });
+  assert.strictEqual(liveNodeDuration(measured, 9999, since), 80, 'a completed, measured container is fixed');
+  assert.strictEqual(liveNodeDuration(node({ key: 'q', status: 'queued' }), 9999, since), 0, 'an unmeasured, not-running leaf has no duration');
 });


### PR DESCRIPTION
## Problem

The viewer header and every container row computed duration as the **sum of descendant leaf durations**. Concurrent tests overlap, so the sum wildly exaggerates: a real 40-file concurrent run whose GitHub job took **40m** rendered as **~16h** in the HTML viewer.

## Fix

The stream already reports measured wall-clock at every level — the run-level `test:summary` (40m 17s for that run), the file wrapper's `test:complete` (with the per-file summary and wrapper pass/fail as fallbacks for builds without completion detail), and each parent test's own `duration_ms`.

- **tree-core**: file group nodes now record the file's wall-clock from the wrapper completion / per-file summary.
- **web**: container rows prefer the node's measured `durationMs` over summing children (summing remains only a fallback for unmeasured containers and for the live tick of still-running subtrees); the header verdict uses `summary.durationMs` once the run completes.

## Verification

- New store tests (wrapper complete / wrapper pass precedence / per-file summary fallback) and rowModel tests for the duration helpers; full suite 241/241, statements 100%.
- Replaying the original 40-file NDJSON: header now reads **40m 17s** (was 15h 58m), and file rows show their real wall-clock (e.g. `s3.test.ts` 22m 57s instead of a leaf sum). Confirmed visually in the built viewer against the served report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)