### PR TITLE
feat(web): distinct loading state before the first log fetch resolves

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -569,13 +569,15 @@ function Verdict({ counts, inProgress, duration }: { counts: Counts; inProgress:
 }
 
 function CenteredState({
-  icon, iconStatus, pulse, title, children,
+  icon, iconStatus, pulse, spin, title, children,
 }: {
-  icon: string; iconStatus: TestStatus; pulse?: boolean; title: string; children?: React.ReactNode;
+  icon: string; iconStatus: TestStatus; pulse?: boolean; spin?: boolean; title: string; children?: React.ReactNode;
 }) {
   return (
     <div className="state">
-      <div className="state-icon" data-soft={iconStatus} data-pulse={pulse ? 'true' : undefined}>{icon}</div>
+      <div className="state-icon" data-soft={iconStatus} data-pulse={pulse ? 'true' : undefined}>
+        {spin ? <span data-spin="true">{icon}</span> : icon}
+      </div>
       <div className="state-title">{title}</div>
       {children}
     </div>
@@ -586,13 +588,15 @@ export interface TreeViewProps {
   snapshot: TreeSnapshot;
   /** The viewer is still polling a live log (no final summary yet). */
   streaming?: boolean;
+  /** The first fetch of the log hasn't resolved yet — we don't know if there are results. */
+  pending?: boolean;
   /** The viewer's `?src=` is missing or unreachable. */
   loadError?: boolean;
   onRetry?: () => void;
 }
 
 export function TreeView({
-  snapshot, streaming = false, loadError = false, onRetry,
+  snapshot, streaming = false, pending = false, loadError = false, onRetry,
 }: TreeViewProps) {
   const [theme, toggleTheme] = useTheme();
   const [query, setQuery] = useState('');
@@ -804,6 +808,8 @@ export function TreeView({
               Clear filters
             </button>
           </CenteredState>
+        ) : pending ? (
+          <CenteredState icon="◐" iconStatus="running" spin title="Loading test log…" />
         ) : (
           <CenteredState icon="◴" iconStatus="queued" pulse title="Waiting for the first results">
             <div className="state-sub">
@@ -818,9 +824,10 @@ export function TreeView({
         <span className="brand">@reporters/web</span>
         <span>·</span>
         <span>
-          {inProgress ? 'Live · streaming results'
-            : snapshot.summary ? 'Run complete'
-              : rows.length === 0 ? 'Awaiting run' : 'Run complete'}
+          {pending ? 'Loading…'
+            : inProgress ? 'Live · streaming results'
+              : snapshot.summary ? 'Run complete'
+                : rows.length === 0 ? 'Awaiting run' : 'Run complete'}
         </span>
         <span className="legend">
           {STATUS_ORDER.map((s) => (

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -27,10 +27,17 @@ export async function startViewer(options: ViewerOptions = {}): Promise<void> {
 
   let store: TreeStore = createTreeStore();
   let streaming = true;
+  let pending = true;
   let loadError = false;
   const retry = () => window.location.reload();
   const draw = () => root.render(
-    <TreeView snapshot={store.getSnapshot()} streaming={streaming} loadError={loadError} onRetry={retry} />,
+    <TreeView
+      snapshot={store.getSnapshot()}
+      streaming={streaming}
+      pending={pending}
+      loadError={loadError}
+      onRetry={retry}
+    />,
   );
 
   let source;
@@ -54,15 +61,17 @@ export async function startViewer(options: ViewerOptions = {}): Promise<void> {
   for (;;) {
     try {
       const { events, reset } = await reader.pull();
+      const firstCheck = pending;
+      pending = false;
       if (reset) store = createTreeStore();
       for (const event of events) store.apply(event);
       loadError = false;
       if (store.getSnapshot().summary) { streaming = false; draw(); break; }
-      if (events.length || reset) draw();
+      if (events.length || reset || firstCheck) draw();
     } catch (err) {
       // Never received any data yet: the source is missing/unreachable — surface
       // the error screen. Once data has arrived, treat failures as transient.
-      if (store.getSnapshot().root.children.length === 0) { loadError = true; draw(); }
+      if (store.getSnapshot().root.children.length === 0) { pending = false; loadError = true; draw(); }
       console.error(err);
     }
     await delay(source.pollMs);


### PR DESCRIPTION
## Summary
- Show a spinner (`Loading test log…`) while the first fetch of the NDJSON log is still in flight, instead of prematurely showing "Waiting for the first results"
- "Waiting for the first results" now appears only after a completed check found an empty log
- Fixes a redraw gap: a first pull returning zero events never triggered a redraw, leaving the viewer stuck on its initial screen

## Test plan
- [x] `node --test` in `packages/web` (79 tests pass)
- [x] Served the built viewer and verified with Playwright: a hanging source shows the loading spinner with a `Loading…` footer; a reachable-but-empty source shows "Waiting for the first results"

🤖 Generated with [Claude Code](https://claude.com/claude-code)