### PR TITLE
feat(web): mobile-friendly viewer layout and header polish

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -74,7 +74,10 @@ function linkifyDom(rootEl: HTMLElement): void {
         a.href = seg.text;
         a.target = '_blank';
         a.rel = 'noreferrer';
-        a.textContent = seg.text;
+        // Long URLs (presigned links, trace endpoints) would wrap across many
+        // lines and bury the message — middle-truncate the label, keep the href.
+        a.textContent = seg.text.length > 64 ? `${seg.text.slice(0, 42)}…${seg.text.slice(-18)}` : seg.text;
+        a.title = seg.text;
         frag.appendChild(a);
       } else {
         frag.appendChild(document.createTextNode(seg.text));
@@ -262,7 +265,12 @@ function CopyButton({ text }: { text: string }) {
       setTimeout(() => setCopied(false), 1200);
     });
   };
-  return <button type="button" className="hbtn" onClick={copy} title="Copy to clipboard">{copied ? 'Copied' : '⧉ Copy'}</button>;
+  return (
+    <button type="button" className="hbtn" onClick={copy} title="Copy to clipboard">
+      {copied ? '✓' : '⧉'}
+      <span className="hbtn-label">{copied ? ' Copied' : ' Copy'}</span>
+    </button>
+  );
 }
 
 /** One section: sticky header with controls above the capped scroll region
@@ -331,9 +339,9 @@ function DiagSection({
               </>
             ) : null}
             <CopyButton text={block.copyText} />
-            <button type="button" className="hbtn" onClick={() => setModal(true)} title="Open full log">⤢ Full log</button>
+            <button type="button" className="hbtn" onClick={() => setModal(true)} title="Open full log">⤢<span className="hbtn-label"> Full log</span></button>
             {open ? (
-              <button type="button" className="hbtn" onClick={onToggle} title="Collapse this section">Collapse</button>
+              <button type="button" className="hbtn hbtn-collapse" onClick={onToggle} title="Collapse this section">Collapse</button>
             ) : null}
           </div>
         </div>
@@ -353,8 +361,10 @@ function DiagSection({
 }
 
 function LogModal({ title, block, onClose }: { title: string; block: DiagBlock; onClose: () => void }) {
-  // Lines stay whole by default — the modal exists for room; wrapping is opt-in (§11b).
-  const [wrap, setWrap] = useState(false);
+  // Lines stay whole by default — the modal exists for room; wrapping is opt-in
+  // (§11b) — except on a phone, where horizontal-scrolling a stack trace is
+  // worse than wrapped lines, so Wrap starts on.
+  const [wrap, setWrap] = useState(() => window.matchMedia?.('(max-width: 640px)').matches ?? false);
   const boxRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     const prev = document.activeElement as HTMLElement | null;
@@ -413,7 +423,7 @@ function OutputPanel({
   const { node, depth } = row;
   const blocks = diagBlocks(node);
   const style: React.CSSProperties = {
-    margin: `4px 12px 7px ${depth * 20 + 18}px`,
+    margin: `4px var(--diag-mr) 7px calc(${depth} * var(--ind) + var(--diag-gap))`,
     ...(enter !== null ? { animationDelay: `${Math.min(enter, 8) * 18}ms` } : {}),
   };
   return (
@@ -519,12 +529,12 @@ function RowView({
         {Array.from({ length: depth }, (_, i) => <span className="guide" key={i} />)}
       </span>
       <span className="caret" data-open={expandable && expanded ? 'true' : undefined}>{expandable ? '▸' : ''}</span>
-      {isTest ? (
-        status === 'running'
-          ? <span className="spinner indicator" />
-          : <span className="dot indicator" data-stf={status} />
+      {isTest && status === 'running' ? (
+        <span className="spinner indicator" />
       ) : (
-        <span className="cglyph indicator" data-stc={status} data-spin={status === 'running' ? 'true' : undefined}>{GLYPH[status]}</span>
+        // One visual language for pass/fail at every level: containers and leaf
+        // tests both use the status glyph (design mobile-review ruling).
+        <span className="cglyph indicator" data-stc={status} data-spin={!isTest && status === 'running' ? 'true' : undefined}>{GLYPH[status]}</span>
       )}
       <span className="name" data-kind={node.type} style={{ color: nameColor }}>{displayName(node)}</span>
       {hasDiag ? (
@@ -779,11 +789,15 @@ export function TreeView({
         <div className="hdr-bar-row">
           <div className="bar">
             {barSegments.map((s) => (
+              // Proportional flex-grow over a 6px basis: a 2-test sliver stays a
+              // visible, hoverable segment instead of a sub-pixel line.
               <span
                 key={s}
                 data-stf={s}
                 data-pulse={s === 'running' ? 'true' : undefined}
-                style={{ width: `${(counts[s] / total) * 100}%` }}
+                title={`${counts[s]} ${STATUS_LABEL[s]}`}
+                aria-label={`${counts[s]} ${STATUS_LABEL[s]}`}
+                style={{ flex: `${counts[s] / total} 0 6px` }}
               />
             ))}
           </div>

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -87,7 +87,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 /* failures earn one extra beat: a single row tint flash, never a loop */
 .settle-failed { animation: failFlash 500ms var(--ease-out); }
 /* the summary bar slides as counts shift queued -> settled */
-.bar > span { transition: width 300ms var(--ease-out); }
+.bar > span { transition: flex-grow 300ms var(--ease-out); }
 .verdict { transition: background-color 200ms var(--ease-out), color 200ms var(--ease-out); }
 
 @media (prefers-reduced-motion: reduce) {
@@ -101,7 +101,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 }
 
 /* app shell */
-.app { height: 100%; display: flex; flex-direction: column; --rh: 34px; --fs: 13.5px; --ind: 20px; }
+.app { height: 100%; display: flex; flex-direction: column; --rh: 34px; --fs: 13.5px; --ind: 20px; --diag-mr: 12px; --diag-gap: 18px; }
 .loading { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 13px; }
 
 /* header */
@@ -111,13 +111,17 @@ button { font-family: inherit; } input { font-family: inherit; }
 .verdict-glyph { font-size: 17px; font-weight: 800; line-height: 1; }
 .verdict-text { display: flex; flex-direction: column; line-height: 1.15; }
 .verdict-main { font-size: 15px; font-weight: 700; letter-spacing: .01em; }
-.verdict-sub { font-size: 11px; opacity: .85; font-variant-numeric: tabular-nums; }
+/* secondary text stays neutral ink; the saturated status color is reserved
+   for the glyph and status word (designer contrast ruling) */
+.verdict-sub { font-size: 11px; color: var(--dim); font-variant-numeric: tabular-nums; }
 .chips { display: flex; gap: 7px; align-items: center; flex-wrap: wrap; }
 .chip { display: inline-flex; align-items: center; gap: 6px; padding: 4px 10px; border-radius: 999px; font-size: 12px; font-weight: 600; border: 1px solid transparent; cursor: pointer; font-family: inherit; }
 .chip:hover { filter: brightness(1.12); }
 .chip[data-active] { border-color: currentColor; }
 .chip-dot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
-.chip-label { opacity: .7; font-weight: 500; }
+/* the count keeps the status color; the label word gets full-contrast ink
+   (color-on-tint failed WCAG AA for the muted variants) */
+.chip-label { color: var(--dim); font-weight: 500; }
 .tools { margin-left: auto; display: flex; gap: 9px; align-items: center; }
 .search { position: relative; display: flex; align-items: center; }
 .search svg { position: absolute; left: 11px; color: var(--faint); pointer-events: none; }
@@ -139,7 +143,6 @@ button { font-family: inherit; } input { font-family: inherit; }
 .guide { width: var(--ind); align-self: stretch; border-left: 1px solid var(--line); }
 .caret { width: 16px; flex: none; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 10px; transition: transform 160ms var(--ease-out); }
 .caret[data-open="true"] { transform: rotate(90deg); }
-.dot { width: 9px; height: 9px; border-radius: 50%; flex: none; }
 .cglyph { font-size: 13px; font-weight: 700; width: 14px; flex: none; text-align: center; }
 .name { font-size: var(--fs); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .name[data-kind="file"] { font-family: var(--mono); font-weight: 700; }
@@ -198,7 +201,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 @keyframes modalIn { from { opacity: 0; transform: translateY(6px) scale(.985); } to { opacity: 1; transform: none; } }
 .modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.55); z-index: 50; display: flex; align-items: center; justify-content: center; }
 .modal { background: var(--panel); border: 1px solid var(--line-2); border-radius: 16px; box-shadow: 0 24px 64px rgba(0,0,0,.45); width: min(1680px, 94vw); height: min(86vh, 100%); display: flex; flex-direction: column; outline: none; animation: modalIn 180ms var(--ease-out) both; }
-@media (max-width: 640px) { .modal-backdrop { padding: 12px; } .modal { width: 100%; height: 100%; } }
+@media (max-width: 640px) { .modal-backdrop { padding: 0; } .modal { width: 100%; height: 100dvh; border: none; border-radius: 0; } }
 .modal-head { display: flex; align-items: center; gap: 8px; padding: 11px 16px; border-bottom: 1px solid var(--line); }
 .modal-title { font-size: 12.5px; font-weight: 700; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .modal-body { flex: 1; min-height: 0; overflow: auto; overscroll-behavior: contain; padding: 8px 4px; }
@@ -222,4 +225,40 @@ button { font-family: inherit; } input { font-family: inherit; }
 .legend { margin-left: auto; display: inline-flex; gap: 13px; }
 .legend > span { display: inline-flex; gap: 5px; align-items: center; }
 .legend .ldot { width: 7px; height: 7px; border-radius: 50%; display: inline-block; }
+
+/* mobile (~phone widths): reclaim the indent budget, let names wrap, keep
+   everything on-screen, and pad tap targets */
+@media (max-width: 640px) {
+  .app { --ind: 12px; --rh: 40px; --fs: 13px; --diag-mr: 8px; --diag-gap: 8px; }
+  .guide { border-left: none; }
+  .tree { padding: 6px 4px 24px; }
+  .row { padding: 0 8px; gap: 6px; }
+  .name { white-space: normal; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; word-break: break-word; }
+  .dur { min-width: 0; }
+  .pills { margin-right: 4px; }
+  .caret { width: 20px; align-self: stretch; }
+  /* one content column: headline row, breakdown pills, controls, progress bar —
+     stacked on a single 12px gutter and spacing step */
+  .hdr-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 12px 12px 0; }
+  .verdict { align-self: flex-start; }
+  .chips { gap: 8px; }
+  .tools { margin-left: 0; }
+  .search { flex: 1; }
+  .search input { width: 100%; min-height: 44px; }
+  .tools .btn { min-height: 44px; min-width: 44px; justify-content: center; }
+  .hdr-bar-row { padding: 12px 12px; }
+  .bar { min-width: 0; }
+  .hbtn { min-height: 34px; min-width: 34px; padding: 5px 9px; font-size: 11px; }
+  .hbtn-label, .hbtn-collapse { display: none; }
+  .diag-head { min-height: 40px; padding: 4px 10px 4px 6px; }
+  .diag-msg { padding: 0 10px; }
+  .diag pre.stack, .diag pre.text { padding: 2px 10px 11px; }
+  .out { padding: 4px 10px 10px; }
+  .diag-list { padding: 2px 10px 10px; }
+  .modal-head { flex-wrap: wrap; row-gap: 6px; padding: 10px 12px; }
+  .modal-title { white-space: normal; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
+  .modal-head .diag-tools { flex: 1 1 100%; margin-left: 0; justify-content: flex-end; }
+  .footer { flex-wrap: wrap; row-gap: 5px; padding: 8px 12px; }
+  .legend { margin-left: 0; flex-basis: 100%; flex-wrap: wrap; gap: 5px 12px; }
+}
 `;


### PR DESCRIPTION
## Summary

Implements the designer's two mobile review rounds (tree/cards/modal + top bar) and a contrast follow-up, verified with Playwright at 390×844 against the real 241-test report and regression-checked on desktop in both themes.

### Horizontal space (P0)
- Mobile indent step drops to 12px per level (via `--ind`; the output-panel margin now derives from the same var instead of a hardcoded `depth * 20`)
- Vertical guide rails hidden below 640px
- Test names wrap up to 2 lines instead of ellipsizing; duration column no longer protected at the name's expense

### Off-screen content (P0)
- Footer legend wraps onto its own row (no more clipped `todo`)
- URLs longer than 64 chars are middle-truncated in the link label — full URL stays in `href` and tooltip
- Full-log modal defaults Wrap to on for phone viewports

### Modal & cards (P1)
- True full-screen modal sheet on mobile (removed the 12px backdrop padding that left a page sliver)
- Modal title gets the full first row (2-line clamp); actions move to a second row
- Section buttons are icon-first on mobile (labels hidden, redundant Collapse hidden — the header itself toggles)

### Consistency & tap targets (P1)
- One glyph language: leaf tests use the same colored status glyphs as containers (applied globally so the system doesn't diverge across breakpoints); running spinner kept
- 44px header controls, 40px rows, 34px section buttons on mobile

### Top bar round
- Mobile header is one stacked content column on a single 12px gutter and spacing step: headline verdict pill, breakdown chips (one flex, one gap), controls row, progress bar — shared left and right edges (measured 12→378px on a 390px viewport)
- Chip label words and the verdict subtitle use neutral ink (`--dim`, ≈7:1 on the tints); saturated color stays on counts and the status word
- Progress bar segments switch to proportional flex-grow over a 6px minimum basis so slivers stay visible, with count tooltips/aria-labels; width transition became flex-grow so live runs still animate

## Test plan
- [x] `yarn workspace @reporters/web test` — 79 passed
- [x] `yarn lint` — no errors
- [x] `tsc --noEmit` on packages/web
- [x] Playwright at 390×844: no horizontal page overflow; measured alignment, tap-target sizes, computed label colors
- [x] Desktop 1440px + dark theme spot-checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)