### PR TITLE
fix(web): one consistent stat-chip tooltip format

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -29,14 +29,7 @@ function pct(n: number, total: number): string {
 }
 
 function chipTip(s: TestStatus, n: number, total: number): string {
-  switch (s) {
-    case 'passed': return `${n} passed · ${pct(n, total)} of the run`;
-    case 'failed': return n === 0 ? '0 failed — nothing to triage' : `${n} failed — click to show only failures`;
-    case 'skipped': return `${n} skipped — expand a row to see why`;
-    case 'todo': return `${n} todo — planned, not yet implemented`;
-    case 'running': return `${n} running — results stream in live`;
-    default: return `${n} queued — waiting to run`;
-  }
+  return `${n} ${STATUS_LABEL[s]} · ${pct(n, total)} of the run`;
 }
 
 function shortReason(reason: string): string {
@@ -50,7 +43,7 @@ function statusTip(node: TestNode, status: TestStatus, ms: number): string | und
     case 'passed': return `Passed in ${formatDuration(ms) || '—'}`;
     case 'failed': return 'Failed';
     case 'skipped': return reason ? `Skipped — ${shortReason(reason)}` : 'Skipped';
-    case 'todo': return reason ? `Todo — ${shortReason(reason)}` : 'Todo — not yet implemented';
+    case 'todo': return reason ? `Todo — ${shortReason(reason)}` : 'Todo — does not fail the run';
     case 'queued': return 'Queued — waiting to run';
     default: return undefined;
   }


### PR DESCRIPTION
## Summary

Follow-up to the review comments on #243:

- **All stat chips share one tooltip format**: `N <status> · X% of the run` (e.g. `4 failed · 1.7% of the run`), replacing the per-status prose (`— click to show only failures`, `— expand a row to see why`, `— planned, not yet implemented`, …). Matches the passed chip and the bar-segment tooltips.
- **Todo copy corrected**: per the node:test docs a `todo` test executes — its failure just doesn't fail the run — so "planned, not yet implemented" was misleading. The chip now uses the neutral count/percentage format; the status-dot fallback reads `Todo — does not fail the run` (a `todo("reason")` still shows its reason).

## Test plan
- All 90 `@reporters/web` tests pass.
- Verified in Chromium against a real report: all four chips show the consistent format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)