### PR TITLE
feat(web): clickable header status chips filter the tree

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -348,6 +348,15 @@ export function TreeView({
   const [theme, toggleTheme] = useTheme();
   const [query, setQuery] = useState('');
   const [overrides, setOverrides] = useState<Map<string, boolean>>(new Map());
+  // Active status-chip filters; empty = unfiltered.
+  const [statuses, setStatuses] = useState<ReadonlySet<TestStatus>>(new Set());
+  const toggleStatus = (s: TestStatus) => {
+    setStatuses((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s); else next.add(s);
+      return next;
+    });
+  };
   // Rows already painted at least once — so we only play the enter animation for
   // rows that newly arrive during a live run, never on every re-render.
   const seenRef = useRef<Set<string>>(new Set());
@@ -361,10 +370,15 @@ export function TreeView({
   const { counts } = snapshot;
   const q = query.trim().toLowerCase();
 
-  const matches = useMemo(() => (q ? computeMatches(files, q) : null), [files, q]);
+  const matches = useMemo(
+    () => (q || statuses.size > 0 ? computeMatches(files, q, statuses) : null),
+    [files, q, statuses],
+  );
   const rows = useMemo(
-    () => buildRows(files, { overrides, query: q, matches }),
-    [files, overrides, q, matches],
+    () => buildRows(files, {
+      overrides, query: q, statuses, matches,
+    }),
+    [files, overrides, q, statuses, matches],
   );
 
   const toggle = (key: string, current: boolean) => {
@@ -441,11 +455,20 @@ export function TreeView({
           <Verdict counts={counts} inProgress={inProgress} duration={duration} />
           <div className="chips">
             {statChips.map((s) => (
-              <span className="chip" data-soft={s} key={s}>
+              <button
+                type="button"
+                className="chip"
+                data-soft={s}
+                data-active={statuses.has(s) ? 'true' : undefined}
+                aria-pressed={statuses.has(s)}
+                title={statuses.has(s) ? `Stop filtering by ${STATUS_LABEL[s]}` : `Show only ${STATUS_LABEL[s]} tests`}
+                onClick={() => toggleStatus(s)}
+                key={s}
+              >
                 <span className="chip-dot" data-stf={s} />
                 {counts[s]}
                 <span className="chip-label">{STATUS_LABEL[s]}</span>
-              </span>
+              </button>
             ))}
           </div>
           <div className="tools">

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -103,37 +103,57 @@ export interface Matches {
   force: Set<string>;
 }
 
-export function computeMatches(files: TestNode[], query: string): Matches {
+/**
+ * Which nodes stay visible under the active filters. The text query and the
+ * status set compose as AND on leaves: a leaf matches when its own (or an
+ * ancestor's) name contains the query and its status is in the set. Ancestors
+ * of a match stay visible for path context and are force-expanded so the
+ * match is actually on screen; a leaf that only inherited its ancestor's name
+ * match doesn't force anything open.
+ */
+export function computeMatches(files: TestNode[], query: string, statuses: ReadonlySet<TestStatus> = new Set()): Matches {
   const visible = new Set<string>();
   const force = new Set<string>();
-  const addSubtree = (node: TestNode): void => {
-    for (const child of node.children) { visible.add(child.key); addSubtree(child); }
-  };
-  const walk = (node: TestNode, ancestors: string[]): boolean => {
-    const self = displayName(node).toLowerCase().includes(query);
-    let desc = false;
-    for (const child of node.children) if (walk(child, [...ancestors, node.key])) desc = true;
-    if (self || desc) {
+  const statusOk = (node: TestNode): boolean => statuses.size === 0 || statuses.has(node.status);
+  const walk = (node: TestNode, ancestors: string[], inheritedText: boolean): { vis: boolean; own: boolean } => {
+    const selfText = query !== '' && displayName(node).toLowerCase().includes(query);
+    const textOk = query === '' || selfText || inheritedText;
+    let descVis = false;
+    let descOwn = false;
+    for (const child of node.children) {
+      const r = walk(child, [...ancestors, node.key], textOk);
+      descVis ||= r.vis;
+      descOwn ||= r.own;
+    }
+    const leafMatch = node.children.length === 0 && textOk && statusOk(node);
+    if (leafMatch || descVis) {
       visible.add(node.key);
       for (const a of ancestors) visible.add(a);
-      if (desc) { force.add(node.key); for (const a of ancestors) force.add(a); }
-      if (self && node.children.length > 0) addSubtree(node);
-      return true;
     }
-    return false;
+    // Expand the path to nodes matched in their own right (a name hit, or a
+    // status hit under an active status filter) — not to leaves merely swept
+    // in by a container's name match.
+    if (descOwn) force.add(node.key);
+    const own = selfText || (leafMatch && statuses.size > 0) || descOwn;
+    return { vis: leafMatch || descVis, own };
   };
-  for (const file of files) walk(file, []);
+  for (const file of files) walk(file, [], false);
   return { visible, force };
 }
 
 export interface BuildOptions {
   overrides: Map<string, boolean>;
   query: string;
+  statuses?: ReadonlySet<TestStatus>;
   matches: Matches | null;
 }
 
+function filtering(opts: BuildOptions): boolean {
+  return opts.query !== '' || (opts.statuses?.size ?? 0) > 0;
+}
+
 export function isExpanded(node: TestNode, opts: BuildOptions): boolean {
-  if (opts.query && opts.matches?.force.has(node.key)) return true;
+  if (filtering(opts) && opts.matches?.force.has(node.key)) return true;
   const { overrides } = opts;
   return overrides.has(node.key) ? overrides.get(node.key)! : defaultExpanded(node);
 }
@@ -146,7 +166,7 @@ export function isDiagOpen(node: TestNode, overrides: Map<string, boolean>): boo
 export function buildRows(files: TestNode[], opts: BuildOptions): FlatRow[] {
   const rows: FlatRow[] = [];
   const push = (node: TestNode, depth: number): void => {
-    if (opts.query && !opts.matches!.visible.has(node.key)) return;
+    if (filtering(opts) && !opts.matches!.visible.has(node.key)) return;
     const container = isContainer(node);
     const expanded = container && isExpanded(node, opts);
     // A container (a file or suite) can still carry its own output — e.g.

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -113,7 +113,9 @@ button { font-family: inherit; } input { font-family: inherit; }
 .verdict-main { font-size: 15px; font-weight: 700; letter-spacing: .01em; }
 .verdict-sub { font-size: 11px; opacity: .85; }
 .chips { display: flex; gap: 7px; align-items: center; flex-wrap: wrap; }
-.chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+.chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; border: 1px solid transparent; cursor: pointer; font-family: inherit; }
+.chip:hover { filter: brightness(1.12); }
+.chip[data-active] { border-color: currentColor; }
 .chip-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
 .chip-label { opacity: .7; font-weight: 500; }
 .tools { margin-left: auto; display: flex; gap: 9px; align-items: center; }

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -214,3 +214,61 @@ test('isPassingTodo flags only a passed leaf that still carries the todo directi
   const child = node({ key: 'c', status: 'passed', todo: true });
   assert.strictEqual(isPassingTodo(node({ status: 'passed', todo: true, children: [child] })), false, 'containers are not badged');
 });
+
+function tree() {
+  // file > suite > [failed leaf, passed leaf], plus a second file with a todo leaf
+  const failed = node({ key: 'f1', name: 'breaks', status: 'failed' });
+  const passed = node({ key: 'p1', name: 'works', status: 'passed' });
+  const suite = node({
+    key: 's1', name: 'suite one', type: 'suite', status: 'failed', children: [failed, passed],
+    counts: { ...zeroCounts(), failed: 1, passed: 1, total: 2 },
+  });
+  const fileA = node({
+    key: 'fa', type: 'file', file: '/a.test.js', children: [suite],
+    counts: { ...zeroCounts(), failed: 1, passed: 1, total: 2 },
+  });
+  const todo = node({ key: 't1', name: 'unfinished', status: 'todo' });
+  const fileB = node({
+    key: 'fb', type: 'file', file: '/b.test.js', children: [todo],
+    counts: { ...zeroCounts(), todo: 1, total: 1 },
+  });
+  return [fileA, fileB];
+}
+
+test('a status filter shows matching leaves with their ancestors, force-expanded', () => {
+  const files = tree();
+  const matches = computeMatches(files, '', new Set(['failed']));
+  assert.deepStrictEqual([...matches.visible].sort(), ['f1', 'fa', 's1']);
+  assert.ok(matches.force.has('fa') && matches.force.has('s1'), 'ancestors of a match are force-expanded');
+  const rows = buildRows(files, { overrides: new Map(), query: '', statuses: new Set(['failed']), matches });
+  assert.deepStrictEqual(rows.map((r) => r.node.key), ['fa', 's1', 'f1']);
+});
+
+test('multiple statuses union their matches', () => {
+  const files = tree();
+  const matches = computeMatches(files, '', new Set(['failed', 'todo']));
+  assert.deepStrictEqual([...matches.visible].sort(), ['f1', 'fa', 'fb', 's1', 't1']);
+});
+
+test('a status filter composes with the text query as AND', () => {
+  const files = tree();
+  const both = computeMatches(files, 'works', new Set(['failed']));
+  assert.deepStrictEqual([...both.visible], [], 'no leaf is both failed and named "works"');
+  const match = computeMatches(files, 'breaks', new Set(['failed']));
+  assert.deepStrictEqual([...match.visible].sort(), ['f1', 'fa', 's1']);
+});
+
+test('an empty status set leaves the tree unfiltered', () => {
+  const files = tree();
+  const rows = buildRows(files, {
+    overrides: new Map(), query: '', statuses: new Set(), matches: null,
+  });
+  assert.strictEqual(rows.length, 6, 'all nodes render');
+});
+
+test('a container name match under a status filter shows only matching leaves beneath it', () => {
+  const files = tree();
+  const matches = computeMatches(files, 'suite one', new Set(['passed']));
+  assert.ok(matches.visible.has('p1'), 'passed leaf under the matched suite is visible');
+  assert.ok(!matches.visible.has('f1'), 'failed leaf is filtered out despite the container name match');
+});


### PR DESCRIPTION
## Change

The header stat chips (`223 passed / 4 failed / 10 skipped / 4 todo`, plus `running`/`queued` during live runs) are now multi-select toggle buttons:

- Clicking a chip filters the tree to leaves with that status, keeping their ancestor path visible and force-expanded — so every match is on screen with context.
- Multiple chips union (e.g. failed + todo); clicking an active chip clears it; no active chips = unfiltered.
- Composes with the text filter as AND (status ∧ name match), reusing the same `computeMatches` visibility machinery.
- Active chips get a border + `aria-pressed`; buttons are keyboard-operable natively.

`computeMatches` internally now tracks "matched in its own right" separately from "swept in by a container's name match", which preserves the existing force-expansion semantics for text search exactly (guarded by the pre-existing tests) while extending them to statuses.

## Verification

New rowModel tests: status-only filtering with force-expanded ancestors, multi-status union, AND-composition with the text query, empty-set no-op, and container-name-match + status interaction. Full suite 253/253, statements 100%.

Exercised in the built viewer against a real 40-file run: clicking `failed` narrows 97 rows to the 4 failed leaves with their paths; `failed`+`todo` unions in the failing todos; toggling off restores the full tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)