### PR TITLE
feat(tree-core): report a passing todo as passed, reserving todo for failing ones

### DIFF
--- a/packages/live/src/TreeNode.tsx
+++ b/packages/live/src/TreeNode.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Text, Box } from 'ink';
 import {
-  formatDuration, INK_COLOR, SPINNER_FRAMES, SYMBOLS, type TestNode,
+  formatDuration, INK_COLOR, SPINNER_FRAMES, SYMBOLS, todoLabel, type TestNode,
 } from '@reporters/tree-core';
 
 function basename(file: string | undefined): string {
@@ -67,6 +67,7 @@ export function TreeNode({
         <Text color="yellow">{hasDiag ? (showDiag ? '▾ ' : '▸ ') : '  '}</Text>
         <Text color={INK_COLOR[node.status]}>{symbol} </Text>
         <Text bold={node.type === 'file'} inverse={selected} underline={selected}>{label}</Text>
+        {todoLabel(node) != null ? <Text color={INK_COLOR.todo}>{' # '}{todoLabel(node)}</Text> : null}
         {node.durationMs != null ? <Text dimColor>{' '}{formatDuration(node.durationMs)}</Text> : null}
       </Box>
       {showDiag ? <Diagnostics node={node} indent={'  '.repeat(depth + 2)} /> : null}

--- a/packages/live/src/text.ts
+++ b/packages/live/src/text.ts
@@ -1,5 +1,5 @@
 import {
-  formatDuration, SYMBOLS, STATUS_LABEL, type TestNode, type TreeSnapshot, type TestStatus,
+  formatDuration, SYMBOLS, STATUS_LABEL, todoLabel, type TestNode, type TreeSnapshot, type TestStatus,
 } from '@reporters/tree-core';
 
 function basename(file: string | undefined): string {
@@ -12,7 +12,8 @@ function renderNode(node: TestNode, depth: number, lines: string[]): void {
   const indent = '  '.repeat(depth);
   const label = node.type === 'file' ? basename(node.file) : node.name;
   const duration = node.durationMs != null ? ` (${formatDuration(node.durationMs)})` : '';
-  lines.push(`${indent}${SYMBOLS[node.status]} ${label}${duration}`);
+  const todoTag = todoLabel(node) != null ? ` # ${todoLabel(node)}` : '';
+  lines.push(`${indent}${SYMBOLS[node.status]} ${label}${duration}${todoTag}`);
 
   if (node.status === 'failed' && node.children.length === 0 && node.error) {
     const errIndent = '  '.repeat(depth + 2);

--- a/packages/live/tests/text.test.ts
+++ b/packages/live/tests/text.test.ts
@@ -66,3 +66,19 @@ test('renders a summary line from the counts', () => {
   assert.match(text, /1 passed/);
   assert.match(text, /1 failed/);
 });
+
+test('suffixes todo tests with the directive, spec-reporter style', () => {
+  const snapshot = build([
+    { type: 'test:pass', data: { name: 'green', nesting: 0, file: '/a.test.js', testId: 1, todo: true, details: { duration_ms: 2 } } },
+    { type: 'test:fail', data: { name: 'red', nesting: 0, file: '/a.test.js', testId: 2, todo: 'flaky backend', details: { error: new Error('boom') } } },
+    { type: 'test:pass', data: { name: 'plain', nesting: 0, file: '/a.test.js', testId: 3 } },
+  ]);
+  const text = renderTreeText(snapshot);
+  // a passing todo reports as passed; the directive is the suffix (# TODO when
+  // no reason was given, the reason otherwise) — same as the spec reporter
+  assert.match(text, /✔ green \(2ms\) # TODO/);
+  const redLine = text.split('\n').find((l) => l.includes('red'))!;
+  assert.ok(redLine.includes('# flaky backend'), 'a failing todo carries its reason');
+  const plainLine = text.split('\n').find((l) => l.includes('plain'))!;
+  assert.ok(!plainLine.includes('#'), 'non-todo rows are not suffixed');
+});

--- a/packages/tree-core/src/expand.ts
+++ b/packages/tree-core/src/expand.ts
@@ -9,3 +9,23 @@ import type { TestNode } from './types.ts';
 export function defaultExpanded(node: TestNode): boolean {
   return node.children.length > 0;
 }
+
+/**
+ * A passing leaf that still carries the todo directive: the store reports it
+ * as passed (only failing todos keep the todo status), so renderers badge the
+ * directive separately — it flags a candidate to un-todo, mirroring the spec
+ * reporter's `\u2714 \u2026 # TODO`.
+ */
+export function isPassingTodo(node: TestNode): boolean {
+  return node.status === 'passed' && node.children.length === 0
+    && node.todo != null && node.todo !== false;
+}
+
+/**
+ * The todo directive's display text, mirroring the spec reporter's
+ * `# \u2026` suffix: the reason when one was given, else "TODO".
+ */
+export function todoLabel(node: TestNode): string | undefined {
+  if (node.todo == null || node.todo === false) return undefined;
+  return typeof node.todo === 'string' && node.todo.length > 0 ? node.todo : 'TODO';
+}

--- a/packages/tree-core/src/index.ts
+++ b/packages/tree-core/src/index.ts
@@ -1,7 +1,7 @@
 export { createTreeStore } from './store.ts';
 export { toWireEvent, serializeWireLine, parseWireLines } from './wire.ts';
 export { formatDuration } from './format.ts';
-export { defaultExpanded } from './expand.ts';
+export { defaultExpanded, isPassingTodo, todoLabel } from './expand.ts';
 export * from './theme.ts';
 export type {
   TestStatus,

--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -42,15 +42,18 @@ interface InternalNode {
 
 const TERMINAL: ReadonlySet<TestStatus> = new Set(['passed', 'failed', 'skipped', 'todo']);
 
+// A todo test that actually passes reports as passed (its `todo` marker is
+// kept on the node); `todo` status is reserved for todos that are failing
+// underneath — the expected state, which must not fail the run.
 function statusFromResult(type: 'pass' | 'fail', data: TestEventData): TestStatus {
   if (data.skip != null && data.skip !== false) return 'skipped';
-  if (data.todo != null && data.todo !== false) return 'todo';
+  if (data.todo != null && data.todo !== false) return type === 'pass' ? 'passed' : 'todo';
   return type === 'pass' ? 'passed' : 'failed';
 }
 
 function statusFromComplete(data: TestEventData): TestStatus {
   if (data.skip != null && data.skip !== false) return 'skipped';
-  if (data.todo != null && data.todo !== false) return 'todo';
+  if (data.todo != null && data.todo !== false) return data.details?.passed ? 'passed' : 'todo';
   return data.details?.passed ? 'passed' : 'failed';
 }
 

--- a/packages/tree-core/tests/helpers.test.ts
+++ b/packages/tree-core/tests/helpers.test.ts
@@ -155,6 +155,22 @@ function node(partial: Partial<TestNode>): TestNode {
   };
 }
 
+test('isPassingTodo flags only a passed leaf still carrying the todo directive', () => {
+  assert.strictEqual(api.isPassingTodo(node({ type: 'test', status: 'passed', todo: true, children: [] })), true);
+  assert.strictEqual(api.isPassingTodo(node({ type: 'test', status: 'passed', todo: 'why', children: [] })), true);
+  assert.strictEqual(api.isPassingTodo(node({ type: 'test', status: 'passed', children: [] })), false);
+  assert.strictEqual(api.isPassingTodo(node({ type: 'test', status: 'todo', todo: true, children: [] })), false);
+  assert.strictEqual(api.isPassingTodo(node({ type: 'suite', status: 'passed', todo: true, children: [node({ type: 'test' })] })), false);
+});
+
+test('todoLabel mirrors the spec reporter directive text', () => {
+  assert.strictEqual(api.todoLabel(node({ type: 'test', todo: true, children: [] })), 'TODO');
+  assert.strictEqual(api.todoLabel(node({ type: 'test', todo: 'flaky backend', children: [] })), 'flaky backend');
+  assert.strictEqual(api.todoLabel(node({ type: 'test', todo: '', children: [] })), 'TODO');
+  assert.strictEqual(api.todoLabel(node({ type: 'test', children: [] })), undefined);
+  assert.strictEqual(api.todoLabel(node({ type: 'test', todo: false, children: [] })), undefined);
+});
+
 test('defaultExpanded keeps every container expanded and leaves collapsed', () => {
   const kids = [node({ type: 'test' })];
   assert.strictEqual(defaultExpanded(node({ type: 'file', children: kids })), true);

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -67,15 +67,33 @@ test('failed test carries the unwrapped cause error', () => {
   assert.strictEqual(node.error?.message, 'actual failure');
 });
 
-test('skip and todo map to their own statuses', () => {
+test('skip maps to its own status; todo status is reserved for failing todos', () => {
   const store = createTreeStore();
   apply(store, [
     { type: 'test:pass', data: { name: 's', nesting: 0, file: '/a.test.js', testId: 1, skip: true } },
-    { type: 'test:pass', data: { name: 'd', nesting: 0, file: '/a.test.js', testId: 2, todo: true } },
+    { type: 'test:pass', data: { name: 'green', nesting: 0, file: '/a.test.js', testId: 2, todo: true } },
+    { type: 'test:fail', data: { name: 'red', nesting: 0, file: '/a.test.js', testId: 3, todo: 'evaluating', details: { error: new Error('boom') } } },
   ]);
-  const [s, d] = store.getSnapshot().root.children[0].children;
+  const [s, green, red] = store.getSnapshot().root.children[0].children;
   assert.strictEqual(s.status, 'skipped');
-  assert.strictEqual(d.status, 'todo');
+  // A todo that actually passes reports as passed — it is a candidate to
+  // un-todo — and keeps its todo marker; a failing todo is the expected
+  // state and must not fail the run.
+  assert.strictEqual(green.status, 'passed');
+  assert.strictEqual(green.todo, true);
+  assert.strictEqual(red.status, 'todo');
+  assert.strictEqual(red.error?.message, 'boom');
+});
+
+test('test:complete resolves a todo result ahead of the buffered pass/fail', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:complete', data: { name: 'green', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, todo: true, details: { passed: true } } },
+    { type: 'test:complete', data: { name: 'red', nesting: 0, file: '/a.test.js', testId: 2, parentId: 0, todo: true, details: { passed: false, error: new Error('boom') } } },
+  ]);
+  const [green, red] = store.getSnapshot().root.children[0].children;
+  assert.strictEqual(green.status, 'passed');
+  assert.strictEqual(red.status, 'todo');
 });
 
 test('diagnostics attach to the last started test at that file+nesting', () => {
@@ -170,7 +188,7 @@ test('test:complete carries failure and skip/todo status', () => {
   apply(store, [
     { type: 'test:complete', data: { name: 'boom', nesting: 0, file: '/t.test.js', testId: 1, parentId: 0, details: { passed: false, error: new Error('nope') } } },
     { type: 'test:complete', data: { name: 'skipped', nesting: 0, file: '/t.test.js', testId: 2, parentId: 0, skip: true, details: { passed: true } } },
-    { type: 'test:complete', data: { name: 'todo', nesting: 0, file: '/t.test.js', testId: 3, parentId: 0, todo: true, details: { passed: true } } },
+    { type: 'test:complete', data: { name: 'todo', nesting: 0, file: '/t.test.js', testId: 3, parentId: 0, todo: true, details: { passed: false } } },
   ]);
   const [boom, skipped, todo] = store.getSnapshot().root.children[0].children;
   assert.strictEqual(boom.status, 'failed');

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -2,10 +2,10 @@ import React, {
   useEffect, useMemo, useRef, useState,
 } from 'react';
 import {
-  formatDuration, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
+  formatDuration, todoLabel, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
 } from '@reporters/tree-core';
 import {
-  buildRows, collectContainerKeys, computeMatches, displayName, isContainer, liveNodeDuration, reasonOf, realError, type FlatRow,
+  buildRows, collectContainerKeys, computeMatches, displayName, isContainer, isPassingTodo, liveNodeDuration, reasonOf, realError, type FlatRow,
 } from './rowModel.ts';
 
 // node:test captures colored output verbatim; render the ANSI SGR codes as real
@@ -256,6 +256,9 @@ function RowView({
           <span className="cglyph indicator" data-stc={status} data-spin={status === 'running' ? 'true' : undefined}>{GLYPH[status]}</span>
         )}
         <span className="name" data-kind={node.type} style={{ color: nameColor }}>{displayName(node)}</span>
+        {isPassingTodo(node) ? (
+          <span className="todotag" data-soft="todo"># {todoLabel(node)}</span>
+        ) : null}
         {hasDiag ? (
           // On a container the row click expands children, so the badge is its
           // own control for the node's own output; on a leaf the row already

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -50,6 +50,8 @@ export function rollup(node: TestNode): TestStatus {
   return 'passed';
 }
 
+export { isPassingTodo } from '@reporters/tree-core';
+
 export function reasonOf(node: TestNode): string | undefined {
   if (typeof node.skip === 'string') return node.skip;
   if (typeof node.todo === 'string') return node.todo;

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -144,6 +144,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 .name[data-kind="suite"] { font-weight: 600; }
 .name[data-kind="test"] { font-weight: 450; }
 .diagbadge { flex: none; font-size: 10px; font-weight: 600; border-radius: 6px; padding: 1px 6px; }
+.todotag { flex: none; font-size: 10px; font-weight: 600; border-radius: 6px; padding: 1px 6px; }
 .spacer { flex: 1; min-width: 10px; }
 .pills { display: inline-flex; gap: 5px; flex: none; margin-right: 9px; }
 .pill { font-size: 11px; font-weight: 700; border-radius: 999px; padding: 1px 8px; font-variant-numeric: tabular-nums; }

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -4,7 +4,7 @@ import { createTreeStore } from '@reporters/tree-core';
 import type { Counts, TestEvent, TestNode } from '@reporters/tree-core';
 import {
   buildRows, collectContainerKeys, computeMatches, displayName, hasDiagnostics,
-  isDiagOpen, isExpanded, liveNodeDuration, nodeDuration, reasonOf, realError, rollup,
+  isDiagOpen, isExpanded, isPassingTodo, liveNodeDuration, nodeDuration, reasonOf, realError, rollup,
 } from '../src/client/rowModel.ts';
 
 const zeroCounts = (): Counts => ({
@@ -204,4 +204,13 @@ test('liveNodeDuration ticks running leaves but keeps measured containers fixed'
   const measured = node({ key: 'm', type: 'suite', durationMs: 80, children: [done] });
   assert.strictEqual(liveNodeDuration(measured, 9999, since), 80, 'a completed, measured container is fixed');
   assert.strictEqual(liveNodeDuration(node({ key: 'q', status: 'queued' }), 9999, since), 0, 'an unmeasured, not-running leaf has no duration');
+});
+
+test('isPassingTodo flags only a passed leaf that still carries the todo directive', () => {
+  assert.strictEqual(isPassingTodo(node({ status: 'passed', todo: true })), true);
+  assert.strictEqual(isPassingTodo(node({ status: 'passed', todo: 'evaluating' })), true);
+  assert.strictEqual(isPassingTodo(node({ status: 'passed' })), false, 'a plain pass is not a todo');
+  assert.strictEqual(isPassingTodo(node({ status: 'todo', todo: true })), false, 'a failing todo keeps the todo status');
+  const child = node({ key: 'c', status: 'passed', todo: true });
+  assert.strictEqual(isPassingTodo(node({ status: 'passed', todo: true, children: [child] })), false, 'containers are not badged');
 });


### PR DESCRIPTION
## Problem

A `todo` test can pass or fail underneath, and the tree reported both as status `todo` — indistinguishable in the web viewer and the live reporter alike. The distinction matters: a **passing** todo is a candidate to un-todo, a **failing** todo is the expected state (and must not fail the run) with an error worth reading. The spec reporter already shows it (`✔`/`✖` next to the `# …` directive).

## Change

In tree-core's status mapping: **todo + pass now reports as `passed`** (the `todo` directive stays on the node), and the `todo` status is reserved for todos that are failing underneath. No new fields — the status carries the distinction, so every consumer (web viewer, live reporter, counts, rollups) inherits it.

Both renderers also surface the directive itself, spec-reporter style — the reason text when one was given, `TODO` otherwise (shared `todoLabel`/`isPassingTodo` helpers in tree-core):

- web viewer: a `# <directive>` chip on passed-but-todo rows (failing todos already show status + error + "why todo")
- live reporter: a `# <directive>` suffix on todo-marked rows in the Ink tree and the final text output

## Verification

Store tests for pass/fail/complete outcomes; tree-core helper tests for `isPassingTodo`/`todoLabel`; live text-renderer tests for the spec-style suffix; rowModel tests for the badge predicate. Full suite 248/248, statements 100%. Against a real 40-file run: header goes from `209 passed / 18 todo` to `223 passed / 4 todo` — the 4 remaining todo rows are exactly the failing-underneath ones, and the 14 passing todos render green with their actual directive (`# evaluating`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
