### PR TITLE
fix(web): keep the http server alive until the viewer reads the whole log

### DIFF
--- a/packages/web/src/server.ts
+++ b/packages/web/src/server.ts
@@ -20,9 +20,14 @@ export interface ViewerServer {
   readonly url: string;
   /** Append NDJSON bytes; served to the viewer via HTTP Range polling. */
   push(chunk: string | Buffer): void;
-  /** Shut the server down. */
+  /** Shut the server down. If a viewer has connected but not yet read the
+   *  whole log, keeps serving until it catches up (or `drainTimeoutMs`). */
   close(): Promise<void>;
 }
+
+/** How long close() keeps serving for a lagging viewer before giving up —
+ *  generous next to the poll cadence, yet a closed tab can't hang the exit. */
+const DRAIN_TIMEOUT_MS = 5000;
 
 /**
  * Start a local HTTP server that serves the viewer page at `/` and a growing
@@ -30,28 +35,42 @@ export interface ViewerServer {
  * live-updates as bytes are appended — no `file://`/CORS limits. Shared by the
  * `httpServer()` sink and the standalone reporter.
  */
-export function startViewerServer(host = '127.0.0.1', pollMs = 250): Promise<ViewerServer> {
+export function startViewerServer(
+  host = '127.0.0.1',
+  pollMs = 250,
+  drainTimeoutMs = DRAIN_TIMEOUT_MS,
+): Promise<ViewerServer> {
   const page = viewerPage();
   let buffer = Buffer.alloc(0);
+  let sawViewer = false;
+  let servedUpTo = 0;
+  let onCaughtUp: (() => void) | undefined;
+  function served(upTo: number): void {
+    servedUpTo = Math.max(servedUpTo, upTo);
+    if (servedUpTo >= buffer.length) onCaughtUp?.();
+  }
 
   return new Promise<ViewerServer>((resolve) => {
     const server: Server = createServer((req, res) => {
       const path = req.url!.split('?')[0];
       if (path === '/run.ndjson') {
+        sawViewer = true;
         const range = /^bytes=(\d+)-/.exec(req.headers.range ?? '');
         if (range) {
           const startByte = Number(range[1]);
-          if (startByte >= buffer.length) { res.writeHead(416).end(); return; }
+          if (startByte >= buffer.length) { served(startByte); res.writeHead(416).end(); return; }
           res.writeHead(206, {
             'content-type': 'application/x-ndjson',
             'accept-ranges': 'bytes',
             'content-range': `bytes ${startByte}-${buffer.length - 1}/${buffer.length}`,
           });
           res.end(buffer.subarray(startByte));
+          served(buffer.length);
           return;
         }
         res.writeHead(200, { 'content-type': 'application/x-ndjson', 'accept-ranges': 'bytes' });
         res.end(buffer);
+        served(buffer.length);
         return;
       }
       res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
@@ -67,8 +86,14 @@ export function startViewerServer(host = '127.0.0.1', pollMs = 250): Promise<Vie
         push(chunk) {
           buffer = Buffer.concat([buffer, Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)]);
         },
-        close() {
-          return new Promise<void>((res) => { server.close(() => res()); });
+        async close() {
+          if (sawViewer && servedUpTo < buffer.length) {
+            await new Promise<void>((res) => {
+              const timer = setTimeout(res, drainTimeoutMs);
+              onCaughtUp = () => { clearTimeout(timer); res(); };
+            });
+          }
+          await new Promise<void>((res) => { server.close(() => res()); });
         },
       });
     });

--- a/packages/web/src/sink.ts
+++ b/packages/web/src/sink.ts
@@ -5,18 +5,21 @@ export interface HttpServerOptions {
   host?: string;
   /** Viewer polling cadence in ms (default 250; the viewer clamps to 100–10000). */
   pollMs?: number;
+  /** How long close() keeps serving a lagging viewer before giving up (default 5000). */
+  drainTimeoutMs?: number;
 }
 
 /**
  * A sink that serves the run locally: the viewer page at `/` and the growing
  * NDJSON at `/run.ndjson` (HTTP Range aware, so the viewer polls appended bytes
  * — no `file://`/CORS limits). Stays alive after the run while attached to an
- * interactive terminal; otherwise shuts down so the process can exit.
+ * interactive terminal; otherwise drains a lagging viewer (bounded by
+ * `drainTimeoutMs`) and shuts down so the process can exit.
  */
 export function httpServer(opts: HttpServerOptions = {}): Sink {
   let server: ViewerServer | undefined;
   return {
-    async start() { server = await startViewerServer(opts.host, opts.pollMs); },
+    async start() { server = await startViewerServer(opts.host, opts.pollMs, opts.drainTimeoutMs); },
     write(chunk) { server?.push(chunk); },
     viewerUrl() { return server?.url; },
     async close() {

--- a/packages/web/tests/sink.test.ts
+++ b/packages/web/tests/sink.test.ts
@@ -47,6 +47,41 @@ test('close() before start() is a no-op (no server to shut down)', async () => {
   await httpServer().close();
 });
 
+test('close() keeps serving until a connected viewer reads the tail', async () => {
+  const sink = httpServer();
+  await sink.start!();
+  const base = baseOf(sink);
+  sink.write('aaa\n');
+  await (await fetch(`${base}/run.ndjson`)).text(); // viewer connects and reads 4 bytes
+  sink.write('bbb\n'); // appended after the viewer's last poll
+  let closed = false;
+  const closing = sink.close().then(() => { closed = true; });
+  await new Promise((r) => setTimeout(r, 50));
+  assert.strictEqual(closed, false); // still serving while the viewer lags
+  const res = await fetch(`${base}/run.ndjson`, { headers: { Range: 'bytes=4-' } });
+  assert.strictEqual(await res.text(), 'bbb\n');
+  await closing; // the catch-up read releases the drain
+});
+
+test('close() gives up draining after drainTimeoutMs', async () => {
+  const sink = httpServer({ drainTimeoutMs: 50 });
+  await sink.start!();
+  const base = baseOf(sink);
+  sink.write('aaa\n');
+  await (await fetch(`${base}/run.ndjson`)).text();
+  sink.write('bbb\n'); // never read again (tab closed)
+  await sink.close();
+});
+
+test('close() does not wait when no viewer ever connected', async () => {
+  const sink = httpServer({ drainTimeoutMs: 60_000 });
+  await sink.start!();
+  sink.write('aaa\n');
+  const started = Date.now();
+  await sink.close();
+  assert.ok(Date.now() - started < 5_000); // headless run: no drain, no hang
+});
+
 test('honors HTTP Range for appended bytes', async () => {
   const sink = httpServer();
   await sink.start!();


### PR DESCRIPTION
## Problem

`ViewerServer.close()` tore the server down the instant the run ended (the non-TTY paths in both the `httpServer()` sink and the standalone reporter). The browser viewer only polls `/run.ndjson` every ~250ms, so bytes appended since its last poll — the tail of the run — were lost, and its next poll failed with `ECONNREFUSED`.

## Fix

The server tracks the highest byte offset any viewer has been served (including "already caught up" 416 responses). `close()` now drains: if a viewer has connected but hasn't read to the end of the buffer, it keeps serving until a request catches up, bounded by a timeout (default 5s, configurable via a new `drainTimeoutMs` option on `httpServer()`) so a closed tab can't hang the process exit. If no viewer ever connected (headless CI), it closes immediately as before.

## Verification

- Three new tests: drain-until-caught-up, drain timeout, and no-wait-when-never-connected. The first reproduced the real-world `ECONNREFUSED` before the fix.
- Verified end-to-end by driving a real `node --test` run through mux + `httpServer()` and polling as the viewer: the lagging client received the complete log through `test:summary`, the server closed 8ms after the catch-up read; a closed-tab client exited after the 5s drain bound; a headless run exited immediately.
- Full suite: 246 passed, statement coverage stays at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)