### PR TITLE
ci: deploy viewer only when @reporters/web is published

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,8 @@ jobs:
         working-directory: packages/${{ steps.package-name.outputs.PACKAGE_NAME }}
 
   deploy-viewer:
-    if: ${{ github.event_name == 'push' || inputs.packages == '' }}
+    needs: release-please
+    if: ${{ always() && ((github.event_name == 'workflow_dispatch' && inputs.packages == '') || (needs.release-please.result == 'success' && contains(fromJson(needs.release-please.outputs.packages || '[]'), '@reporters/web'))) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Gates the `deploy-viewer` job on release-please actually publishing `@reporters/web`, so the hosted viewer version tracks the npm version instead of deploying on every push to main.

- `deploy-viewer` now `needs: release-please` and only runs when `@reporters/web` is in the released-packages list
- Manual `workflow_dispatch` with an empty `packages` input still force-deploys the viewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)