### PR TITLE
fix(web): true live durations via writer stamps on the wire

### DIFF
--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -28,6 +28,7 @@ interface InternalNode {
   type: NodeType;
   status: TestStatus;
   durationMs?: number;
+  startedAt?: number;
   error?: SerializedError;
   diagnostics: TestNode['diagnostics'];
   stdout: string[];
@@ -119,6 +120,12 @@ export function createTreeStore(): TreeStore {
   let autoId = 0;
   let sawFileWrapper = false;
   let summary: SummaryData | undefined;
+  // Wall-clock stamps from the writer (`event.t`). `currentT` is the stamp of
+  // the event being applied, so the helpers that mark a node running can record
+  // when it actually started without threading it through every signature.
+  let firstT: number | undefined;
+  let lastT: number | undefined;
+  let currentT: number | undefined;
   let dirty = true;
   let version = 0;
   let cached: TreeSnapshot | null = null;
@@ -357,7 +364,10 @@ export function createTreeStore(): TreeStore {
     if (!settled) placeInDeclOrder(node);
     settleGroup(node.parentKey!);
     assignFields(node, data);
-    if (!TERMINAL.has(node.status)) node.status = 'running';
+    if (!TERMINAL.has(node.status)) {
+      node.status = 'running';
+      node.startedAt ??= currentT;
+    }
     declOpen.set(nesting, node.key);
     for (const level of [...declOpen.keys()]) if (level > nesting) declOpen.delete(level);
     const nestingMap = lastByGroupNesting.get(gk) ?? new Map<number, string>();
@@ -408,6 +418,7 @@ export function createTreeStore(): TreeStore {
     settleGroup(node.parentKey!);
     assignFields(node, data);
     node.status = 'running';
+    node.startedAt ??= currentT;
 
     open.set(nesting, key);
     lastByNesting.set(nesting, key);
@@ -445,6 +456,11 @@ export function createTreeStore(): TreeStore {
 
   function apply(event: TestEvent): void {
     const { type, data } = event;
+    currentT = event.t;
+    if (event.t != null) {
+      if (firstT == null || event.t < firstT) firstT = event.t;
+      if (lastT == null || event.t > lastT) lastT = event.t;
+    }
     // The wrapper's relative `name` is the spelling stdout/stderr events use for
     // `file`; map it to the resolved absolute path so both group together.
     if (isFileLevel(data) && data.name !== data.file) fileAlias.set(data.name!, data.file!);
@@ -475,6 +491,7 @@ export function createTreeStore(): TreeStore {
         upsertFromTestEvent(data, (node) => {
           if (TERMINAL.has(node.status)) return;
           node.status = type === 'test:dequeue' ? 'running' : 'queued';
+          if (node.status === 'running') node.startedAt ??= currentT;
         });
         break;
       case 'test:start':
@@ -635,6 +652,7 @@ export function createTreeStore(): TreeStore {
       type: internal.type,
       status,
       durationMs: internal.durationMs,
+      startedAt: internal.startedAt,
       error: internal.error,
       diagnostics: internal.diagnostics,
       stdout: internal.stdout,
@@ -653,7 +671,11 @@ export function createTreeStore(): TreeStore {
     if (!dirty && cached) return cached;
     const rootNode = build(ROOT_KEY);
     cached = {
-      version: ++version, root: rootNode, counts: rootNode.counts, summary,
+      version: ++version,
+      root: rootNode,
+      counts: rootNode.counts,
+      summary,
+      ...(firstT != null && lastT != null ? { clock: { firstT, lastT } } : {}),
     };
     dirty = false;
     return cached;

--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -418,7 +418,7 @@ export function createTreeStore(): TreeStore {
     settleGroup(node.parentKey!);
     assignFields(node, data);
     node.status = 'running';
-    node.startedAt ??= currentT;
+    node.startedAt = currentT; // freshly created above — never stamped yet
 
     open.set(nesting, key);
     lastByNesting.set(nesting, key);
@@ -458,8 +458,8 @@ export function createTreeStore(): TreeStore {
     const { type, data } = event;
     currentT = event.t;
     if (event.t != null) {
-      if (firstT == null || event.t < firstT) firstT = event.t;
-      if (lastT == null || event.t > lastT) lastT = event.t;
+      firstT = firstT == null ? event.t : Math.min(firstT, event.t);
+      lastT = lastT == null ? event.t : Math.max(lastT, event.t);
     }
     // The wrapper's relative `name` is the spelling stdout/stderr events use for
     // `file`; map it to the resolved absolute path so both group together.
@@ -675,7 +675,8 @@ export function createTreeStore(): TreeStore {
       root: rootNode,
       counts: rootNode.counts,
       summary,
-      ...(firstT != null && lastT != null ? { clock: { firstT, lastT } } : {}),
+      // firstT and lastT are always set together (same stamped event).
+      ...(firstT != null ? { clock: { firstT, lastT: lastT! } } : {}),
     };
     dirty = false;
     return cached;

--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -377,6 +377,15 @@ export function createTreeStore(): TreeStore {
     recordLastStarted(data, node.key);
   }
 
+  // A finish for a test whose start was never seen (head-truncated log,
+  // mid-run attach) still pins its start: the finish stamp minus the measured
+  // duration is when it really began.
+  function backdateStart(node: InternalNode, data: TestEventData): void {
+    if (node.startedAt == null && currentT != null && data.details?.duration_ms != null) {
+      node.startedAt = currentT - data.details.duration_ms;
+    }
+  }
+
   function declFinalize(status: TestStatus, data: TestEventData): void {
     const gk = groupKey(data);
     const nesting = data.nesting ?? 0;
@@ -384,6 +393,7 @@ export function createTreeStore(): TreeStore {
     const openNode = openKey ? nodes.get(openKey) : undefined;
     const matchesOpen = openNode && openNode.testId === data.testId && openNode.name === data.name;
     const node = matchesOpen ? openNode : eagerInstance(gk, data.testId!, data);
+    backdateStart(node, data);
     assignFields(node, data);
     node.status = status;
     if (data.details?.duration_ms != null) node.durationMs = data.details.duration_ms;
@@ -438,7 +448,15 @@ export function createTreeStore(): TreeStore {
     const gk = groupKey(data);
     const nesting = data.nesting ?? 0;
     const key = pendingByGroupNesting.get(gk)?.get(nesting)?.shift();
-    const node = (key && nodes.get(key)) || stackStart(data);
+    let node = key ? nodes.get(key) : undefined;
+    if (!node) {
+      // No matching open node: this finish IS the first sight of the test, so
+      // the start stamp stackStart put on it (the finish event's clock) is a
+      // duration too late — backdate it.
+      node = stackStart(data);
+      node.startedAt = undefined;
+      backdateStart(node, data);
+    }
     assignFields(node, data);
     node.status = status;
     if (data.details?.duration_ms != null) node.durationMs = data.details.duration_ms;
@@ -520,6 +538,7 @@ export function createTreeStore(): TreeStore {
         if (data.testId == null) break;
         const status = statusFromComplete(data);
         upsertFromTestEvent(data, (node) => {
+          backdateStart(node, data);
           node.status = status;
           if (data.details?.duration_ms != null) node.durationMs = data.details.duration_ms;
           if (data.details?.type != null) node.type = data.details.type === 'suite' ? 'suite' : 'test';

--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -379,10 +379,13 @@ export function createTreeStore(): TreeStore {
 
   // A finish for a test whose start was never seen (head-truncated log,
   // mid-run attach) still pins its start: the finish stamp minus the measured
-  // duration is when it really began.
+  // duration is when it really began. That start is evidence the run was
+  // already underway, so it widens the stream's stamp range too — the header
+  // must never read less than a row it contains.
   function backdateStart(node: InternalNode, data: TestEventData): void {
     if (node.startedAt == null && currentT != null && data.details?.duration_ms != null) {
       node.startedAt = currentT - data.details.duration_ms;
+      if (firstT == null || node.startedAt < firstT) firstT = node.startedAt;
     }
   }
 
@@ -452,8 +455,11 @@ export function createTreeStore(): TreeStore {
     if (!node) {
       // No matching open node: this finish IS the first sight of the test, so
       // the start stamp stackStart put on it (the finish event's clock) is a
-      // duration too late — backdate it.
+      // duration too late — backdate it. And the node is finished the moment
+      // it's born: take back the pending-queue slot stackStart just pushed,
+      // or the NEXT first-sighting finish would merge into this node.
       node = stackStart(data);
+      pendingByGroupNesting.get(gk)!.get(nesting)!.pop();
       node.startedAt = undefined;
       backdateStart(node, data);
     }

--- a/packages/tree-core/src/types.ts
+++ b/packages/tree-core/src/types.ts
@@ -41,6 +41,9 @@ export interface TestNode {
   type: NodeType;
   status: TestStatus;
   durationMs?: number;
+  /** Writer wall-clock (`t` of the event that set it running); viewers diff
+   *  stamps against each other, never against their own clock. */
+  startedAt?: number;
   error?: SerializedError;
   diagnostics: Diagnostic[];
   stdout: string[];
@@ -65,6 +68,10 @@ export interface TreeSnapshot {
   root: TestNode;
   counts: Counts;
   summary?: SummaryData;
+  /** Stamp range of the stream so far — the run's elapsed wall-clock is
+   *  `lastT - firstT`, independent of when a viewer joined. Absent when the
+   *  stream carries no stamps (logs from older writers). */
+  clock?: { firstT: number; lastT: number };
 }
 
 /** The fields of a `node:test` reporter event that the store consumes. */
@@ -96,6 +103,8 @@ export interface TestEventData {
 
 export interface TestEvent {
   type: string;
+  /** Writer wall-clock (epoch ms), stamped when the event is serialized. */
+  t?: number;
   data: TestEventData;
 }
 

--- a/packages/tree-core/src/types.ts
+++ b/packages/tree-core/src/types.ts
@@ -68,9 +68,11 @@ export interface TreeSnapshot {
   root: TestNode;
   counts: Counts;
   summary?: SummaryData;
-  /** Stamp range of the stream so far — the run's elapsed wall-clock is
-   *  `lastT - firstT`, independent of when a viewer joined. Absent when the
-   *  stream carries no stamps (logs from older writers). */
+  /** Stamp range of the run so far — the run's elapsed wall-clock is
+   *  `lastT - firstT`, independent of when a viewer joined. `firstT` reaches
+   *  before the first stamped line when a finish-first node's backdated start
+   *  does (head-truncated log). Absent when the stream carries no stamps
+   *  (logs from older writers). */
   clock?: { firstT: number; lastT: number };
 }
 

--- a/packages/tree-core/src/wire.ts
+++ b/packages/tree-core/src/wire.ts
@@ -51,7 +51,8 @@ export function toWireEvent(event: TestEvent): TestEvent {
 /** Serialize one event as an NDJSON line, stamping the writer wall-clock so
  *  viewers can compute real elapsed times however late they join the stream. */
 export function serializeWireLine(event: TestEvent): string {
-  return `${JSON.stringify(toWireEvent({ t: Date.now(), ...event }))}\n`;
+  const stamped = event.t != null ? event : { ...event, t: Date.now() };
+  return `${JSON.stringify(toWireEvent(stamped))}\n`;
 }
 
 export function parseWireLines(text: string): TestEvent[] {

--- a/packages/tree-core/src/wire.ts
+++ b/packages/tree-core/src/wire.ts
@@ -19,6 +19,7 @@ function flattenError(raw: unknown): unknown {
 export function toWireEvent(event: TestEvent): TestEvent {
   const d = event.data ?? {};
   const data: TestEventData = {};
+  const t = event.t;
   if (d.name != null) data.name = d.name;
   if (d.nesting != null) data.nesting = d.nesting;
   if (d.file != null) data.file = d.file;
@@ -44,11 +45,13 @@ export function toWireEvent(event: TestEvent): TestEvent {
       error: flattenError(d.details.error) as Error | undefined,
     };
   }
-  return { type: event.type, data };
+  return t != null ? { type: event.type, t, data } : { type: event.type, data };
 }
 
+/** Serialize one event as an NDJSON line, stamping the writer wall-clock so
+ *  viewers can compute real elapsed times however late they join the stream. */
 export function serializeWireLine(event: TestEvent): string {
-  return `${JSON.stringify(toWireEvent(event))}\n`;
+  return `${JSON.stringify(toWireEvent({ t: Date.now(), ...event }))}\n`;
 }
 
 export function parseWireLines(text: string): TestEvent[] {

--- a/packages/tree-core/tests/helpers.test.ts
+++ b/packages/tree-core/tests/helpers.test.ts
@@ -63,6 +63,21 @@ test('serializeWireLine produces one parseable JSON line per event', () => {
   assert.strictEqual(JSON.parse(line).type, 'test:pass');
 });
 
+test('serializeWireLine stamps the event with the writer wall-clock', () => {
+  const before = Date.now();
+  const line = serializeWireLine({ type: 'test:pass', data: { name: 't', testId: 1, nesting: 0 } });
+  const after = Date.now();
+  const { t } = JSON.parse(line);
+  assert.strictEqual(typeof t, 'number');
+  assert.ok(t >= before && t <= after);
+});
+
+test('a pre-stamped event keeps its own clock through the wire', () => {
+  const line = serializeWireLine({ type: 'test:pass', t: 12345, data: { name: 't', testId: 1, nesting: 0 } });
+  assert.strictEqual(JSON.parse(line).t, 12345);
+  assert.strictEqual(toWireEvent({ type: 'test:pass', t: 777, data: {} }).t, 777);
+});
+
 test('parseWireLines parses NDJSON and skips blank or truncated lines', () => {
   const text = [
     '{"type":"test:start","data":{"name":"a"}}',

--- a/packages/tree-core/tests/helpers.test.ts
+++ b/packages/tree-core/tests/helpers.test.ts
@@ -78,6 +78,11 @@ test('a pre-stamped event keeps its own clock through the wire', () => {
   assert.strictEqual(toWireEvent({ type: 'test:pass', t: 777, data: {} }).t, 777);
 });
 
+test('an explicit undefined t still gets a fresh stamp', () => {
+  const line = serializeWireLine({ type: 'test:pass', t: undefined, data: { name: 't', testId: 1, nesting: 0 } });
+  assert.strictEqual(typeof JSON.parse(line).t, 'number');
+});
+
 test('parseWireLines parses NDJSON and skips blank or truncated lines', () => {
   const text = [
     '{"type":"test:start","data":{"name":"a"}}',

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -351,6 +351,25 @@ test('a buffered declaration start never moves startedAt off the eager dequeue s
   assert.strictEqual(leaf.startedAt, 500);
 });
 
+test('a replayed dequeue (re-read stream) keeps the original start stamp', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:dequeue', t: 500, data: { name: 't', file: '/a.test.js', nesting: 0, testId: 2, parentId: 0 } },
+    { type: 'test:dequeue', t: 900, data: { name: 't', file: '/a.test.js', nesting: 0, testId: 2, parentId: 0 } },
+  ]);
+  const leaf = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(leaf.startedAt, 500);
+});
+
+test('stackStart stamps testId-free starts (v22-shaped streams)', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', t: 700, data: { name: 'leaf', nesting: 0, file: '/a.test.js' } },
+  ]);
+  const leaf = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(leaf.startedAt, 700);
+});
+
 test('unstamped events leave startedAt and the stream clock unset', () => {
   const store = createTreeStore();
   apply(store, [

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -324,3 +324,39 @@ test('testId-free results settle the node type from details.type (v22-shaped)', 
   assert.strictEqual(group.type, 'suite');
   assert.deepStrictEqual(group.children.map((c) => [c.name, c.type]), [['leaf', 'test']]);
 });
+
+test('stamped events record when each test started and the stream clock', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:enqueue', t: 1000, data: { name: 'a.test.js', file: '/a.test.js', nesting: 0, testId: 1, parentId: 0 } },
+    { type: 'test:dequeue', t: 1005, data: { name: 'a.test.js', file: '/a.test.js', nesting: 0, testId: 1, parentId: 0 } },
+    { type: 'test:enqueue', t: 1010, data: { name: 'slow', file: '/a.test.js', nesting: 0, testId: 2, parentId: 0 } },
+    { type: 'test:dequeue', t: 2000, data: { name: 'slow', file: '/a.test.js', nesting: 0, testId: 2, parentId: 0 } },
+  ]);
+  const snapshot = store.getSnapshot();
+  assert.deepStrictEqual(snapshot.clock, { firstT: 1000, lastT: 2000 });
+  const leaf = snapshot.root.children[0].children[0];
+  assert.strictEqual(leaf.name, 'slow');
+  assert.strictEqual(leaf.status, 'running');
+  assert.strictEqual(leaf.startedAt, 2000, 'startedAt is the stamp of the event that set it running');
+});
+
+test('a buffered declaration start never moves startedAt off the eager dequeue stamp', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:dequeue', t: 500, data: { name: 't', file: '/a.test.js', nesting: 0, testId: 2, parentId: 0 } },
+    { type: 'test:start', t: 9000, data: { name: 't', file: '/a.test.js', nesting: 0, testId: 2, parentId: 0 } },
+  ]);
+  const leaf = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(leaf.startedAt, 500);
+});
+
+test('unstamped events leave startedAt and the stream clock unset', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:dequeue', data: { name: 't', file: '/a.test.js', nesting: 0, testId: 2, parentId: 0 } },
+  ]);
+  const snapshot = store.getSnapshot();
+  assert.strictEqual(snapshot.clock, undefined);
+  assert.strictEqual(snapshot.root.children[0].children[0].startedAt, undefined);
+});

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -361,6 +361,30 @@ test('a replayed dequeue (re-read stream) keeps the original start stamp', () =>
   assert.strictEqual(leaf.startedAt, 500);
 });
 
+test('a finish whose start was never seen backdates startedAt by its duration', () => {
+  // testId-free result with no prior start (head-truncated log / mid-run attach).
+  const stackStore = createTreeStore();
+  apply(stackStore, [
+    { type: 'test:pass', t: 5000, data: { name: 't', nesting: 0, file: '/a.test.js', details: { duration_ms: 1200, type: 'test' } } },
+  ]);
+  assert.strictEqual(stackStore.getSnapshot().root.children[0].children[0].startedAt, 3800);
+
+  // Same for an execution-ordered completion that is the test's first sighting.
+  const completeStore = createTreeStore();
+  apply(completeStore, [
+    { type: 'test:complete', t: 5000, data: { name: 't', nesting: 0, file: '/a.test.js', testId: 2, parentId: 0, details: { duration_ms: 1200, passed: true, type: 'test' } } },
+  ]);
+  assert.strictEqual(completeStore.getSnapshot().root.children[0].children[0].startedAt, 3800);
+});
+
+test('a first-sighting finish without a measured duration stays unstamped', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:pass', t: 5000, data: { name: 't', nesting: 0, file: '/a.test.js', details: { type: 'test' } } },
+  ]);
+  assert.strictEqual(store.getSnapshot().root.children[0].children[0].startedAt, undefined);
+});
+
 test('stackStart stamps testId-free starts (v22-shaped streams)', () => {
   const store = createTreeStore();
   apply(store, [

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -377,10 +377,32 @@ test('a finish whose start was never seen backdates startedAt by its duration', 
   assert.strictEqual(completeStore.getSnapshot().root.children[0].children[0].startedAt, 3800);
 });
 
+test('consecutive first-sighting finishes stay distinct tests', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:pass', t: 5000, data: { name: 'alpha', nesting: 0, file: '/a.test.js', details: { duration_ms: 1200, type: 'test' } } },
+    { type: 'test:pass', t: 5300, data: { name: 'beta', nesting: 0, file: '/a.test.js', details: { duration_ms: 300, type: 'test' } } },
+  ]);
+  const leaves = store.getSnapshot().root.children[0].children;
+  assert.deepStrictEqual(
+    leaves.map((n) => [n.name, n.startedAt, n.durationMs]),
+    [['alpha', 3800, 1200], ['beta', 5000, 300]],
+  );
+});
+
+test('a backdated start widens the stream clock so the run never reads shorter than a test', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:pass', t: 5000, data: { name: 't', nesting: 0, file: '/a.test.js', details: { duration_ms: 1200, type: 'test' } } },
+  ]);
+  assert.deepStrictEqual(store.getSnapshot().clock, { firstT: 3800, lastT: 5000 });
+});
+
 test('a first-sighting finish without a measured duration stays unstamped', () => {
   const store = createTreeStore();
   apply(store, [
-    { type: 'test:pass', t: 5000, data: { name: 't', nesting: 0, file: '/a.test.js', details: { type: 'test' } } },
+    // No nesting either — top-level is the default.
+    { type: 'test:pass', t: 5000, data: { name: 't', file: '/a.test.js', details: { type: 'test' } } },
   ]);
   assert.strictEqual(store.getSnapshot().root.children[0].children[0].startedAt, undefined);
 });

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -676,9 +676,12 @@ export function TreeView({
   // The run summary carries the real wall-clock; while still running, the
   // stream's stamp range IS the run's elapsed time — first stamp to the
   // projected "now" (stamp-less logs fall back to aggregating files, which
-  // ticks with the run).
+  // ticks with the run). Project past the last stamp only while something is
+  // actually running: a stream that dies without a summary must freeze at its
+  // last stamp, not tick forever on the client clock.
+  const headerLead = counts.running > 0 && clock ? now - clock.receivedAt : 0;
   const duration = snapshot.summary?.durationMs
-    ?? (snapshot.clock && clock ? clock.lastT + (now - clock.receivedAt) - snapshot.clock.firstT
+    ?? (snapshot.clock && clock ? clock.lastT + headerLead - snapshot.clock.firstT
       : liveNodeDuration(snapshot.root, now, since, clock));
 
   // Enter-animation bookkeeping: play only for rows first seen during a live run,

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -677,8 +677,11 @@ export function TreeView({
   // stream's stamp range IS the run's elapsed time — first stamp to the
   // projected "now" (stamp-less logs fall back to aggregating files, which
   // ticks with the run). Project past the last stamp only while something is
-  // actually running: a stream that dies without a summary must freeze at its
-  // last stamp, not tick forever on the client clock.
+  // running, so the header ticks exactly when some row ticks: a stream that
+  // dies idle freezes at its last stamp. One that dies mid-test keeps ticking
+  // with its running rows — from the client there is no telling that apart
+  // from a long quiet test. The freeze during a zero-running gap (isolation
+  // spawning the next file) lasts a process spawn and reads as a pause.
   const headerLead = counts.running > 0 && clock ? now - clock.receivedAt : 0;
   const duration = snapshot.summary?.durationMs
     ?? (snapshot.clock && clock ? clock.lastT + headerLead - snapshot.clock.firstT

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -674,9 +674,12 @@ export function TreeView({
   }
   const clock = clockRef.current;
   // The run summary carries the real wall-clock; while still running, the
-  // stamped span of the whole tree is the run's true elapsed time (stamp-less
-  // logs fall back to aggregating files, which ticks with the run).
-  const duration = snapshot.summary?.durationMs ?? liveNodeDuration(snapshot.root, now, since, clock);
+  // stream's stamp range IS the run's elapsed time — first stamp to the
+  // projected "now" (stamp-less logs fall back to aggregating files, which
+  // ticks with the run).
+  const duration = snapshot.summary?.durationMs
+    ?? (snapshot.clock && clock ? clock.lastT + (now - clock.receivedAt) - snapshot.clock.firstT
+      : liveNodeDuration(snapshot.root, now, since, clock));
 
   // Enter-animation bookkeeping: play only for rows first seen during a live run,
   // staggered within each file so a file "unfurls" rather than popping as a slab.

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -5,7 +5,7 @@ import {
   formatDuration, todoLabel, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
 } from '@reporters/tree-core';
 import {
-  buildRows, collectContainerKeys, computeMatches, displayName, isContainer, isSectionOpen, liveNodeDuration, reasonOf, realError, type FlatRow,
+  buildRows, collectContainerKeys, computeMatches, displayName, isContainer, isSectionOpen, liveNodeDuration, reasonOf, realError, type FlatRow, type LiveClock,
 } from './rowModel.ts';
 
 // node:test captures colored output verbatim; render the ANSI SGR codes as real
@@ -467,10 +467,12 @@ interface RowViewProps {
   /** Shared clock (performance.now) + per-node running-start map, for live duration ticking. */
   now: number;
   since: Map<string, number>;
+  /** The stream's stamp clock, when the log carries writer stamps. */
+  clock: LiveClock | null;
 }
 
 function RowView({
-  row, toggle, enter, now, since,
+  row, toggle, enter, now, since, clock,
 }: RowViewProps) {
   const {
     node, depth, status, expandable, expanded, hasDiag,
@@ -544,7 +546,7 @@ function RowView({
           ))}
         </span>
       ) : null}
-      <span className="dur">{formatDuration(liveNodeDuration(node, now, since)) || '—'}</span>
+      <span className="dur">{formatDuration(liveNodeDuration(node, now, since, clock)) || '—'}</span>
     </div>
   );
 }
@@ -613,9 +615,11 @@ export function TreeView({
   // Rows already painted at least once — so we only play the enter animation for
   // rows that newly arrive during a live run, never on every re-render.
   const seenRef = useRef<Set<string>>(new Set());
-  // Client clock (performance.now) at which each node was first seen running, so
-  // running durations tick live between polls.
+  // Client clock (performance.now) at which each node was first seen running —
+  // the live-tick fallback for streams without writer stamps.
   const sinceRef = useRef<Map<string, number>>(new Map());
+  // The newest writer stamp and when it arrived, for stamped streams.
+  const clockRef = useRef<LiveClock | null>(null);
   // A steadily-incrementing tick that drives live duration re-renders.
   const [, setTick] = useState(0);
 
@@ -662,10 +666,17 @@ export function TreeView({
   }, [inProgress]);
   const now = performance.now();
   const since = sinceRef.current;
-  // The run summary carries the real wall-clock; while still running, fall back
-  // to aggregating the files (running leaves count live elapsed, so the header
-  // ticks with the run).
-  const duration = snapshot.summary?.durationMs ?? liveNodeDuration(snapshot.root, now, since);
+  // Fix the stream's stamp clock to the client clock each time a newer stamp
+  // arrives; between polls the pair projects the writer's "now" so counters
+  // tick smoothly without ever measuring against the client's own timeline.
+  if (snapshot.clock && snapshot.clock.lastT !== clockRef.current?.lastT) {
+    clockRef.current = { lastT: snapshot.clock.lastT, receivedAt: now };
+  }
+  const clock = clockRef.current;
+  // The run summary carries the real wall-clock; while still running, the
+  // stamped span of the whole tree is the run's true elapsed time (stamp-less
+  // logs fall back to aggregating files, which ticks with the run).
+  const duration = snapshot.summary?.durationMs ?? liveNodeDuration(snapshot.root, now, since, clock);
 
   // Enter-animation bookkeeping: play only for rows first seen during a live run,
   // staggered within each file so a file "unfurls" rather than popping as a slab.
@@ -788,6 +799,7 @@ export function TreeView({
               enter={enterMap.has(rowKey(row)) ? enterMap.get(rowKey(row))! : null}
               now={now}
               since={since}
+              clock={clock}
             />
           )))
         ) : q || statuses.size > 0 ? (

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -44,6 +44,17 @@ export interface LiveClock {
 }
 
 /**
+ * A descendant that would count toward a duration (running, or measured) but
+ * carries no stamp — a mixed old/new-writer log. A span would silently drop
+ * it, so its container must fall back to summing instead.
+ */
+function hasUnstampedContributor(node: TestNode): boolean {
+  if (node.startedAt == null && !isContainer(node)
+    && (node.status === 'running' || node.durationMs != null)) return true;
+  return node.children.some(hasUnstampedContributor);
+}
+
+/**
  * Wall-clock span of a stamped subtree: earliest descendant start to latest
  * descendant end, where a still-running descendant ends at the projected
  * stream "now". Null when nothing in the subtree carries a stamp.
@@ -91,7 +102,7 @@ export function liveNodeDuration(
   }
   if (node.durationMs != null) return node.durationMs;
   if (!isContainer(node)) return 0;
-  if (streamNow != null) {
+  if (streamNow != null && !hasUnstampedContributor(node)) {
     const span = stampedSpan(node, streamNow);
     if (span) return Math.max(0, span.end - span.start);
   }

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -32,18 +32,70 @@ export function nodeDuration(node: TestNode): number {
 }
 
 /**
- * Like `nodeDuration`, but a still-running leaf counts the time elapsed since
- * the client first saw it running (`since`), so its counter ticks live between
- * polls instead of sitting at 0 until the run settles.
+ * The client's fix on the stream's clock: `lastT` is the newest writer stamp
+ * seen, `receivedAt` the client clock (performance.now) when it arrived. The
+ * pair projects the writer's "now" between polls, so live counters tick
+ * smoothly yet always measure writer-stamp against writer-stamp — a viewer
+ * that joins (or reloads) mid-run still shows true elapsed times.
  */
-export function liveNodeDuration(node: TestNode, now: number, since: Map<string, number>): number {
+export interface LiveClock {
+  lastT: number;
+  receivedAt: number;
+}
+
+/**
+ * Wall-clock span of a stamped subtree: earliest descendant start to latest
+ * descendant end, where a still-running descendant ends at the projected
+ * stream "now". Null when nothing in the subtree carries a stamp.
+ */
+function stampedSpan(node: TestNode, streamNow: number): { start: number; end: number } | null {
+  let span: { start: number; end: number } | null = null;
+  const fold = (start: number, end: number) => {
+    if (!span) span = { start, end };
+    else {
+      span.start = Math.min(span.start, start);
+      span.end = Math.max(span.end, end);
+    }
+  };
+  if (node.startedAt != null) {
+    const end = node.status === 'running' ? streamNow
+      : node.durationMs != null ? node.startedAt + node.durationMs : node.startedAt;
+    fold(node.startedAt, end);
+  }
+  for (const child of node.children) {
+    const s = stampedSpan(child, streamNow);
+    if (s) fold(s.start, s.end);
+  }
+  return span;
+}
+
+/**
+ * Like `nodeDuration`, but live: a running leaf measures from its own start
+ * stamp against the projected stream "now", and an unmeasured container spans
+ * its stamped descendants' wall-clock instead of summing them (concurrent
+ * children overlap — 80 running tests summed would tick 80× real time).
+ * Stamp-less streams (older writers) fall back to anchoring on when the client
+ * first saw each leaf running (`since`) and summing unmeasured containers.
+ */
+export function liveNodeDuration(
+  node: TestNode,
+  now: number,
+  since: Map<string, number>,
+  clock?: LiveClock | null,
+): number {
+  const streamNow = clock ? clock.lastT + (now - clock.receivedAt) : null;
   if (!isContainer(node) && node.status === 'running') {
+    if (streamNow != null && node.startedAt != null) return Math.max(0, streamNow - node.startedAt);
     if (!since.has(node.key)) since.set(node.key, now); // first sight: start the clock
     return Math.max(0, now - since.get(node.key)!);
   }
   if (node.durationMs != null) return node.durationMs;
   if (!isContainer(node)) return 0;
-  return node.children.reduce((total, child) => total + liveNodeDuration(child, now, since), 0);
+  if (streamNow != null) {
+    const span = stampedSpan(node, streamNow);
+    if (span) return Math.max(0, span.end - span.start);
+  }
+  return node.children.reduce((total, child) => total + liveNodeDuration(child, now, since, clock), 0);
 }
 
 /** Container status = the worst status among descendants (severity order). */

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -44,13 +44,15 @@ export interface LiveClock {
 }
 
 /**
- * A descendant that would count toward a duration (running, or measured) but
- * carries no stamp — a mixed old/new-writer log. A span would silently drop
- * it, so its container must fall back to summing instead.
+ * A descendant that would count toward a duration but carries no stamp — a
+ * mixed old/new-writer log. A span would silently drop it, so its container
+ * must fall back to summing instead. Anything measured counts (suites too);
+ * `running` only on leaves, since containers derive that status from children
+ * and files never carry a stamp of their own.
  */
 function hasUnstampedContributor(node: TestNode): boolean {
-  if (node.startedAt == null && !isContainer(node)
-    && (node.status === 'running' || node.durationMs != null)) return true;
+  if (node.startedAt == null
+    && (node.durationMs != null || (!isContainer(node) && node.status === 'running'))) return true;
   return node.children.some(hasUnstampedContributor);
 }
 

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -111,7 +111,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 .verdict-glyph { font-size: 17px; font-weight: 800; line-height: 1; }
 .verdict-text { display: flex; flex-direction: column; line-height: 1.15; }
 .verdict-main { font-size: 15px; font-weight: 700; letter-spacing: .01em; }
-.verdict-sub { font-size: 11px; opacity: .85; }
+.verdict-sub { font-size: 11px; opacity: .85; font-variant-numeric: tabular-nums; }
 .chips { display: flex; gap: 7px; align-items: center; flex-wrap: wrap; }
 .chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; border: 1px solid transparent; cursor: pointer; font-family: inherit; }
 .chip:hover { filter: brightness(1.12); }

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -299,6 +299,17 @@ test('a measured stampless child disqualifies the span — the container sums in
   assert.strictEqual(liveNodeDuration(file, 0, new Map(), clock), 302_000);
 });
 
+test('a measured stampless suite disqualifies its ancestor span too', () => {
+  // Same failure one level up: the suite carries the measurement itself and
+  // its skipped children trip no leaf predicate.
+  const skipped = node({ key: 'k', status: 'skipped' });
+  const suite = node({ key: 's', type: 'suite', status: 'passed', durationMs: 300_000, children: [skipped] });
+  const stamped = node({ key: 'r', status: 'running', startedAt: 7_000 });
+  const file = node({ key: 'f', type: 'file', children: [suite, stamped] });
+  const clock = { lastT: 9_000, receivedAt: 0 };
+  assert.strictEqual(liveNodeDuration(file, 0, new Map(), clock), 302_000);
+});
+
 test('a container with a clock but no stamped descendants falls back to summing', () => {
   const a = node({ key: 'a', durationMs: 300 });
   const b = node({ key: 'b', durationMs: 400 });

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -251,6 +251,41 @@ test('liveNodeDuration ticks running leaves but keeps measured containers fixed'
   assert.strictEqual(liveNodeDuration(node({ key: 'q', status: 'queued' }), 9999, since), 0, 'an unmeasured, not-running leaf has no duration');
 });
 
+test('a stamped running leaf measures from its own start, immune to client resets', () => {
+  const leaf = node({ key: 'r', status: 'running', startedAt: 1_000 });
+  const clock = { lastT: 61_000, receivedAt: 5_000 };
+  assert.strictEqual(liveNodeDuration(leaf, 5_250, new Map(), clock), 60_250);
+  // A page reload throws away every client-side anchor; the stamps still give
+  // the same answer — the counter never restarts from zero.
+  assert.strictEqual(liveNodeDuration(leaf, 5_500, new Map(), clock), 60_500);
+});
+
+test('a stamped container spans wall-clock instead of summing concurrent children', () => {
+  const early = node({ key: 'a', status: 'running', startedAt: 1_000 });
+  const late = node({ key: 'b', status: 'running', startedAt: 31_000 });
+  const file = node({ key: 'f', type: 'file', children: [early, late] });
+  const clock = { lastT: 61_000, receivedAt: 500 };
+  // Two concurrent leaves 60s and 30s in: the file has been running 60s, not 90s.
+  assert.strictEqual(liveNodeDuration(file, 500, new Map(), clock), 60_000);
+});
+
+test('a stamped container span covers finished children and keeps ticking with running ones', () => {
+  const done = node({ key: 'd', status: 'passed', startedAt: 1_000, durationMs: 2_000 });
+  const running = node({ key: 'r', status: 'running', startedAt: 2_000 });
+  const file = node({ key: 'f', type: 'file', children: [done, running] });
+  const clock = { lastT: 10_000, receivedAt: 0 };
+  assert.strictEqual(liveNodeDuration(file, 0, new Map(), clock), 9_000);
+  assert.strictEqual(liveNodeDuration(file, 400, new Map(), clock), 9_400, 'ticks between polls');
+});
+
+test('without stamps the clock is ignored and the legacy client anchor applies', () => {
+  const since = new Map<string, number>();
+  const leaf = node({ key: 'r', status: 'running' });
+  const clock = { lastT: 61_000, receivedAt: 5_000 };
+  assert.strictEqual(liveNodeDuration(leaf, 1_000, since, clock), 0, 'first sight starts at zero');
+  assert.strictEqual(liveNodeDuration(leaf, 1_300, since, clock), 300);
+});
+
 test('isPassingTodo flags only a passed leaf that still carries the todo directive', () => {
   assert.strictEqual(isPassingTodo(node({ status: 'passed', todo: true })), true);
   assert.strictEqual(isPassingTodo(node({ status: 'passed', todo: 'evaluating' })), true);

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -278,15 +278,25 @@ test('a stamped container span covers finished children and keeps ticking with r
   assert.strictEqual(liveNodeDuration(file, 400, new Map(), clock), 9_400, 'ticks between polls');
 });
 
-test('a stamped span skips stampless children and ends abandoned nodes at their start', () => {
+test('a stamped span skips durationless stampless children and ends abandoned nodes at their start', () => {
   // A skipped/aborted node carries a start stamp but no measured duration; a
-  // stampless sibling (older-writer line mixed in) contributes nothing.
+  // stampless sibling with nothing measured contributes nothing either way.
   const abandoned = node({ key: 's', status: 'skipped', startedAt: 4_000 });
-  const stampless = node({ key: 'x', status: 'passed', durationMs: 500 });
+  const stampless = node({ key: 'x', status: 'passed' });
   const running = node({ key: 'r', status: 'running', startedAt: 1_000 });
   const file = node({ key: 'f', type: 'file', children: [abandoned, stampless, running] });
   const clock = { lastT: 9_000, receivedAt: 0 };
   assert.strictEqual(liveNodeDuration(file, 0, new Map(), clock), 8_000);
+});
+
+test('a measured stampless child disqualifies the span — the container sums instead', () => {
+  // Mixed old/new-writer log: a span would silently drop the 5-minute
+  // unstamped test while its own row still shows 5m. Fall back to summing.
+  const unstampedSlow = node({ key: 'x', status: 'passed', durationMs: 300_000 });
+  const stamped = node({ key: 'r', status: 'running', startedAt: 7_000 });
+  const file = node({ key: 'f', type: 'file', children: [unstampedSlow, stamped] });
+  const clock = { lastT: 9_000, receivedAt: 0 };
+  assert.strictEqual(liveNodeDuration(file, 0, new Map(), clock), 302_000);
 });
 
 test('a container with a clock but no stamped descendants falls back to summing', () => {

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -278,6 +278,25 @@ test('a stamped container span covers finished children and keeps ticking with r
   assert.strictEqual(liveNodeDuration(file, 400, new Map(), clock), 9_400, 'ticks between polls');
 });
 
+test('a stamped span skips stampless children and ends abandoned nodes at their start', () => {
+  // A skipped/aborted node carries a start stamp but no measured duration; a
+  // stampless sibling (older-writer line mixed in) contributes nothing.
+  const abandoned = node({ key: 's', status: 'skipped', startedAt: 4_000 });
+  const stampless = node({ key: 'x', status: 'passed', durationMs: 500 });
+  const running = node({ key: 'r', status: 'running', startedAt: 1_000 });
+  const file = node({ key: 'f', type: 'file', children: [abandoned, stampless, running] });
+  const clock = { lastT: 9_000, receivedAt: 0 };
+  assert.strictEqual(liveNodeDuration(file, 0, new Map(), clock), 8_000);
+});
+
+test('a container with a clock but no stamped descendants falls back to summing', () => {
+  const a = node({ key: 'a', durationMs: 300 });
+  const b = node({ key: 'b', durationMs: 400 });
+  const suite = node({ key: 's', type: 'suite', children: [a, b] });
+  const clock = { lastT: 9_000, receivedAt: 0 };
+  assert.strictEqual(liveNodeDuration(suite, 0, new Map(), clock), 700);
+});
+
 test('without stamps the clock is ignored and the legacy client anchor applies', () => {
   const since = new Map<string, number>();
   const leaf = node({ key: 'r', status: 'running' });


### PR DESCRIPTION
## The bug

Watching a live run mid-flight (screen recording of an ~80-concurrent-test run):

- the header elapsed showed **26m 2s** minutes into the run, ticking at ~80× real time
- every running test showed the **same** duration, which **reset to ~0 on every page reload** (35ms → 3s → back to 0…), because the "elapsed" was anchored to when the client first painted the row
- the header width jittered as the counter text changed

The stream carried no timestamps, so the viewer fundamentally could not know when a test actually started — it guessed from its own clock, and the live fallback summed concurrent running leaves (80 running tests ⇒ header ticks 80s per second).

## The fix

- **Wire**: `serializeWireLine` stamps every NDJSON line with the writer's wall-clock (`t`); pre-stamped events pass through.
- **Store**: records each node's start stamp (`startedAt`, from the event that set it running — the eager dequeue wins over the buffered decl start) and the stream's stamp range (`snapshot.clock`).
- **Viewer**: measures stamp against stamp, projecting the writer's "now" between polls from the newest stamp + client delta:
  - running leaf = stream-now − its own start stamp
  - unmeasured container = wall-clock **span** of its stamped descendants (never a sum)
  - header = span of the whole tree until the run summary takes over
- Stamp-less logs (older writers) keep the previous client-anchored behavior.
- Header verdict uses tabular numerals so the ticking duration doesn't resize it every second.

## Verification

- New unit tests across wire/store/rowModel, including reload immunity (a fresh client `since` map yields identical values).
- Full suite: 287 pass, statements 100%.
- Playwright against a live-streamed stamped log: header ticks at exactly 1×; a test that started 2m before the page was opened shows 2m; after a full page reload every counter continues (2m43s) instead of restarting at zero; concurrent files span instead of summing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)