### PR TITLE
feat(web): shared body-level tooltip engine and full tooltip coverage

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -23,6 +23,39 @@ const STATUS_LABEL: Record<TestStatus, string> = {
   passed: 'passed', failed: 'failed', skipped: 'skipped', todo: 'todo', running: 'running', queued: 'queued',
 };
 
+function pct(n: number, total: number): string {
+  const tenths = Math.round((n / Math.max(total, 1)) * 1000) / 10;
+  return `${tenths % 1 === 0 ? tenths.toFixed(0) : tenths}%`;
+}
+
+function chipTip(s: TestStatus, n: number, total: number): string {
+  switch (s) {
+    case 'passed': return `${n} passed · ${pct(n, total)} of the run`;
+    case 'failed': return n === 0 ? '0 failed — nothing to triage' : `${n} failed — click to show only failures`;
+    case 'skipped': return `${n} skipped — expand a row to see why`;
+    case 'todo': return `${n} todo — planned, not yet implemented`;
+    case 'running': return `${n} running — results stream in live`;
+    default: return `${n} queued — waiting to run`;
+  }
+}
+
+function shortReason(reason: string): string {
+  const plain = stripAnsi(reason).replace(/\s+/g, ' ').trim();
+  return plain.length > 90 ? `${plain.slice(0, 89)}…` : plain;
+}
+
+function statusTip(node: TestNode, status: TestStatus, ms: number): string | undefined {
+  const reason = reasonOf(node);
+  switch (status) {
+    case 'passed': return `Passed in ${formatDuration(ms) || '—'}`;
+    case 'failed': return 'Failed';
+    case 'skipped': return reason ? `Skipped — ${shortReason(reason)}` : 'Skipped';
+    case 'todo': return reason ? `Todo — ${shortReason(reason)}` : 'Todo — not yet implemented';
+    case 'queued': return 'Queued — waiting to run';
+    default: return undefined;
+  }
+}
+
 interface OutLine { stream: 'out' | 'err'; text: string; }
 
 interface DiagBlock {
@@ -77,7 +110,7 @@ function linkifyDom(rootEl: HTMLElement): void {
         // Long URLs (presigned links, trace endpoints) would wrap across many
         // lines and bury the message — middle-truncate the label, keep the href.
         a.textContent = seg.text.length > 64 ? `${seg.text.slice(0, 42)}…${seg.text.slice(-18)}` : seg.text;
-        a.title = seg.text;
+        if (seg.text.length > 64) a.setAttribute('data-tip', seg.text);
         frag.appendChild(a);
       } else {
         frag.appendChild(document.createTextNode(seg.text));
@@ -273,7 +306,7 @@ function CopyButton({ text }: { text: string }) {
     });
   };
   return (
-    <button type="button" className="hbtn" onClick={copy} title="Copy to clipboard">
+    <button type="button" className="hbtn" onClick={copy} data-tip="Copy to clipboard" aria-label="Copy to clipboard">
       {copied ? '✓' : '⧉'}
       <span className="hbtn-label">{copied ? ' Copied' : ' Copy'}</span>
     </button>
@@ -341,14 +374,14 @@ function DiagSection({
           >
             {open && long ? (
               <>
-                <button type="button" className="hbtn" onClick={() => jump(false)} title="Jump to top">⤒</button>
-                <button type="button" className="hbtn" onClick={() => jump(true)} title="Jump to end">⤓</button>
+                <button type="button" className="hbtn" onClick={() => jump(false)} data-tip="Jump to top" aria-label="Jump to top">⤒</button>
+                <button type="button" className="hbtn" onClick={() => jump(true)} data-tip="Jump to end" aria-label="Jump to end">⤓</button>
               </>
             ) : null}
             <CopyButton text={block.copyText} />
-            <button type="button" className="hbtn" onClick={() => setModal(true)} title="Open full log">⤢<span className="hbtn-label"> Full log</span></button>
+            <button type="button" className="hbtn" onClick={() => setModal(true)} data-tip="Open full log" aria-label="Open full log">⤢<span className="hbtn-label"> Full log</span></button>
             {open ? (
-              <button type="button" className="hbtn hbtn-collapse" onClick={onToggle} title="Collapse this section">Collapse</button>
+              <button type="button" className="hbtn hbtn-collapse" onClick={onToggle} data-tip="Collapse this section">Collapse</button>
             ) : null}
           </div>
         </div>
@@ -407,7 +440,7 @@ function LogModal({ title, block, onClose }: { title: string; block: DiagBlock; 
           {block.count ? <span className="diag-count">{formatCount(block.count.n)} {block.count.unit}</span> : null}
           <div className="diag-tools">
             <CopyButton text={block.copyText} />
-            <button type="button" className="hbtn" data-on={wrap ? 'true' : undefined} onClick={() => setWrap(!wrap)} title="Toggle line wrapping">Wrap</button>
+            <button type="button" className="hbtn" data-on={wrap ? 'true' : undefined} onClick={() => setWrap(!wrap)} data-tip="Toggle line wrapping">Wrap</button>
             <button type="button" className="hbtn" onClick={onClose} aria-label="Close">✕</button>
           </div>
         </div>
@@ -526,6 +559,10 @@ function RowView({
   const rowClass = `row${enter !== null ? ' row-enter' : ''}${settled ? ` settle-${status}` : ''}`;
   const rowStyle = enter !== null ? { animationDelay: `${Math.min(enter, 8) * 18}ms` } : undefined;
   const hasError = hasDiag && diagBlocks(node).some((b) => b.key === 'error');
+  const ms = liveNodeDuration(node, now, since, clock);
+  const durTip = carried || rollupMark
+    ? `${formatDuration(ms) || '—'} — measured on ${markAttempt != null ? `attempt ${markAttempt + 1}` : 'an earlier attempt'}`
+    : status !== 'running' && ms >= 1000 ? `${Math.round(ms).toLocaleString('en-US')} ms` : undefined;
 
   return (
     <div
@@ -553,12 +590,12 @@ function RowView({
       ) : (
         // One visual language for pass/fail at every level: containers and leaf
         // tests both use the status glyph (design mobile-review ruling).
-        <span className="cglyph indicator" data-stc={status} data-spin={!isTest && status === 'running' ? 'true' : undefined}>{GLYPH[status]}</span>
+        <span className="cglyph indicator" data-stc={status} data-spin={!isTest && status === 'running' ? 'true' : undefined} data-tip={!container ? statusTip(node, status, ms) : undefined}>{GLYPH[status]}</span>
       )}
-      <span className="name" data-kind={node.type} style={{ color: nameColor }}>{displayName(node)}</span>
+      <span className="name" data-kind={node.type} data-tip-clipped={node.type === 'file' ? node.file ?? displayName(node) : displayName(node)} style={{ color: nameColor }}>{displayName(node)}</span>
       {hasDiag ? (
         // Passive badge (never a control): output exists inside this node.
-        <span className="outbadge" data-stc={hasError ? 'failed' : undefined} title="Has output">
+        <span className="outbadge" data-stc={hasError ? 'failed' : undefined} data-tip={hasError ? 'Has error output — expand the row to view' : 'Has output — expand the row to view'}>
           {hasError ? '✕' : '◇'}
         </span>
       ) : null}
@@ -571,21 +608,21 @@ function RowView({
       {container && !expanded ? (
         <span className="pills">
           {STATUS_ORDER.filter((s) => (s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]) > 0).map((s) => (
-            <span className="pill" data-soft={s} key={s}>{s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]}</span>
+            <span className="pill" data-soft={s} data-tip={`${s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]} ${STATUS_LABEL[s]}`} key={s}>{s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]}</span>
           ))}
         </span>
       ) : null}
       {carriedRun ? (
         <span className="carry-gut">
           {carryTip ? (
-            <span className="carry-chip" data-tip={carryTip} title={carryTip} aria-label={carryTip}>
+            <span className="carry-chip" data-tip={carryTip} aria-label={carryTip} tabIndex={0}>
               <CarryIcon />
               {markAttempt != null ? markAttempt + 1 : null}
             </span>
           ) : null}
         </span>
       ) : null}
-      <span className="dur" data-carried={carried || rollupMark ? 'true' : undefined}>{formatDuration(liveNodeDuration(node, now, since, clock)) || '—'}</span>
+      <span className="dur" data-carried={carried || rollupMark ? 'true' : undefined} data-tip={durTip}>{formatDuration(ms) || '—'}</span>
     </div>
   );
 }
@@ -593,8 +630,9 @@ function RowView({
 function Verdict({ counts, inProgress, duration }: { counts: Counts; inProgress: boolean; duration: number }) {
   const status: TestStatus = inProgress ? 'running' : counts.failed > 0 ? 'failed' : 'passed';
   const label = inProgress ? 'Running' : counts.failed > 0 ? 'Failing' : 'Passing';
+  const tip = `${counts.total} ${counts.total === 1 ? 'test' : 'tests'} · ${inProgress ? 'running for' : 'finished in'} ${formatDuration(duration) || '—'}`;
   return (
-    <div className="verdict" data-soft={status}>
+    <div className="verdict" data-soft={status} data-tip={tip} tabIndex={0}>
       <span className="verdict-glyph" data-spin={inProgress ? 'true' : undefined}>{GLYPH[status]}</span>
       <div className="verdict-text">
         <span className="verdict-main">{label}</span>
@@ -782,7 +820,7 @@ export function TreeView({
                 data-soft={s}
                 data-active={statuses.has(s) ? 'true' : undefined}
                 aria-pressed={statuses.has(s)}
-                title={statuses.has(s) ? `Stop filtering by ${STATUS_LABEL[s]}` : `Show only ${STATUS_LABEL[s]} tests`}
+                data-tip={statuses.has(s) ? `Stop filtering by ${STATUS_LABEL[s]}` : chipTip(s, counts[s], counts.total)}
                 onClick={() => toggleStatus(s)}
                 key={s}
               >
@@ -815,7 +853,7 @@ export function TreeView({
                 data-on={onlyRerun ? 'true' : undefined}
                 aria-pressed={onlyRerun}
                 onClick={() => setOnlyRerun(!onlyRerun)}
-                title={onlyRerun ? 'Show carried-over tests again' : 'Show only tests that actually executed this attempt'}
+                data-tip={onlyRerun ? 'Show carried-over tests again' : 'Show only tests that actually executed this attempt'}
               >
                 Only re-run
               </button>
@@ -824,7 +862,7 @@ export function TreeView({
               type="button"
               className="btn"
               onClick={toggleTheme}
-              title={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
+              data-tip={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
               aria-label={`Switch to ${theme === 'dark' ? 'light' : 'dark'} mode`}
             >
               <ThemeIcon theme={theme} />
@@ -833,7 +871,7 @@ export function TreeView({
               type="button"
               className="btn"
               onClick={toggleAll}
-              title={allCollapsed ? 'Expand all files and suites' : 'Collapse all files and suites'}
+              data-tip={allCollapsed ? 'Expand every file and suite' : 'Collapse every file and suite'}
             >
               {allCollapsed ? 'Expand all' : 'Collapse all'}
             </button>
@@ -848,7 +886,7 @@ export function TreeView({
                 key={s}
                 data-stf={s}
                 data-pulse={s === 'running' ? 'true' : undefined}
-                title={`${counts[s]} ${STATUS_LABEL[s]}`}
+                data-tip={`${counts[s]} ${STATUS_LABEL[s]} · ${pct(counts[s], total)}`}
                 aria-label={`${counts[s]} ${STATUS_LABEL[s]}`}
                 style={{ flex: `${counts[s] / total} 0 6px` }}
               />

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -5,6 +5,7 @@ import { createNdjsonReader } from '../poll.ts';
 import { resolveReportSource, type ViewerOptions } from '../source.ts';
 import { STYLES } from '../template.ts';
 import { TreeView } from './TreeView.tsx';
+import { initTooltips } from './tooltip.ts';
 
 export type { ReportSource, ViewerOptions } from '../source.ts';
 export type { FetchLike } from '../poll.ts';
@@ -21,6 +22,7 @@ function injectStyles(): void {
 
 export async function startViewer(options: ViewerOptions = {}): Promise<void> {
   injectStyles();
+  initTooltips();
   const mount = document.getElementById('root');
   if (!mount) return;
   const root = createRoot(mount);

--- a/packages/web/src/client/tooltip.ts
+++ b/packages/web/src/client/tooltip.ts
@@ -1,0 +1,73 @@
+/**
+ * One shared tooltip element, appended to `document.body` and positioned with
+ * `position:fixed` + `getBoundingClientRect()`, driven by `data-tip` and event
+ * delegation (designer reference engine). A body-level fixed node sits outside
+ * every `overflow` container and stacking context, so nothing clips it or
+ * paints over it — the failure modes of the previous per-element CSS tooltip.
+ *
+ * `data-tip` always shows. `data-tip-clipped` shows only while the target's
+ * text is actually truncated (ellipsis or line-clamp), checked at hover time
+ * so window resizes need no bookkeeping.
+ */
+export function initTooltips(): void {
+  if (document.getElementById('rt-tooltip')) return;
+  const tip = document.createElement('div');
+  tip.id = 'rt-tooltip';
+  tip.className = 'rt-tooltip';
+  tip.setAttribute('role', 'tooltip');
+  document.body.appendChild(tip);
+
+  const textFor = (el: Element): string | null => {
+    const clipped = el.getAttribute('data-tip-clipped');
+    if (clipped && (el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight)) return clipped;
+    return el.getAttribute('data-tip');
+  };
+
+  let openTimer: ReturnType<typeof setTimeout> | undefined;
+  let current: Element | null = null;
+
+  const place = (el: Element): void => {
+    const text = textFor(el);
+    if (!text) return;
+    tip.textContent = text;
+    tip.style.display = 'block';
+    const r = el.getBoundingClientRect();
+    const t = tip.getBoundingClientRect();
+    const gap = 8;
+    let top = r.top - t.height - gap;
+    if (top < gap) top = r.bottom + gap; // flip below near the top edge
+    const left = Math.max(gap, Math.min(r.left + r.width / 2 - t.width / 2, window.innerWidth - t.width - gap));
+    tip.style.top = `${top}px`;
+    tip.style.left = `${left}px`;
+    void tip.offsetWidth; // reflow so the opacity fade runs
+    tip.style.opacity = '1';
+  };
+  const hide = (): void => {
+    clearTimeout(openTimer);
+    current = null;
+    tip.style.opacity = '0';
+    tip.style.display = 'none';
+  };
+
+  const targetOf = (e: Event): Element | null => (e.target as Element | null)?.closest?.('[data-tip], [data-tip-clipped]') ?? null;
+  const over = (e: Event): void => {
+    const el = targetOf(e);
+    if (!el || el === current || !textFor(el)) return;
+    current = el;
+    clearTimeout(openTimer);
+    openTimer = setTimeout(() => place(el), 140);
+  };
+  const out = (e: Event): void => {
+    const el = targetOf(e);
+    // Moving between children of the target isn't a leave — don't flicker.
+    const to = (e as PointerEvent).relatedTarget as Node | null;
+    if (el && el === current && !(to && el.contains(to))) hide();
+  };
+
+  document.addEventListener('pointerover', over);
+  document.addEventListener('pointerout', out);
+  document.addEventListener('focusin', over);
+  document.addEventListener('focusout', out);
+  document.addEventListener('keydown', (e) => { if (e.key === 'Escape') hide(); });
+  window.addEventListener('scroll', hide, true);
+}

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -8,6 +8,7 @@ const DARK = `
   --soft-passed:rgba(52,210,123,.15); --soft-failed:rgba(251,90,106,.16); --soft-skipped:rgba(138,147,161,.16); --soft-todo:rgba(124,156,255,.16); --soft-running:rgba(255,177,61,.17); --soft-queued:rgba(93,101,115,.18);
   --fail-tint:rgba(251,90,106,.07);
   --carry-fg:#a2a9b5; --carry-bg:rgba(255,255,255,.06); --carry-border:rgba(255,255,255,.14);
+  --tip-bg:#eceef3; --tip-fg:#15171e; --tip-border:rgba(2,21,30,.12); --tip-shadow:0 12px 30px rgba(0,0,0,.5);
   --ansi-black:#5d6573; --ansi-red:#fb5a6a; --ansi-green:#34d27b; --ansi-yellow:#ffb13d; --ansi-blue:#7c9cff; --ansi-magenta:#c792ea; --ansi-cyan:#56d4dd; --ansi-white:#c4c9d4;
   --ansi-bright-black:#8a93a1; --ansi-bright-red:#ff8087; --ansi-bright-green:#66e0a3; --ansi-bright-yellow:#ffca6a; --ansi-bright-blue:#a3b8ff; --ansi-bright-magenta:#e0aaff; --ansi-bright-cyan:#8be9fd; --ansi-bright-white:#ffffff;
   --ansi-bold-font-weight:700; --ansi-dim-opacity:.6;
@@ -23,6 +24,7 @@ const LIGHT = `
   --soft-passed:rgba(22,163,74,.12); --soft-failed:rgba(226,55,68,.10); --soft-skipped:rgba(105,115,129,.12); --soft-todo:rgba(63,99,214,.11); --soft-running:rgba(191,116,0,.13); --soft-queued:rgba(151,160,173,.14);
   --fail-tint:rgba(226,55,68,.05);
   --carry-fg:#586170; --carry-bg:rgba(17,24,33,.05); --carry-border:rgba(17,24,33,.14);
+  --tip-bg:#161b22; --tip-fg:#f6f7f9; --tip-border:rgba(255,255,255,.08); --tip-shadow:0 10px 26px rgba(2,21,30,.34);
   --ansi-black:#161b22; --ansi-red:#e23744; --ansi-green:#16a34a; --ansi-yellow:#bf7400; --ansi-blue:#3f63d6; --ansi-magenta:#9333ea; --ansi-cyan:#0e7490; --ansi-white:#5a636f;
   --ansi-bright-black:#697381; --ansi-bright-red:#dc2626; --ansi-bright-green:#15803d; --ansi-bright-yellow:#a16207; --ansi-bright-blue:#2947c0; --ansi-bright-magenta:#7e22ce; --ansi-bright-cyan:#0891b2; --ansi-bright-white:#161b22;
   --ansi-bold-font-weight:700; --ansi-dim-opacity:.6;
@@ -159,12 +161,16 @@ button { font-family: inherit; } input { font-family: inherit; }
 .pills { display: inline-flex; gap: 5px; flex: none; margin-right: 9px; }
 .pill { font-size: 11px; font-weight: 700; border-radius: 999px; padding: 1px 8px; font-variant-numeric: tabular-nums; }
 .carry-gut { flex: none; min-width: 44px; display: flex; justify-content: flex-end; }
-.carry-chip { position: relative; display: inline-flex; align-items: center; gap: 3px; color: var(--carry-fg); background: var(--carry-bg); border: 1px solid var(--carry-border); border-radius: 999px; padding: 1px 7px; font-size: 10.5px; font-weight: 600; font-family: var(--mono); font-variant-numeric: tabular-nums; }
-.carry-chip::after { content: attr(data-tip); position: absolute; right: 0; bottom: calc(100% + 6px); z-index: 5; white-space: nowrap; background: var(--raise); color: var(--fg); border: 1px solid var(--line-2); border-radius: 8px; padding: 4px 9px; font-size: 11px; font-weight: 500; font-family: var(--sans); opacity: 0; pointer-events: none; transition: opacity .12s; }
-.carry-chip:hover::after { opacity: 1; }
+.carry-chip { display: inline-flex; align-items: center; gap: 3px; color: var(--carry-fg); background: var(--carry-bg); border: 1px solid var(--carry-border); border-radius: 999px; padding: 1px 7px; font-size: 10.5px; font-weight: 600; font-family: var(--mono); font-variant-numeric: tabular-nums; }
 .carry-sum { flex: none; font-size: 11px; color: var(--dim); font-variant-numeric: tabular-nums; }
 .dur { flex: none; color: var(--faint); font-size: 11.5px; font-family: var(--mono); min-width: 54px; text-align: right; font-variant-numeric: tabular-nums; }
 .dur[data-carried="true"] { font-style: italic; }
+
+/* shared floating tooltip: one body-level fixed node (client/tooltip.ts), so
+   no overflow container or sticky-header stacking context can clip or cover
+   it; opaque INVERTED surface — a tooltip is a layer, not a chip */
+.rt-tooltip { position: fixed; top: 0; left: 0; z-index: 99999; display: none; opacity: 0; pointer-events: none; max-width: 300px; overflow-wrap: anywhere; font: 600 11.5px/1.45 var(--sans); padding: 6px 10px; border-radius: 8px; background: var(--tip-bg); color: var(--tip-fg); border: 1px solid var(--tip-border); box-shadow: var(--tip-shadow); transition: opacity .12s ease; }
+@media (prefers-reduced-motion: reduce) { .rt-tooltip { transition: none; } }
 
 /* diagnostics */
 .diag { border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: var(--panel-2); }


### PR DESCRIPTION
## Summary

Designer feedback round on tooltips: the carried-marker tooltip was implemented as a CSS `::after` inside the tree scroller, so it was clipped by `overflow`, painted under the sticky header, and reused the pale inline-chip tokens. This replaces it with the designer's reference engine and adds tooltips across the viewer per the handoff's placement map.

### The engine (`client/tooltip.ts`)
- One shared `role="tooltip"` node appended to `document.body` — outside every overflow container and stacking context, so nothing can clip or cover it.
- `position:fixed` + `getBoundingClientRect()`, `z-index:99999`, 140 ms open delay, viewport clamping with flip-below near the top edge, `Escape` and scroll dismissal, `focusin`/`focusout` for keyboard parity, `prefers-reduced-motion` respected.
- Driven by `data-tip` via event delegation; `data-tip-clipped` shows the full text only while the target is actually truncated (checked at hover time, so resizes need no bookkeeping).
- Opaque, theme-INVERTED surface via new `--tip-*` tokens (dark tooltip on light pages and vice versa) — a tooltip is a layer, not a chip.

### Placement map
Verdict badge (totals + duration), stat chips (`223 passed · 92.5% of the run`, `0 failed — nothing to triage`, …), proportional-bar segments, theme/collapse/only-re-run buttons, leaf status glyphs (`Passed in 76ms`, `Skipped — <reason>`), collapsed-container count pills, truncated file/suite/test names (full path for files), durations (exact `1,160 ms` when abbreviated; `14ms — measured on attempt 1` for carried rows), output badges, carried markers, and the diagnostics toolbar buttons. All native `title=` tooltips removed. Carets, filter input, and footer legend intentionally skipped.

### Deviations from the handoff copy
- Failed chip says "click to show only failures" (chips filter; they don't jump-to-first).
- Verdict tooltip omits "completed 2:14 PM" — the NDJSON log carries only relative stamps, no wall-clock epoch; needs a writer-side change if wanted.
- Per-row status dots aren't tabbable (a tab stop per row on thousand-row runs); rows themselves are focusable and announce status via `aria-label`.

## Test plan
- All 90 `@reporters/web` tests pass; build clean.
- Verified in Chromium against a real 241-test report and a synthesized carried-run log: no clipping over the sticky header, correct inversion in both themes, conditional truncation tips, Escape/scroll dismissal, Tab-focus tooltip on the carry chip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)