### PR TITLE
fix(tree-core): let terminal events demote a wrong suite type hint

### DIFF
--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -338,7 +338,10 @@ export function createTreeStore(): TreeStore {
     assignFields(node, data);
     node.status = status;
     if (data.details?.duration_ms != null) node.durationMs = data.details.duration_ms;
-    if (data.details?.type === 'suite') node.type = 'suite';
+    // details.type is the finishing test's own type — authoritative. It can
+    // DEMOTE a wrong 'suite': Node dequeues a queued subtest with its parent's
+    // type, so a plain test() inside a describe() dequeues as 'suite'.
+    if (data.details?.type != null) node.type = data.details.type === 'suite' ? 'suite' : 'test';
     const error = serializeError(data.details?.error);
     if (error) node.error = error;
     for (const level of [...declOpen.keys()]) if (level >= nesting) declOpen.delete(level);
@@ -388,7 +391,7 @@ export function createTreeStore(): TreeStore {
     assignFields(node, data);
     node.status = status;
     if (data.details?.duration_ms != null) node.durationMs = data.details.duration_ms;
-    if (data.details?.type === 'suite') node.type = 'suite';
+    if (data.details?.type != null) node.type = data.details.type === 'suite' ? 'suite' : 'test';
     const error = serializeError(data.details?.error);
     if (error) node.error = error;
   }
@@ -443,7 +446,7 @@ export function createTreeStore(): TreeStore {
         upsertFromTestEvent(data, (node) => {
           node.status = status;
           if (data.details?.duration_ms != null) node.durationMs = data.details.duration_ms;
-          if (data.details?.type === 'suite') node.type = 'suite';
+          if (data.details?.type != null) node.type = data.details.type === 'suite' ? 'suite' : 'test';
           const error = serializeError(data.details?.error);
           if (error) node.error = error;
         });

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -249,3 +249,16 @@ test('a leaf test stays a test when its dequeue wrongly reports the parent suite
     ['queued', 'test', 'passed'],
   ]);
 });
+
+test('testId-free results settle the node type from details.type (v22-shaped)', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', data: { name: 'group', nesting: 0, file: '/a.test.js' } },
+    { type: 'test:start', data: { name: 'leaf', nesting: 1, file: '/a.test.js' } },
+    { type: 'test:pass', data: { name: 'leaf', nesting: 1, file: '/a.test.js', details: { duration_ms: 1, type: 'test' } } },
+    { type: 'test:pass', data: { name: 'group', nesting: 0, file: '/a.test.js', details: { duration_ms: 2, type: 'suite' } } },
+  ]);
+  const group = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(group.type, 'suite');
+  assert.deepStrictEqual(group.children.map((c) => [c.name, c.type]), [['leaf', 'test']]);
+});

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -220,3 +220,32 @@ test('subscribe is notified on apply and stops after unsubscribe', () => {
   store.apply({ type: 'test:pass', data: { name: 'u', nesting: 0, file: '/a.test.js', testId: 2 } });
   assert.strictEqual(calls, 1);
 });
+
+test('a leaf test stays a test when its dequeue wrongly reports the parent suite type (nodejs/node dequeue bug)', () => {
+  // Node's processPendingSubtests dequeues queued subtests with the PARENT's
+  // reportedType, so a plain test() queued inside a describe() dequeues as
+  // type 'suite'. The terminal events carry the test's real type — trust them.
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:enqueue', data: { name: 'suite', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, type: 'suite' } },
+    { type: 'test:dequeue', data: { name: 'suite', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, type: 'suite' } },
+    { type: 'test:enqueue', data: { name: 'first', nesting: 1, file: '/a.test.js', testId: 2, parentId: 1, type: 'test' } },
+    { type: 'test:enqueue', data: { name: 'queued', nesting: 1, file: '/a.test.js', testId: 3, parentId: 1, type: 'test' } },
+    { type: 'test:complete', data: { name: 'first', nesting: 1, file: '/a.test.js', testId: 2, parentId: 1, details: { duration_ms: 1, type: 'test', passed: true } } },
+    { type: 'test:dequeue', data: { name: 'queued', nesting: 1, file: '/a.test.js', testId: 3, parentId: 1, type: 'suite' } },
+    { type: 'test:complete', data: { name: 'queued', nesting: 1, file: '/a.test.js', testId: 3, parentId: 1, details: { duration_ms: 1, type: 'test', passed: true } } },
+    { type: 'test:complete', data: { name: 'suite', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, details: { duration_ms: 2, type: 'suite', passed: true } } },
+    { type: 'test:start', data: { name: 'suite', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0 } },
+    { type: 'test:start', data: { name: 'first', nesting: 1, file: '/a.test.js', testId: 2, parentId: 1 } },
+    { type: 'test:pass', data: { name: 'first', nesting: 1, file: '/a.test.js', testId: 2, parentId: 1, details: { duration_ms: 1, type: 'test' } } },
+    { type: 'test:start', data: { name: 'queued', nesting: 1, file: '/a.test.js', testId: 3, parentId: 1 } },
+    { type: 'test:pass', data: { name: 'queued', nesting: 1, file: '/a.test.js', testId: 3, parentId: 1, details: { duration_ms: 1, type: 'test' } } },
+    { type: 'test:pass', data: { name: 'suite', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, details: { duration_ms: 2, type: 'suite' } } },
+  ]);
+  const suite = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(suite.type, 'suite');
+  assert.deepStrictEqual(suite.children.map((c) => [c.name, c.type, c.status]), [
+    ['first', 'test', 'passed'],
+    ['queued', 'test', 'passed'],
+  ]);
+});


### PR DESCRIPTION
## Problem

In the viewer, nine of ten passing leaf tests under a `describe()` rendered with container checkmarks while one rendered with the (correct) leaf dot.

Node's `processPendingSubtests` dequeues a queued subtest with its **parent's** `reportedType`, so a plain `test()` that waits for a concurrency slot inside a `describe()` emits `test:dequeue` with `type: "suite"`. Only a subtest that gets a slot immediately dequeues with its own type. The store trusted the hint and only ever promoted to `suite`, never demoted, so those tests were permanently misclassified as containers.

## Fix

Treat the terminal events' `details.type` (`test:complete`, `test:pass`/`test:fail`) as authoritative in both directions — it can now demote a node wrongly promoted to `suite` by the eager dequeue hint. The hint still applies live, so real suites show as containers immediately; the finishing event settles the truth.

## Verification

- New store test reproducing the exact event shape (dequeue lies `suite`, complete says `test`) — failed before, passes after
- Full suite: 237 passed, statement coverage 100%
- Replayed the real-world ndjson that surfaced this: all ten sibling tests now come out `type: test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)