### PR TITLE
feat(web): richer diagnostics rendering in the viewer

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -11,6 +11,9 @@ import {
 // node:test captures colored output verbatim; render the ANSI SGR codes as real
 // colors (mapped to the theme's --ansi-* vars) rather than stripping them.
 import { AnsiHtml } from 'fancy-ansi/react';
+import {
+  classifyStack, extractLevel, levelSeverity, splitUrls,
+} from './format.ts';
 
 const GLYPH: Record<TestStatus, string> = {
   passed: '✓', failed: '✕', skipped: '⊘', todo: '◇', running: '◐', queued: '○',
@@ -23,7 +26,9 @@ const STATUS_LABEL: Record<TestStatus, string> = {
 /** Severity of a test's diagnostics, for the row badge tint. */
 function diagSeverity(node: TestNode): TestStatus {
   if (realError(node) || node.stderr.length > 0) return 'failed';
-  if (node.diagnostics.some((d) => d.level === 'warn')) return 'running';
+  const sevs = node.diagnostics.map((d) => levelSeverity(extractLevel(d.message) ?? d.level));
+  if (sevs.includes('failed')) return 'failed';
+  if (sevs.includes('running')) return 'running';
   return 'skipped';
 }
 
@@ -56,6 +61,59 @@ function outputLines(node: TestNode): OutLine[] {
   return lines;
 }
 
+function linkifyDom(rootEl: HTMLElement): void {
+  const walker = document.createTreeWalker(rootEl, NodeFilter.SHOW_TEXT);
+  const textNodes: Text[] = [];
+  for (let n = walker.nextNode(); n; n = walker.nextNode()) {
+    if (!n.parentElement?.closest('a')) textNodes.push(n as Text);
+  }
+  for (const textNode of textNodes) {
+    const segments = splitUrls(textNode.data);
+    if (!segments.some((s) => s.kind === 'url')) continue;
+    const frag = document.createDocumentFragment();
+    for (const seg of segments) {
+      if (seg.kind === 'url') {
+        const a = document.createElement('a');
+        a.href = seg.text;
+        a.target = '_blank';
+        a.rel = 'noreferrer';
+        a.textContent = seg.text;
+        frag.appendChild(a);
+      } else {
+        frag.appendChild(document.createTextNode(seg.text));
+      }
+    }
+    textNode.replaceWith(frag);
+  }
+}
+
+// AnsiHtml plus a DOM post-pass that wraps http(s) URLs in links — post-render
+// so ANSI color state stays intact across the link boundary.
+function Ansi({ text }: { text: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  useEffect(() => { if (ref.current) linkifyDom(ref.current); });
+  return <span ref={ref}><AnsiHtml text={text} /></span>;
+}
+
+function Stack({ stack }: { stack: string }) {
+  return (
+    <pre className="stack">
+      {classifyStack(stack).map((line, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <div className="stack-line" data-kind={line.kind} key={i}>
+          {line.loc ? (
+            <>
+              {line.loc.pre}
+              <span className="stack-loc">{line.loc.location}</span>
+              {line.loc.post}
+            </>
+          ) : (line.text === '' ? ' ' : line.text)}
+        </div>
+      ))}
+    </pre>
+  );
+}
+
 // At most three sections per test — Error, Output, Diagnostics (plus a reason
 // for skipped/todo). stdout+stderr collapse into one Output block; text keeps
 // its ANSI (colored at render); synthetic container rollups never render an Error.
@@ -75,11 +133,10 @@ function diagBlocks(node: TestNode): DiagBlock[] {
   if (node.diagnostics.length > 0) {
     blocks.push({
       key: 'diag', title: 'Diagnostics', icon: '◇', sev: 'skipped', kind: 'list',
-      items: node.diagnostics.map((d) => ({
-        level: d.level,
-        sev: d.level === 'error' ? 'failed' : d.level === 'warn' ? 'running' : 'skipped',
-        text: d.message,
-      })),
+      items: node.diagnostics.map((d) => {
+        const level = extractLevel(d.message) ?? d.level;
+        return { level, sev: levelSeverity(level), text: d.message };
+      }),
     });
   }
   const reason = reasonOf(node);
@@ -138,8 +195,8 @@ function Diagnostics({ node, indent }: { node: TestNode; indent: string }) {
             </div>
             {block.kind === 'error' ? (
               <>
-                <div className="diag-msg" data-stc="failed"><AnsiHtml text={block.message!} /></div>
-                <pre className="stack"><AnsiHtml text={block.stack!} /></pre>
+                <div className="diag-msg" data-stc="failed"><Ansi text={block.message!} /></div>
+                <Stack stack={block.stack!} />
               </>
             ) : null}
             {block.kind === 'output' ? (
@@ -147,20 +204,20 @@ function Diagnostics({ node, indent }: { node: TestNode; indent: string }) {
                 {block.lines!.map((line, i) => (
                   // eslint-disable-next-line react/no-array-index-key
                   <div className="out-line" data-err={line.stream === 'err' ? 'true' : undefined} key={i}>
-                    <AnsiHtml text={line.text === '' ? ' ' : line.text} />
+                    <Ansi text={line.text === '' ? ' ' : line.text} />
                   </div>
                 ))}
               </div>
             ) : null}
             {block.kind === 'text' ? (
-              <pre className="text"><AnsiHtml text={block.text!} /></pre>
+              <pre className="text"><Ansi text={block.text!} /></pre>
             ) : null}
             {block.kind === 'list' ? (
               <div className="diag-list">
                 {block.items!.map((item, i) => (
                   <div className="diag-item" key={i}>
                     <span className="diag-level" data-soft={item.sev}>{item.level}</span>
-                    <span className="txt"><AnsiHtml text={item.text} /></span>
+                    <span className="txt"><Ansi text={item.text} /></span>
                   </div>
                 ))}
               </div>

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -12,7 +12,7 @@ import {
 // colors (mapped to the theme's --ansi-* vars) rather than stripping them.
 import { AnsiHtml } from 'fancy-ansi/react';
 import {
-  classifyStack, extractLevel, levelSeverity, splitUrls,
+  classifyFrame, classifyStack, extractLevel, levelSeverity, splitUrls, type StackLine,
 } from './format.ts';
 
 const GLYPH: Record<TestStatus, string> = {
@@ -87,12 +87,36 @@ function linkifyDom(rootEl: HTMLElement): void {
   }
 }
 
+const FrameText = ({ frame }: { frame: StackLine }) => (frame.loc ? (
+  <>
+    {frame.loc.pre}
+    <span className="stack-loc">{frame.loc.location}</span>
+    {frame.loc.post}
+  </>
+) : <>{frame.text === '' ? ' ' : frame.text}</>);
+
 // AnsiHtml plus a DOM post-pass that wraps http(s) URLs in links — post-render
-// so ANSI color state stays intact across the link boundary.
+// so ANSI color state stays intact across the link boundary. Lines that look
+// like stack frames (also inside log messages) get node-style frame coloring.
 function Ansi({ text }: { text: string }) {
   const ref = useRef<HTMLSpanElement>(null);
   useEffect(() => { if (ref.current) linkifyDom(ref.current); });
-  return <span ref={ref}><AnsiHtml text={text} /></span>;
+  return (
+    <span ref={ref}>
+      {text.split('\n').map((line, i) => {
+        const frame = classifyFrame(line);
+        return (
+          // eslint-disable-next-line react/no-array-index-key
+          <React.Fragment key={i}>
+            {i > 0 ? '\n' : null}
+            {frame ? (
+              <span className="frame" data-kind={frame.kind}><FrameText frame={frame} /></span>
+            ) : <AnsiHtml text={line} />}
+          </React.Fragment>
+        );
+      })}
+    </span>
+  );
 }
 
 function Stack({ stack }: { stack: string }) {
@@ -101,13 +125,7 @@ function Stack({ stack }: { stack: string }) {
       {classifyStack(stack).map((line, i) => (
         // eslint-disable-next-line react/no-array-index-key
         <div className="stack-line" data-kind={line.kind} key={i}>
-          {line.loc ? (
-            <>
-              {line.loc.pre}
-              <span className="stack-loc">{line.loc.location}</span>
-              {line.loc.post}
-            </>
-          ) : (line.text === '' ? ' ' : line.text)}
+          <FrameText frame={line} />
         </div>
       ))}
     </pre>

--- a/packages/web/src/client/format.ts
+++ b/packages/web/src/client/format.ts
@@ -1,0 +1,22 @@
+import type { TestStatus } from '@reporters/tree-core';
+
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /\[[0-9;]*m/g;
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, '');
+}
+
+const LEVEL_RE = /^\s*(?:\[[^\]]*\]\s*)?(trace|debug|info|warn|warning|error|fatal)\s*:/i;
+
+/** Best-effort log level from a leading `[time] LEVEL:` / `LEVEL:` prefix, else null. */
+export function extractLevel(message: string): string | null {
+  const match = stripAnsi(message).match(LEVEL_RE);
+  return match ? match[1].toLowerCase() : null;
+}
+
+export function levelSeverity(level: string): TestStatus {
+  if (level === 'error' || level === 'fatal') return 'failed';
+  if (level === 'warn' || level === 'warning') return 'running';
+  return 'skipped';
+}

--- a/packages/web/src/client/format.ts
+++ b/packages/web/src/client/format.ts
@@ -15,6 +15,34 @@ export function extractLevel(message: string): string | null {
   return match ? match[1].toLowerCase() : null;
 }
 
+export interface StackLine {
+  text: string;
+  kind: 'head' | 'frame' | 'internal';
+  loc?: { pre: string; location: string; post: string };
+}
+
+const FRAME_RE = /^\s+at\s/;
+const INTERNAL_RE = /\(node:|\snode:|node_modules[/\\]/;
+const LOC_RE = /((?:file:\/\/)?[^()\s]+:\d+:\d+)/;
+
+export function classifyStack(stack: string): StackLine[] {
+  return stripAnsi(stack).split('\n').map((text) => {
+    if (!FRAME_RE.test(text)) return { text, kind: 'head' as const };
+    if (INTERNAL_RE.test(text)) return { text, kind: 'internal' as const };
+    const match = text.match(LOC_RE);
+    if (!match || match.index === undefined) return { text, kind: 'frame' as const };
+    return {
+      text,
+      kind: 'frame' as const,
+      loc: {
+        pre: text.slice(0, match.index),
+        location: match[1],
+        post: text.slice(match.index + match[1].length),
+      },
+    };
+  });
+}
+
 export function levelSeverity(level: string): TestStatus {
   if (level === 'error' || level === 'fatal') return 'failed';
   if (level === 'warn' || level === 'warning') return 'running';

--- a/packages/web/src/client/format.ts
+++ b/packages/web/src/client/format.ts
@@ -25,22 +25,26 @@ const FRAME_RE = /^\s+at\s/;
 const INTERNAL_RE = /\(node:|\snode:|node_modules[/\\]/;
 const LOC_RE = /((?:file:\/\/)?[^()\s]+:\d+:\d+)/;
 
+/** Classify a single line as a stack frame (dimmed internals, located user code), or null. */
+export function classifyFrame(line: string): StackLine | null {
+  const text = stripAnsi(line);
+  if (!FRAME_RE.test(text)) return null;
+  if (INTERNAL_RE.test(text)) return { text, kind: 'internal' };
+  const match = text.match(LOC_RE);
+  if (!match || match.index === undefined) return { text, kind: 'frame' };
+  return {
+    text,
+    kind: 'frame',
+    loc: {
+      pre: text.slice(0, match.index),
+      location: match[1],
+      post: text.slice(match.index + match[1].length),
+    },
+  };
+}
+
 export function classifyStack(stack: string): StackLine[] {
-  return stripAnsi(stack).split('\n').map((text) => {
-    if (!FRAME_RE.test(text)) return { text, kind: 'head' as const };
-    if (INTERNAL_RE.test(text)) return { text, kind: 'internal' as const };
-    const match = text.match(LOC_RE);
-    if (!match || match.index === undefined) return { text, kind: 'frame' as const };
-    return {
-      text,
-      kind: 'frame' as const,
-      loc: {
-        pre: text.slice(0, match.index),
-        location: match[1],
-        post: text.slice(match.index + match[1].length),
-      },
-    };
-  });
+  return stripAnsi(stack).split('\n').map((text) => classifyFrame(text) ?? { text, kind: 'head' as const });
 }
 
 export function levelSeverity(level: string): TestStatus {

--- a/packages/web/src/client/format.ts
+++ b/packages/web/src/client/format.ts
@@ -48,3 +48,19 @@ export function levelSeverity(level: string): TestStatus {
   if (level === 'warn' || level === 'warning') return 'running';
   return 'skipped';
 }
+
+export interface TextSegment { kind: 'text' | 'url'; text: string; }
+
+const URL_RE = /https?:\/\/[^\s"'<>()\][]+/g;
+
+export function splitUrls(text: string): TextSegment[] {
+  const segments: TextSegment[] = [];
+  let last = 0;
+  for (const match of text.matchAll(URL_RE)) {
+    if (match.index > last) segments.push({ kind: 'text', text: text.slice(last, match.index) });
+    segments.push({ kind: 'url', text: match[0] });
+    last = match.index + match[0].length;
+  }
+  if (last < text.length || segments.length === 0) segments.push({ kind: 'text', text: text.slice(last) });
+  return segments;
+}

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -164,7 +164,9 @@ button { font-family: inherit; } input { font-family: inherit; }
 .diag-msg { padding: 0 14px; }
 .diag-msg span { font-size: 13px; font-weight: 600; }
 .diag pre { margin: 0; font-family: var(--mono); font-size: 11.5px; line-height: 1.55; }
-.diag pre.stack { padding: 2px 14px 13px; color: var(--dim); overflow-x: auto; white-space: pre; }
+.diag pre.stack { padding: 2px 14px 13px; color: var(--fg); overflow-x: auto; white-space: pre; }
+.stack-line[data-kind="internal"] { color: var(--faint); }
+.stack-loc { color: var(--ansi-cyan); }
 .diag pre.text { padding: 2px 14px 13px; color: var(--fg); overflow-x: auto; white-space: pre-wrap; word-break: break-word; }
 /* merged stdout+stderr: one block, per-line stream tagging */
 .out { padding: 4px 14px 12px; }
@@ -173,7 +175,9 @@ button { font-family: inherit; } input { font-family: inherit; }
 .diag-list { padding: 2px 14px 12px; display: flex; flex-direction: column; gap: 6px; }
 .diag-item { font-size: 12.5px; color: var(--fg); display: flex; gap: 9px; align-items: baseline; }
 .diag-level { font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; flex: none; border-radius: 5px; padding: 1px 6px; }
-.diag-item .txt { font-family: var(--mono); font-size: 12px; }
+.diag-item .txt { font-family: var(--mono); font-size: 12px; white-space: pre-wrap; word-break: break-word; }
+.diag a { color: var(--st-todo); text-decoration: underline; text-underline-offset: 2px; word-break: break-all; }
+.diag a:hover { filter: brightness(1.15); }
 
 /* full-tree states */
 .state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 13px; padding: 66px 20px; text-align: center; }

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -165,7 +165,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 .diag-msg span { font-size: 13px; font-weight: 600; }
 .diag pre { margin: 0; font-family: var(--mono); font-size: 11.5px; line-height: 1.55; }
 .diag pre.stack { padding: 2px 14px 13px; color: var(--fg); overflow-x: auto; white-space: pre; }
-.stack-line[data-kind="internal"] { color: var(--faint); }
+.stack-line[data-kind="internal"], .frame[data-kind="internal"] { color: var(--faint); }
 .stack-loc { color: var(--ansi-cyan); }
 .diag pre.text { padding: 2px 14px 13px; color: var(--fg); overflow-x: auto; white-space: pre-wrap; word-break: break-word; }
 /* merged stdout+stderr: one block, per-line stream tagging */

--- a/packages/web/tests/format.test.ts
+++ b/packages/web/tests/format.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import {
-  classifyStack, extractLevel, levelSeverity, splitUrls, stripAnsi,
+  classifyFrame, classifyStack, extractLevel, levelSeverity, splitUrls, stripAnsi,
 } from '../src/client/format.ts';
 
 test('stripAnsi removes SGR codes', () => {
@@ -56,6 +56,22 @@ test('classifyStack: frame without parseable location stays plain', () => {
   const lines = classifyStack('    at <anonymous>');
   assert.strictEqual(lines[0].kind, 'frame');
   assert.strictEqual(lines[0].loc, undefined);
+});
+
+test('classifyFrame: frame lines inside log text are classified, others null', () => {
+  assert.strictEqual(classifyFrame('cacheKey: "256965e5"'), null);
+  assert.strictEqual(classifyFrame('Error: Simulated 504'), null);
+  const internal = classifyFrame('        at Test.run (node:internal/test_runner/test:1382:25)');
+  assert.strictEqual(internal?.kind, 'internal');
+  const user = classifyFrame('        at failOnce (file:///runner/t.test.ts:52:15)');
+  assert.strictEqual(user?.kind, 'frame');
+  assert.strictEqual(user?.loc?.location, 'file:///runner/t.test.ts:52:15');
+});
+
+test('classifyFrame: strips ANSI before matching', () => {
+  const frame = classifyFrame('    at f (\u001b[36m/repo/a.ts:1:2\u001b[39m)');
+  assert.strictEqual(frame?.kind, 'frame');
+  assert.strictEqual(frame?.loc?.location, '/repo/a.ts:1:2');
 });
 
 test('splitUrls: extracts http(s) URLs, keeps surrounding text', () => {

--- a/packages/web/tests/format.test.ts
+++ b/packages/web/tests/format.test.ts
@@ -1,7 +1,7 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import {
-  classifyStack, extractLevel, levelSeverity, stripAnsi,
+  classifyStack, extractLevel, levelSeverity, splitUrls, stripAnsi,
 } from '../src/client/format.ts';
 
 test('stripAnsi removes SGR codes', () => {
@@ -56,6 +56,31 @@ test('classifyStack: frame without parseable location stays plain', () => {
   const lines = classifyStack('    at <anonymous>');
   assert.strictEqual(lines[0].kind, 'frame');
   assert.strictEqual(lines[0].loc, undefined);
+});
+
+test('splitUrls: extracts http(s) URLs, keeps surrounding text', () => {
+  assert.deepStrictEqual(splitUrls('logs: "https://app.example.com/logs?a=%22b%22&c=1" done'), [
+    { kind: 'text', text: 'logs: "' },
+    { kind: 'url', text: 'https://app.example.com/logs?a=%22b%22&c=1' },
+    { kind: 'text', text: '" done' },
+  ]);
+});
+
+test('splitUrls: no URLs yields single text segment', () => {
+  assert.deepStrictEqual(splitUrls('plain text'), [{ kind: 'text', text: 'plain text' }]);
+});
+
+test('splitUrls: URL at start and end, multiple URLs', () => {
+  assert.deepStrictEqual(splitUrls('https://a.io and http://b.io'), [
+    { kind: 'url', text: 'https://a.io' },
+    { kind: 'text', text: ' and ' },
+    { kind: 'url', text: 'http://b.io' },
+  ]);
+});
+
+test('splitUrls: does not swallow closing quotes/brackets', () => {
+  const [seg] = splitUrls('https://a.io/x)');
+  assert.deepStrictEqual(seg, { kind: 'url', text: 'https://a.io/x' });
 });
 
 test('levelSeverity maps levels to status tints', () => {

--- a/packages/web/tests/format.test.ts
+++ b/packages/web/tests/format.test.ts
@@ -1,6 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
-import { extractLevel, levelSeverity, stripAnsi } from '../src/client/format.ts';
+import {
+  classifyStack, extractLevel, levelSeverity, stripAnsi,
+} from '../src/client/format.ts';
 
 test('stripAnsi removes SGR codes', () => {
   assert.strictEqual(stripAnsi('[32mINFO[39m: hi'), 'INFO: hi');
@@ -21,6 +23,39 @@ test('extractLevel: non-matching free text returns null', () => {
   assert.strictEqual(extractLevel('tests 4'), null);
   assert.strictEqual(extractLevel('duration_ms 2.5'), null);
   assert.strictEqual(extractLevel('the error: was handled'), null);
+});
+
+test('classifyStack: head, user frame with location split, internal frames', () => {
+  const stack = [
+    'Error: Test not implemented',
+    '    at TestContext.<anonymous> (/Users/me/repos/app/a.test.js:4:11)',
+    '    at Test.runInAsyncScope (node:async_hooks:226:14)',
+    '    at Test.run (node:internal/test_runner/test:1382:25)',
+    '    at fn (/repo/node_modules/lib/index.js:1:1)',
+  ].join('\n');
+  const lines = classifyStack(stack);
+  assert.strictEqual(lines[0].kind, 'head');
+  assert.strictEqual(lines[1].kind, 'frame');
+  assert.deepStrictEqual(lines[1].loc, {
+    pre: '    at TestContext.<anonymous> (',
+    location: '/Users/me/repos/app/a.test.js:4:11',
+    post: ')',
+  });
+  assert.strictEqual(lines[2].kind, 'internal');
+  assert.strictEqual(lines[3].kind, 'internal');
+  assert.strictEqual(lines[4].kind, 'internal');
+});
+
+test('classifyStack: file:// URLs in frames are located', () => {
+  const lines = classifyStack('    at failOnce (file:///runner/_work/app/t.test.ts:52:15)');
+  assert.strictEqual(lines[0].kind, 'frame');
+  assert.strictEqual(lines[0].loc?.location, 'file:///runner/_work/app/t.test.ts:52:15');
+});
+
+test('classifyStack: frame without parseable location stays plain', () => {
+  const lines = classifyStack('    at <anonymous>');
+  assert.strictEqual(lines[0].kind, 'frame');
+  assert.strictEqual(lines[0].loc, undefined);
 });
 
 test('levelSeverity maps levels to status tints', () => {

--- a/packages/web/tests/format.test.ts
+++ b/packages/web/tests/format.test.ts
@@ -1,0 +1,33 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { extractLevel, levelSeverity, stripAnsi } from '../src/client/format.ts';
+
+test('stripAnsi removes SGR codes', () => {
+  assert.strictEqual(stripAnsi('[32mINFO[39m: hi'), 'INFO: hi');
+});
+
+test('extractLevel: pino-style timestamped prefix with ANSI', () => {
+  assert.strictEqual(extractLevel('[12:44:42.549] [31mERROR[39m: Cached operation failed'), 'error');
+  assert.strictEqual(extractLevel('[12:44:42.550] [33mWARN[39m: Error during caching'), 'warn');
+  assert.strictEqual(extractLevel('[12:44:42.778] [32mINFO[39m: [36mTest context initialized[39m'), 'info');
+});
+
+test('extractLevel: bare level prefix', () => {
+  assert.strictEqual(extractLevel('WARNING: disk almost full'), 'warning');
+  assert.strictEqual(extractLevel('debug: verbose detail'), 'debug');
+});
+
+test('extractLevel: non-matching free text returns null', () => {
+  assert.strictEqual(extractLevel('tests 4'), null);
+  assert.strictEqual(extractLevel('duration_ms 2.5'), null);
+  assert.strictEqual(extractLevel('the error: was handled'), null);
+});
+
+test('levelSeverity maps levels to status tints', () => {
+  assert.strictEqual(levelSeverity('error'), 'failed');
+  assert.strictEqual(levelSeverity('fatal'), 'failed');
+  assert.strictEqual(levelSeverity('warn'), 'running');
+  assert.strictEqual(levelSeverity('warning'), 'running');
+  assert.strictEqual(levelSeverity('info'), 'skipped');
+  assert.strictEqual(levelSeverity('debug'), 'skipped');
+});


### PR DESCRIPTION
## Summary

Diagnostic messages arriving over NDJSON already carry ANSI colors and real newlines (e.g. pino-style logs), but the viewer flattened them into a single grey line. This PR makes the Diagnostics/Error/Output sections render them faithfully:

- **Line breaks respected** — `.diag-item .txt` now uses `pre-wrap`, so multi-line diagnostics keep their newlines and indentation.
- **Best-effort log-level extraction** — node:test hardcodes `level: "info"` on every `t.diagnostic()`, so a leading `[timestamp] LEVEL:` / `LEVEL:` prefix (ANSI-stripped) is parsed out of the message. The badge and severity tint show the real level (ERROR red, WARN amber), and a test row's Details badge tints accordingly. Non-matching messages are untouched; message text is never altered.
- **Node-style stack coloring** — stacks render line-by-line like modern node: `node:`/`node_modules` frames dimmed, user frames bright with the `file:line:column` location in cyan. Applies to the Error section and to stack traces embedded inside log messages.
- **URLs are links** — `http(s)` URLs in diagnostics/output become `<a target="_blank" rel="noreferrer">` via a DOM post-pass after the ANSI renderer, so ANSI color state stays intact across link boundaries.

Before/after (real CI report):

| before | after |
| --- | --- |
| one flattened INFO line per diagnostic | multiline, level badges, dimmed internal frames, clickable links |

## Testing

- New unit tests for the level extractor, stack-line classifier, and URL splitter (`packages/web/tests/format.test.ts`); full `packages/web` suite passes (76).
- Verified in a browser against a 241-test CI NDJSON report (multiline pino logs, embedded stacks, groundcover URLs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)