### PR TITLE
feat: carried-over (rerun) test annotation in the web viewer

### DIFF
--- a/packages/tree-core/src/carried.ts
+++ b/packages/tree-core/src/carried.ts
@@ -1,0 +1,26 @@
+import type { TestNode } from './types.ts';
+
+/** Carried overlay: a leaf that passed without executing this attempt, or a
+ *  container whose every test descendant did. */
+export function isCarried(node: TestNode): boolean {
+  if (node.children.length === 0) return node.passedOnAttempt != null;
+  return node.counts.carried > 0 && node.counts.carried === node.counts.total;
+}
+
+/** The attempt shared by every carried test under `node`, else undefined. */
+export function carriedAttempt(node: TestNode): number | undefined {
+  let attempt: number | undefined;
+  let mixed = false;
+  const walk = (n: TestNode): void => {
+    if (mixed) return;
+    if (n.children.length === 0) {
+      if (n.passedOnAttempt == null) return;
+      if (attempt == null) attempt = n.passedOnAttempt;
+      else if (attempt !== n.passedOnAttempt) mixed = true;
+      return;
+    }
+    for (const child of n.children) walk(child);
+  };
+  walk(node);
+  return mixed ? undefined : attempt;
+}

--- a/packages/tree-core/src/index.ts
+++ b/packages/tree-core/src/index.ts
@@ -2,6 +2,7 @@ export { createTreeStore } from './store.ts';
 export { toWireEvent, serializeWireLine, parseWireLines } from './wire.ts';
 export { formatDuration } from './format.ts';
 export { defaultExpanded, isPassingTodo, todoLabel } from './expand.ts';
+export { isCarried, carriedAttempt } from './carried.ts';
 export * from './theme.ts';
 export type {
   TestStatus,

--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -38,6 +38,7 @@ interface InternalNode {
   tags?: string[];
   todo?: boolean | string;
   skip?: boolean | string;
+  passedOnAttempt?: number;
   childKeys: string[];
 }
 
@@ -120,6 +121,7 @@ export function createTreeStore(): TreeStore {
   let autoId = 0;
   let sawFileWrapper = false;
   let summary: SummaryData | undefined;
+  let runAttempt: number | undefined;
   // Wall-clock stamps from the writer (`event.t`). `currentT` is the stamp of
   // the event being applied, so the helpers that mark a node running can record
   // when it actually started without threading it through every signature.
@@ -396,10 +398,18 @@ export function createTreeStore(): TreeStore {
   // already underway, so it widens the stream's stamp range too — the header
   // must never read less than a row it contains.
   function backdateStart(node: InternalNode, data: TestEventData): void {
+    // A carried test's duration is a prior attempt's measurement, not evidence
+    // of when this run began.
+    if (data.details?.passed_on_attempt != null) return;
     if (node.startedAt == null && currentT != null && data.details?.duration_ms != null) {
       node.startedAt = currentT - data.details.duration_ms;
       if (firstT == null || node.startedAt < firstT) firstT = node.startedAt;
     }
+  }
+
+  function noteAttempt(node: InternalNode, data: TestEventData): void {
+    if (data.details?.attempt != null) runAttempt = data.details.attempt;
+    if (data.details?.passed_on_attempt != null) node.passedOnAttempt = data.details.passed_on_attempt;
   }
 
   function declFinalize(status: TestStatus, data: TestEventData): void {
@@ -410,6 +420,7 @@ export function createTreeStore(): TreeStore {
     const matchesOpen = openNode && openNode.testId === data.testId && openNode.name === data.name;
     const node = matchesOpen ? openNode : eagerInstance(gk, data.testId!, data);
     backdateStart(node, data);
+    noteAttempt(node, data);
     assignFields(node, data);
     node.status = status;
     if (data.details?.duration_ms != null) node.durationMs = data.details.duration_ms;
@@ -476,6 +487,7 @@ export function createTreeStore(): TreeStore {
       node.startedAt = undefined;
       backdateStart(node, data);
     }
+    noteAttempt(node, data);
     assignFields(node, data);
     node.status = status;
     if (data.details?.duration_ms != null) node.durationMs = data.details.duration_ms;
@@ -558,6 +570,7 @@ export function createTreeStore(): TreeStore {
         const status = statusFromComplete(data);
         upsertFromTestEvent(data, (node) => {
           backdateStart(node, data);
+          noteAttempt(node, data);
           node.status = status;
           if (data.details?.duration_ms != null) node.durationMs = data.details.duration_ms;
           if (data.details?.type != null) node.type = data.details.type === 'suite' ? 'suite' : 'test';
@@ -633,7 +646,7 @@ export function createTreeStore(): TreeStore {
   }
 
   function emptyCounts(): Counts {
-    return { passed: 0, failed: 0, skipped: 0, todo: 0, running: 0, queued: 0, total: 0 };
+    return { passed: 0, failed: 0, skipped: 0, todo: 0, running: 0, queued: 0, carried: 0, total: 0 };
   }
 
   function addCounts(into: Counts, from: Counts): void {
@@ -643,6 +656,7 @@ export function createTreeStore(): TreeStore {
     into.todo += from.todo;
     into.running += from.running;
     into.queued += from.queued;
+    into.carried += from.carried;
     into.total += from.total;
   }
 
@@ -668,6 +682,7 @@ export function createTreeStore(): TreeStore {
     if (children.length === 0 && internal.type !== 'file' && internal.type !== 'root') {
       counts.total = 1;
       counts[internal.status] += 1;
+      if (internal.passedOnAttempt != null && internal.status === 'passed') counts.carried = 1;
     } else {
       for (const child of children) addCounts(counts, child.counts);
     }
@@ -701,6 +716,7 @@ export function createTreeStore(): TreeStore {
       tags: internal.tags,
       todo: internal.todo,
       skip: internal.skip,
+      passedOnAttempt: internal.passedOnAttempt,
       counts,
     };
   }
@@ -713,6 +729,7 @@ export function createTreeStore(): TreeStore {
       root: rootNode,
       counts: rootNode.counts,
       summary,
+      ...(runAttempt != null ? { attempt: runAttempt } : {}),
       // firstT and lastT are always set together (same stamped event).
       ...(firstT != null ? { clock: { firstT, lastT: lastT! } } : {}),
     };

--- a/packages/tree-core/src/types.ts
+++ b/packages/tree-core/src/types.ts
@@ -28,6 +28,7 @@ export interface Counts {
   todo: number;
   running: number;
   queued: number;
+  carried: number;
   total: number;
 }
 
@@ -54,6 +55,9 @@ export interface TestNode {
   tags?: string[];
   todo?: boolean | string;
   skip?: boolean | string;
+  /** Attempt this test last actually passed on (0-based). Present ⇔ the test
+   *  was carried — reported passed without executing this attempt. */
+  passedOnAttempt?: number;
   counts: Counts;
 }
 
@@ -68,6 +72,8 @@ export interface TreeSnapshot {
   root: TestNode;
   counts: Counts;
   summary?: SummaryData;
+  /** Current attempt (0-based) under --test-rerun-failures; absent otherwise. */
+  attempt?: number;
   /** Stamp range of the run so far — the run's elapsed wall-clock is
    *  `lastT - firstT`, independent of when a viewer joined. `firstT` reaches
    *  before the first stamped line when a finish-first node's backdated start

--- a/packages/tree-core/src/types.ts
+++ b/packages/tree-core/src/types.ts
@@ -97,6 +97,8 @@ export interface TestEventData {
     error?: unknown;
     type?: string;
     passed?: boolean;
+    attempt?: number;
+    passed_on_attempt?: number;
   };
   counts?: Record<string, number>;
   duration_ms?: number;

--- a/packages/tree-core/src/wire.ts
+++ b/packages/tree-core/src/wire.ts
@@ -44,6 +44,8 @@ export function toWireEvent(event: TestEvent): TestEvent {
       passed: d.details.passed,
       error: flattenError(d.details.error) as Error | undefined,
     };
+    if (d.details.attempt != null) data.details.attempt = d.details.attempt;
+    if (d.details.passed_on_attempt != null) data.details.passed_on_attempt = d.details.passed_on_attempt;
   }
   return t != null ? { type: event.type, t, data } : { type: event.type, data };
 }

--- a/packages/tree-core/tests/carried.test.ts
+++ b/packages/tree-core/tests/carried.test.ts
@@ -1,6 +1,12 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { toWireEvent } from '../src/wire.ts';
+import { createTreeStore } from '../src/store.ts';
+import type { TestEvent } from '../src/types.ts';
+
+function apply(store: ReturnType<typeof createTreeStore>, events: TestEvent[]) {
+  for (const event of events) store.apply(event);
+}
 
 test('toWireEvent preserves rerun details fields', () => {
   const wired = toWireEvent({
@@ -21,4 +27,51 @@ test('toWireEvent omits absent rerun fields', () => {
   });
   assert.ok(!('attempt' in wired.data.details!));
   assert.ok(!('passed_on_attempt' in wired.data.details!));
+});
+
+test('carried pass stamps passedOnAttempt and counts carried up the tree', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', data: { name: 'carried one', nesting: 0, file: '/a.test.js', testId: 1 } },
+    { type: 'test:pass', data: { name: 'carried one', nesting: 0, file: '/a.test.js', testId: 1, details: { duration_ms: 14, attempt: 1, passed_on_attempt: 0 } } },
+    { type: 'test:start', data: { name: 'fresh one', nesting: 0, file: '/a.test.js', testId: 2 } },
+    { type: 'test:pass', data: { name: 'fresh one', nesting: 0, file: '/a.test.js', testId: 2, details: { duration_ms: 3, attempt: 1 } } },
+  ]);
+  const snap = store.getSnapshot();
+  const [carried, fresh] = snap.root.children[0].children;
+  assert.strictEqual(carried.passedOnAttempt, 0);
+  assert.strictEqual(fresh.passedOnAttempt, undefined);
+  assert.strictEqual(snap.counts.carried, 1);
+  assert.strictEqual(snap.counts.passed, 2);
+  assert.strictEqual(snap.root.children[0].counts.carried, 1);
+  assert.strictEqual(snap.attempt, 1);
+});
+
+test('non-rerun stream has no attempt and zero carried', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', data: { name: 'adds', nesting: 0, file: '/a.test.js', testId: 1 } },
+    { type: 'test:pass', data: { name: 'adds', nesting: 0, file: '/a.test.js', testId: 1, details: { duration_ms: 5 } } },
+  ]);
+  const snap = store.getSnapshot();
+  assert.strictEqual(snap.attempt, undefined);
+  assert.strictEqual(snap.counts.carried, 0);
+  assert.strictEqual(snap.root.children[0].children[0].passedOnAttempt, undefined);
+});
+
+test('a carried replayed duration does not backdate the run clock', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:pass', t: 1000000, data: { name: 'carried', nesting: 0, file: '/a.test.js', testId: 1, details: { duration_ms: 900000, attempt: 1, passed_on_attempt: 0 } } },
+  ]);
+  const snap = store.getSnapshot();
+  assert.deepStrictEqual(snap.clock, { firstT: 1000000, lastT: 1000000 });
+});
+
+test('a fresh finish without a start still backdates the run clock', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:pass', t: 1000000, data: { name: 'fresh', nesting: 0, file: '/a.test.js', testId: 1, details: { duration_ms: 900000, attempt: 1 } } },
+  ]);
+  assert.strictEqual(store.getSnapshot().clock?.firstT, 100000);
 });

--- a/packages/tree-core/tests/carried.test.ts
+++ b/packages/tree-core/tests/carried.test.ts
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { toWireEvent } from '../src/wire.ts';
+
+test('toWireEvent preserves rerun details fields', () => {
+  const wired = toWireEvent({
+    type: 'test:pass',
+    data: {
+      name: 'adds', nesting: 0, file: '/a.test.js', testId: 1,
+      details: { duration_ms: 14, attempt: 1, passed_on_attempt: 0 },
+    },
+  });
+  assert.strictEqual(wired.data.details?.attempt, 1);
+  assert.strictEqual(wired.data.details?.passed_on_attempt, 0);
+});
+
+test('toWireEvent omits absent rerun fields', () => {
+  const wired = toWireEvent({
+    type: 'test:pass',
+    data: { name: 'adds', nesting: 0, file: '/a.test.js', testId: 1, details: { duration_ms: 14 } },
+  });
+  assert.ok(!('attempt' in wired.data.details!));
+  assert.ok(!('passed_on_attempt' in wired.data.details!));
+});

--- a/packages/tree-core/tests/carried.test.ts
+++ b/packages/tree-core/tests/carried.test.ts
@@ -112,7 +112,11 @@ test('isCarried: leaf by passedOnAttempt, container by all-carried counts', () =
 test('carriedAttempt: uniform value or undefined', () => {
   const a0 = leaf({ passedOnAttempt: 0, counts: { ...zero(), passed: 1, carried: 1, total: 1 } });
   const a1 = leaf({ passedOnAttempt: 1, counts: { ...zero(), passed: 1, carried: 1, total: 1 } });
+  const fresh = leaf();
   assert.strictEqual(carriedAttempt(container([a0, a0])), 0);
   assert.strictEqual(carriedAttempt(container([a0, a1])), undefined);
   assert.strictEqual(carriedAttempt(a1), 1);
+  // Non-carried leaves don't participate; siblings after a detected mix are skipped.
+  assert.strictEqual(carriedAttempt(container([fresh, a1])), 1);
+  assert.strictEqual(carriedAttempt(container([container([a0, a1]), a0])), undefined);
 });

--- a/packages/tree-core/tests/carried.test.ts
+++ b/packages/tree-core/tests/carried.test.ts
@@ -2,10 +2,33 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import { toWireEvent } from '../src/wire.ts';
 import { createTreeStore } from '../src/store.ts';
-import type { TestEvent } from '../src/types.ts';
+import { isCarried, carriedAttempt } from '../src/carried.ts';
+import type { Counts, TestEvent, TestNode } from '../src/types.ts';
 
 function apply(store: ReturnType<typeof createTreeStore>, events: TestEvent[]) {
   for (const event of events) store.apply(event);
+}
+
+const zero = (): Counts => ({
+  passed: 0, failed: 0, skipped: 0, todo: 0, running: 0, queued: 0, carried: 0, total: 0,
+});
+
+function leaf(over: Partial<TestNode> = {}): TestNode {
+  return {
+    key: 'k', testId: undefined, parentKey: null, file: undefined, name: '',
+    nesting: 0, type: 'test', status: 'passed', diagnostics: [], stdout: [], stderr: [],
+    children: [], counts: { ...zero(), passed: 1, total: 1 }, ...over,
+  };
+}
+
+function container(children: TestNode[]): TestNode {
+  const counts = zero();
+  for (const c of children) {
+    counts.passed += c.counts.passed;
+    counts.carried += c.counts.carried;
+    counts.total += c.counts.total;
+  }
+  return { ...leaf({ type: 'suite' }), children, counts };
 }
 
 test('toWireEvent preserves rerun details fields', () => {
@@ -74,4 +97,22 @@ test('a fresh finish without a start still backdates the run clock', () => {
     { type: 'test:pass', t: 1000000, data: { name: 'fresh', nesting: 0, file: '/a.test.js', testId: 1, details: { duration_ms: 900000, attempt: 1 } } },
   ]);
   assert.strictEqual(store.getSnapshot().clock?.firstT, 100000);
+});
+
+test('isCarried: leaf by passedOnAttempt, container by all-carried counts', () => {
+  const carried0 = leaf({ passedOnAttempt: 0, counts: { ...zero(), passed: 1, carried: 1, total: 1 } });
+  const fresh = leaf();
+  assert.strictEqual(isCarried(carried0), true);
+  assert.strictEqual(isCarried(fresh), false);
+  assert.strictEqual(isCarried(container([carried0, carried0])), true);
+  assert.strictEqual(isCarried(container([carried0, fresh])), false);
+  assert.strictEqual(isCarried(container([fresh, fresh])), false);
+});
+
+test('carriedAttempt: uniform value or undefined', () => {
+  const a0 = leaf({ passedOnAttempt: 0, counts: { ...zero(), passed: 1, carried: 1, total: 1 } });
+  const a1 = leaf({ passedOnAttempt: 1, counts: { ...zero(), passed: 1, carried: 1, total: 1 } });
+  assert.strictEqual(carriedAttempt(container([a0, a0])), 0);
+  assert.strictEqual(carriedAttempt(container([a0, a1])), undefined);
+  assert.strictEqual(carriedAttempt(a1), 1);
 });

--- a/packages/tree-core/tests/helpers.test.ts
+++ b/packages/tree-core/tests/helpers.test.ts
@@ -169,7 +169,7 @@ function node(partial: Partial<TestNode>): TestNode {
     stderr: [],
     children: [],
     counts: {
-      passed: 0, failed: 0, skipped: 0, todo: 0, running: 0, queued: 0, total: 0,
+      passed: 0, failed: 0, skipped: 0, todo: 0, running: 0, queued: 0, carried: 0, total: 0,
     },
     ...partial,
   };

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -2,7 +2,7 @@ import React, {
   useEffect, useMemo, useRef, useState,
 } from 'react';
 import {
-  formatDuration, todoLabel, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
+  carriedAttempt, formatDuration, isCarried, todoLabel, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
 } from '@reporters/tree-core';
 import {
   buildRows, collectContainerKeys, computeMatches, displayName, isContainer, isSectionOpen, liveNodeDuration, reasonOf, realError, type FlatRow, type LiveClock,
@@ -217,6 +217,13 @@ const SearchIcon = () => (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
     <circle cx="11" cy="11" r="7" />
     <line x1="21" y1="21" x2="16.5" y2="16.5" />
+  </svg>
+);
+
+const CarryIcon = () => (
+  <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M3 12a9 9 0 1 0 2.6-6.4" />
+    <path d="M3 4v5h5" />
   </svg>
 );
 
@@ -479,10 +486,14 @@ interface RowViewProps {
   since: Map<string, number>;
   /** The stream's stamp clock, when the log carries writer stamps. */
   clock: LiveClock | null;
+  /** The run has carried tests — reserve the attempt gutter on every row. */
+  carriedRun: boolean;
+  /** The only-re-run filter is active (collapsed pills show re-run counts). */
+  onlyRerun: boolean;
 }
 
 function RowView({
-  row, toggle, enter, now, since, clock,
+  row, toggle, enter, now, since, clock, carriedRun, onlyRerun,
 }: RowViewProps) {
   const {
     node, depth, status, expandable, expanded, hasDiag,
@@ -503,6 +514,14 @@ function RowView({
   const nameColor = isTest && status === 'failed' ? 'var(--st-failed)'
     : isTest && (status === 'skipped' || status === 'todo' || status === 'queued') ? 'var(--dim)'
       : 'var(--fg)';
+  const carried = isTest && !container && node.passedOnAttempt != null;
+  const rollupMark = container && isCarried(node);
+  const markAttempt = carried ? node.passedOnAttempt : rollupMark ? carriedAttempt(node) : undefined;
+  const carryTip = carried
+    ? `Carried from attempt ${node.passedOnAttempt! + 1} · not executed this run`
+    : rollupMark
+      ? `All ${counts.carried} tests carried${markAttempt != null ? ` from attempt ${markAttempt + 1}` : ''} · not run this attempt`
+      : undefined;
 
   const rowClass = `row${enter !== null ? ' row-enter' : ''}${settled ? ` settle-${status}` : ''}`;
   const rowStyle = enter !== null ? { animationDelay: `${Math.min(enter, 8) * 18}ms` } : undefined;
@@ -551,12 +570,22 @@ function RowView({
       <span className="spacer" />
       {container && !expanded ? (
         <span className="pills">
-          {STATUS_ORDER.filter((s) => counts[s] > 0).map((s) => (
-            <span className="pill" data-soft={s} key={s}>{counts[s]}</span>
+          {STATUS_ORDER.filter((s) => (s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]) > 0).map((s) => (
+            <span className="pill" data-soft={s} key={s}>{s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]}</span>
           ))}
         </span>
       ) : null}
-      <span className="dur">{formatDuration(liveNodeDuration(node, now, since, clock)) || '—'}</span>
+      {carriedRun ? (
+        <span className="carry-gut">
+          {carryTip ? (
+            <span className="carry-chip" data-tip={carryTip} title={carryTip} aria-label={carryTip}>
+              <CarryIcon />
+              {markAttempt != null ? markAttempt + 1 : null}
+            </span>
+          ) : null}
+        </span>
+      ) : null}
+      <span className="dur" data-carried={carried || rollupMark ? 'true' : undefined}>{formatDuration(liveNodeDuration(node, now, since, clock)) || '—'}</span>
     </div>
   );
 }
@@ -633,19 +662,25 @@ export function TreeView({
   // A steadily-incrementing tick that drives live duration re-renders.
   const [, setTick] = useState(0);
 
+  const [onlyRerun, setOnlyRerun] = useState(false);
+
   const files = snapshot.root.children;
   const { counts } = snapshot;
   const q = query.trim().toLowerCase();
+  const carriedRun = counts.carried > 0;
+  const freshCount = counts.total - counts.carried;
+  const runAttempt = snapshot.attempt;
+  const summaryAttempt = carriedRun ? carriedAttempt(snapshot.root) : undefined;
 
   const matches = useMemo(
-    () => (q || statuses.size > 0 ? computeMatches(files, q, statuses) : null),
-    [files, q, statuses],
+    () => (q || statuses.size > 0 || onlyRerun ? computeMatches(files, q, statuses, onlyRerun) : null),
+    [files, q, statuses, onlyRerun],
   );
   const rows = useMemo(
     () => buildRows(files, {
-      overrides, query: q, statuses, matches,
+      overrides, query: q, statuses, matches, onlyRerun,
     }),
-    [files, overrides, q, statuses, matches],
+    [files, overrides, q, statuses, matches, onlyRerun],
   );
 
   const toggle = (key: string, current: boolean) => {
@@ -757,6 +792,12 @@ export function TreeView({
               </button>
             ))}
           </div>
+          {carriedRun ? (
+            <span className="carry-sum">
+              {runAttempt != null ? `attempt ${runAttempt + 1} of ${runAttempt + 1} · ` : ''}
+              {freshCount} re-run · {counts.carried} carried{summaryAttempt != null ? ` from attempt ${summaryAttempt + 1}` : ''}
+            </span>
+          ) : null}
           <div className="tools">
             <div className="search">
               <SearchIcon />
@@ -767,6 +808,18 @@ export function TreeView({
                 aria-label="Filter tests"
               />
             </div>
+            {carriedRun ? (
+              <button
+                type="button"
+                className="btn"
+                data-on={onlyRerun ? 'true' : undefined}
+                aria-pressed={onlyRerun}
+                onClick={() => setOnlyRerun(!onlyRerun)}
+                title={onlyRerun ? 'Show carried-over tests again' : 'Show only tests that actually executed this attempt'}
+              >
+                Only re-run
+              </button>
+            ) : null}
             <button
               type="button"
               className="btn"
@@ -823,9 +876,11 @@ export function TreeView({
               now={now}
               since={since}
               clock={clock}
+              carriedRun={carriedRun}
+              onlyRerun={onlyRerun}
             />
           )))
-        ) : q || statuses.size > 0 ? (
+        ) : q || statuses.size > 0 || onlyRerun ? (
           <CenteredState
             icon="⌕"
             iconStatus="skipped"
@@ -833,12 +888,13 @@ export function TreeView({
           >
             <div className="state-sub">
               {q ? 'Try a shorter query, or search by file name.'
-                : 'No test has any of the selected statuses.'}
+                : statuses.size > 0 ? 'No test has any of the selected statuses.'
+                  : 'Every test was carried over — nothing executed this attempt.'}
             </div>
             <button
               type="button"
               className="btn-primary"
-              onClick={() => { setQuery(''); setStatuses(new Set()); }}
+              onClick={() => { setQuery(''); setStatuses(new Set()); setOnlyRerun(false); }}
             >
               Clear filters
             </button>

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -183,7 +183,7 @@ export interface Matches {
  * match is actually on screen; a leaf that only inherited its ancestor's name
  * match doesn't force anything open.
  */
-export function computeMatches(files: TestNode[], query: string, statuses: ReadonlySet<TestStatus> = new Set()): Matches {
+export function computeMatches(files: TestNode[], query: string, statuses: ReadonlySet<TestStatus> = new Set(), onlyRerun = false): Matches {
   const visible = new Set<string>();
   const force = new Set<string>();
   const statusOk = (node: TestNode): boolean => statuses.size === 0 || statuses.has(node.status);
@@ -197,7 +197,8 @@ export function computeMatches(files: TestNode[], query: string, statuses: Reado
       descVis ||= r.vis;
       descOwn ||= r.own;
     }
-    const leafMatch = node.children.length === 0 && textOk && statusOk(node);
+    const leafMatch = node.children.length === 0 && textOk && statusOk(node)
+      && (!onlyRerun || node.passedOnAttempt == null);
     if (leafMatch || descVis) {
       visible.add(node.key);
       for (const a of ancestors) visible.add(a);
@@ -217,11 +218,12 @@ export interface BuildOptions {
   overrides: Map<string, boolean>;
   query: string;
   statuses?: ReadonlySet<TestStatus>;
+  onlyRerun?: boolean;
   matches: Matches | null;
 }
 
 function filtering(opts: BuildOptions): boolean {
-  return opts.query !== '' || (opts.statuses?.size ?? 0) > 0;
+  return opts.query !== '' || (opts.statuses?.size ?? 0) > 0 || opts.onlyRerun === true;
 }
 
 export function isExpanded(node: TestNode, opts: BuildOptions): boolean {

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -7,6 +7,7 @@ const DARK = `
   --st-passed:#34d27b; --st-failed:#fb5a6a; --st-skipped:#8a93a1; --st-todo:#7c9cff; --st-running:#ffb13d; --st-queued:#5d6573;
   --soft-passed:rgba(52,210,123,.15); --soft-failed:rgba(251,90,106,.16); --soft-skipped:rgba(138,147,161,.16); --soft-todo:rgba(124,156,255,.16); --soft-running:rgba(255,177,61,.17); --soft-queued:rgba(93,101,115,.18);
   --fail-tint:rgba(251,90,106,.07);
+  --carry-fg:#a2a9b5; --carry-bg:rgba(255,255,255,.06); --carry-border:rgba(255,255,255,.14);
   --ansi-black:#5d6573; --ansi-red:#fb5a6a; --ansi-green:#34d27b; --ansi-yellow:#ffb13d; --ansi-blue:#7c9cff; --ansi-magenta:#c792ea; --ansi-cyan:#56d4dd; --ansi-white:#c4c9d4;
   --ansi-bright-black:#8a93a1; --ansi-bright-red:#ff8087; --ansi-bright-green:#66e0a3; --ansi-bright-yellow:#ffca6a; --ansi-bright-blue:#a3b8ff; --ansi-bright-magenta:#e0aaff; --ansi-bright-cyan:#8be9fd; --ansi-bright-white:#ffffff;
   --ansi-bold-font-weight:700; --ansi-dim-opacity:.6;
@@ -21,6 +22,7 @@ const LIGHT = `
   --st-passed:#16a34a; --st-failed:#e23744; --st-skipped:#697381; --st-todo:#3f63d6; --st-running:#bf7400; --st-queued:#97a0ad;
   --soft-passed:rgba(22,163,74,.12); --soft-failed:rgba(226,55,68,.10); --soft-skipped:rgba(105,115,129,.12); --soft-todo:rgba(63,99,214,.11); --soft-running:rgba(191,116,0,.13); --soft-queued:rgba(151,160,173,.14);
   --fail-tint:rgba(226,55,68,.05);
+  --carry-fg:#586170; --carry-bg:rgba(17,24,33,.05); --carry-border:rgba(17,24,33,.14);
   --ansi-black:#161b22; --ansi-red:#e23744; --ansi-green:#16a34a; --ansi-yellow:#bf7400; --ansi-blue:#3f63d6; --ansi-magenta:#9333ea; --ansi-cyan:#0e7490; --ansi-white:#5a636f;
   --ansi-bright-black:#697381; --ansi-bright-red:#dc2626; --ansi-bright-green:#15803d; --ansi-bright-yellow:#a16207; --ansi-bright-blue:#2947c0; --ansi-bright-magenta:#7e22ce; --ansi-bright-cyan:#0891b2; --ansi-bright-white:#161b22;
   --ansi-bold-font-weight:700; --ansi-dim-opacity:.6;
@@ -127,6 +129,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 .search svg { position: absolute; left: 11px; color: var(--faint); pointer-events: none; }
 .search input { background: var(--panel-2); border: 1px solid var(--line); color: var(--fg); font-size: 13px; padding: 8px 12px 8px 32px; border-radius: 10px; width: 188px; outline: none; }
 .btn { display: inline-flex; align-items: center; gap: 6px; background: var(--panel-2); border: 1px solid var(--line); color: var(--dim); border-radius: 10px; padding: 8px 11px; font-size: 12px; cursor: pointer; transition: background .13s, color .13s, transform .13s; }
+.btn[data-on="true"] { color: var(--fg); border-color: var(--line-2); background: var(--raise); }
 .btn:hover { background: var(--raise); color: var(--fg); }
 .btn:active { transform: scale(.97); }
 .hdr-bar-row { padding: 0 18px 13px; display: flex; align-items: center; gap: 14px; }
@@ -155,7 +158,13 @@ button { font-family: inherit; } input { font-family: inherit; }
 .spacer { flex: 1; min-width: 10px; }
 .pills { display: inline-flex; gap: 5px; flex: none; margin-right: 9px; }
 .pill { font-size: 11px; font-weight: 700; border-radius: 999px; padding: 1px 8px; font-variant-numeric: tabular-nums; }
+.carry-gut { flex: none; min-width: 44px; display: flex; justify-content: flex-end; }
+.carry-chip { position: relative; display: inline-flex; align-items: center; gap: 3px; color: var(--carry-fg); background: var(--carry-bg); border: 1px solid var(--carry-border); border-radius: 999px; padding: 1px 7px; font-size: 10.5px; font-weight: 600; font-family: var(--mono); font-variant-numeric: tabular-nums; }
+.carry-chip::after { content: attr(data-tip); position: absolute; right: 0; bottom: calc(100% + 6px); z-index: 5; white-space: nowrap; background: var(--raise); color: var(--fg); border: 1px solid var(--line-2); border-radius: 8px; padding: 4px 9px; font-size: 11px; font-weight: 500; font-family: var(--sans); opacity: 0; pointer-events: none; transition: opacity .12s; }
+.carry-chip:hover::after { opacity: 1; }
+.carry-sum { flex: none; font-size: 11px; color: var(--dim); font-variant-numeric: tabular-nums; }
 .dur { flex: none; color: var(--faint); font-size: 11.5px; font-family: var(--mono); min-width: 54px; text-align: right; font-variant-numeric: tabular-nums; }
+.dur[data-carried="true"] { font-style: italic; }
 
 /* diagnostics */
 .diag { border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: var(--panel-2); }

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../src/client/rowModel.ts';
 
 const zeroCounts = (): Counts => ({
-  passed: 0, failed: 0, skipped: 0, todo: 0, running: 0, queued: 0, total: 0,
+  passed: 0, failed: 0, skipped: 0, todo: 0, running: 0, queued: 0, carried: 0, total: 0,
 });
 
 function node(over: Partial<TestNode> = {}): TestNode {

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -392,3 +392,44 @@ test('a container name match under a status filter shows only matching leaves be
   assert.ok(matches.visible.has('p1'), 'passed leaf under the matched suite is visible');
   assert.ok(!matches.visible.has('f1'), 'failed leaf is filtered out despite the container name match');
 });
+
+test('onlyRerun hides carried leaves, keeps executed tests and their ancestors', () => {
+  const carried = node({ key: 'c', name: 'carried', passedOnAttempt: 0, counts: { ...zeroCounts(), passed: 1, carried: 1, total: 1 } });
+  const fresh = node({ key: 'f', name: 'fresh', counts: { ...zeroCounts(), passed: 1, total: 1 } });
+  const file = node({
+    key: 'file', type: 'file', children: [carried, fresh],
+    counts: { ...zeroCounts(), passed: 2, carried: 1, total: 2 },
+  });
+  const matches = computeMatches([file], '', new Set(), true);
+  assert.ok(!matches.visible.has('c'));
+  assert.ok(matches.visible.has('f'));
+  assert.ok(matches.visible.has('file'));
+
+  const rows = buildRows([file], { overrides: new Map(), query: '', statuses: new Set(), matches, onlyRerun: true });
+  assert.deepStrictEqual(rows.map((r) => r.node.key), ['file', 'f']);
+});
+
+test('onlyRerun composes with the name filter', () => {
+  const carried = node({ key: 'c', name: 'alpha carried', passedOnAttempt: 0, counts: { ...zeroCounts(), passed: 1, carried: 1, total: 1 } });
+  const fresh = node({ key: 'f', name: 'alpha fresh', counts: { ...zeroCounts(), passed: 1, total: 1 } });
+  const other = node({ key: 'o', name: 'beta fresh', counts: { ...zeroCounts(), passed: 1, total: 1 } });
+  const file = node({
+    key: 'file', type: 'file', children: [carried, fresh, other],
+    counts: { ...zeroCounts(), passed: 3, carried: 1, total: 3 },
+  });
+  const matches = computeMatches([file], 'alpha', new Set(), true);
+  assert.ok(!matches.visible.has('c'));
+  assert.ok(matches.visible.has('f'));
+  assert.ok(!matches.visible.has('o'));
+});
+
+test('an all-carried file disappears under onlyRerun', () => {
+  const carried = node({ key: 'c', name: 'carried', passedOnAttempt: 0, counts: { ...zeroCounts(), passed: 1, carried: 1, total: 1 } });
+  const file = node({
+    key: 'file', type: 'file', children: [carried],
+    counts: { ...zeroCounts(), passed: 1, carried: 1, total: 1 },
+  });
+  const matches = computeMatches([file], '', new Set(), true);
+  const rows = buildRows([file], { overrides: new Map(), query: '', statuses: new Set(), matches, onlyRerun: true });
+  assert.deepStrictEqual(rows, []);
+});


### PR DESCRIPTION
## What

Under node's `--test-rerun-failures`, a rerun re-executes only the tests that failed on the previous attempt — everything else is reported as passed but **did not actually run**, carrying its pass forward. The viewer had no way to tell a carried pass from a fresh one.

This implements the designer's chosen direction (**1c — aligned attempt gutter**): a neutral `⟲ N` chip in a right-aligned gutter column just before the duration, so "what actually ran this attempt" is scannable even across hundreds of carried rows. Carried-over is an overlay on `passed`, never a new status.

## How

Node already stamps `details.attempt` (all pass/fail) and `details.passed_on_attempt` (only on carried, replayed passes) under `--test-rerun-failures`; `toWireEvent` was dropping both. Carried ⇔ `passed_on_attempt` present — a single ndjson is self-sufficient.

- **tree-core**: pass the two fields through the wire; `TestNode.passedOnAttempt`, `Counts.carried`, `TreeSnapshot.attempt`; `isCarried`/`carriedAttempt` rollup helpers. A carried test's replayed duration no longer backdates the run clock (it would inflate the header's elapsed time by hours).
- **web**: gutter chip with pure-CSS hover tooltip (`Carried from attempt N · not executed this run`) + `title`/aria; prior duration dimmed + italic; rollup marker on all-carried file/suite headers (mixed containers mark children individually); **Only re-run** header toggle that hides carried tests (composes with the name/status filters, pills show re-run counts); header summary `attempt N of N · X re-run · Y carried from attempt N`.

Attempt numbers are stored 0-based as emitted, displayed 1-based. Reports without the fields render exactly as before — no gutter, no toggle, no summary.

## Testing

- Unit tests across the wire passthrough, store overlay/counts/clock guard, rollup helpers, and the only-re-run row-model filter (312 passing, statement coverage stays 100%).
- Verified in the browser against a real 242-test rerun log (annotated per node's replay semantics) in both themes, and side-by-side with the design handoff's 1c reference; confirmed a non-rerun report is pixel-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)