### PR TITLE
fix(tree-core,web): keep still-running parents and open file wrappers marked running

### DIFF
--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -39,6 +39,10 @@ interface InternalNode {
   todo?: boolean | string;
   skip?: boolean | string;
   passedOnAttempt?: number;
+  // File groups only: the file-level wrapper has started but not yet
+  // completed — the file is alive even when every test in it has settled
+  // (hooks, teardown, or subtests still to come).
+  wrapperOpen?: boolean;
   childKeys: string[];
 }
 
@@ -531,6 +535,7 @@ export function createTreeStore(): TreeStore {
           // group must stay unplaced to settle in decl-stream order instead.
           const group = ensureGroupNode(groupKey(data), data.file);
           if (type === 'test:enqueue') group.declPlaced = true;
+          else group.wrapperOpen = true;
           break;
         }
         if (data.testId == null) break;
@@ -544,7 +549,12 @@ export function createTreeStore(): TreeStore {
         });
         break;
       case 'test:start':
-        if (isFileLevel(data)) { sawFileWrapper = true; declOpen.clear(); break; }
+        if (isFileLevel(data)) {
+          sawFileWrapper = true;
+          declOpen.clear();
+          ensureGroupNode(groupKey(data), data.file).wrapperOpen = true;
+          break;
+        }
         if (data.testId != null) {
           declStart(data);
         } else {
@@ -559,11 +569,11 @@ export function createTreeStore(): TreeStore {
         // the declaration-ordered pass/fail stack below.
         if (isFileLevel(data)) {
           sawFileWrapper = true;
+          const group = ensureGroupNode(groupKey(data), data.file);
+          group.wrapperOpen = false;
           // The wrapper measures the file's real wall-clock — the file's
           // concurrent tests sum to much more than the run actually took.
-          if (data.details?.duration_ms != null) {
-            ensureGroupNode(groupKey(data), data.file).durationMs = data.details.duration_ms;
-          }
+          if (data.details?.duration_ms != null) group.durationMs = data.details.duration_ms;
           break;
         }
         if (data.testId == null) break;
@@ -584,8 +594,9 @@ export function createTreeStore(): TreeStore {
         if (isFileLevel(data)) {
           sawFileWrapper = true;
           declOpen.clear();
+          const group = ensureGroupNode(groupKey(data), data.file);
+          group.wrapperOpen = false;
           if (data.details?.duration_ms != null) {
-            const group = ensureGroupNode(groupKey(data), data.file);
             group.durationMs = group.durationMs ?? data.details.duration_ms;
           }
           break;
@@ -622,8 +633,9 @@ export function createTreeStore(): TreeStore {
         // completion lacks duration detail.
         if (data.file !== undefined) {
           declOpen.clear();
+          const group = ensureGroupNode(groupKey(data), data.file);
+          group.wrapperOpen = false;
           if (data.duration_ms != null) {
-            const group = ensureGroupNode(groupKey(data), data.file);
             group.durationMs = group.durationMs ?? data.duration_ms;
           }
         }
@@ -685,13 +697,22 @@ export function createTreeStore(): TreeStore {
       if (internal.passedOnAttempt != null && internal.status === 'passed') counts.carried = 1;
     } else {
       for (const child of children) addCounts(counts, child.counts);
+      // A parent whose own body is still executing is itself a running test —
+      // its subtests so far may all have settled while it awaits more (or runs
+      // teardown). Count it, so ancestors and the header can't read done early.
+      // Once it settles it leaves the counts again: totals stay leaves-only.
+      if ((internal.type === 'test' || internal.type === 'suite') && !TERMINAL.has(internal.status)) {
+        counts[internal.status] += 1;
+        counts.total += 1;
+      }
     }
     // File and root nodes have no result event of their own; derive their
-    // status from their descendants.
+    // status from their descendants — and from the wrapper's own liveness,
+    // which outlives the last settled test (hooks, subtests still to come).
     let { status } = internal;
     if (internal.type === 'file' || internal.type === 'root') {
       if (counts.failed > 0) status = 'failed';
-      else if (counts.running > 0) status = 'running';
+      else if (counts.running > 0 || internal.wrapperOpen) status = 'running';
       else if (counts.queued > 0 && counts.passed + counts.skipped + counts.todo === 0) status = 'queued';
       else status = 'passed';
     }

--- a/packages/tree-core/tests/live-status.test.ts
+++ b/packages/tree-core/tests/live-status.test.ts
@@ -1,0 +1,102 @@
+// A parent test still executing is itself a running test: its own status must
+// reach the counts and the file rollup even when every subtest it has produced
+// so far is settled — otherwise the live tree shows ✓ and flips back to
+// running when the next subtest arrives, and the header reads "Running" with
+// no running row in sight. Same for a file whose wrapper hasn't completed.
+// Distilled from a real isolated run (mongoAtlas.test.ts, 39-minute parent).
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { build, done, ev } from './util.ts';
+
+const ENTRY = '/x/tests/atlas.test.ts';
+const WRAP = { name: 'tests/atlas.test.ts', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' as const };
+
+test('a running parent with settled children counts and rolls up as running', () => {
+  const { root, counts } = build([
+    ev('test:enqueue', WRAP),
+    ev('test:dequeue', WRAP),
+    ev('test:enqueue', { name: 'backup on demand', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:dequeue', { name: 'backup on demand', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:enqueue', { name: 'validate snapshot', nesting: 1, file: ENTRY, testId: 2, parentId: 1, type: 'test' }),
+    ev('test:dequeue', { name: 'validate snapshot', nesting: 1, file: ENTRY, testId: 2, parentId: 1, type: 'test' }),
+    ev('test:complete', { name: 'validate snapshot', nesting: 1, file: ENTRY, testId: 2, parentId: 1, details: done }),
+  ]);
+  const file = root.children.find((n) => n.type === 'file')!;
+  const parent = file.children.find((n) => n.name === 'backup on demand')!;
+  assert.strictEqual(parent.status, 'running', 'the parent is still executing');
+  assert.strictEqual(counts.running, 1, 'the running parent is a running test');
+  assert.strictEqual(counts.total, 2, 'the running parent counts toward the total');
+  assert.strictEqual(file.status, 'running', 'the file cannot be done while a parent runs');
+});
+
+test('a running suite with settled children counts and rolls up as running', () => {
+  const { root, counts } = build([
+    ev('test:enqueue', WRAP),
+    ev('test:dequeue', WRAP),
+    ev('test:enqueue', { name: 'Atlas', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'suite' }),
+    ev('test:dequeue', { name: 'Atlas', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'suite' }),
+    ev('test:enqueue', { name: 'scan cluster', nesting: 1, file: ENTRY, testId: 2, parentId: 1, type: 'test' }),
+    ev('test:dequeue', { name: 'scan cluster', nesting: 1, file: ENTRY, testId: 2, parentId: 1, type: 'test' }),
+    ev('test:complete', { name: 'scan cluster', nesting: 1, file: ENTRY, testId: 2, parentId: 1, details: done }),
+  ]);
+  const file = root.children.find((n) => n.type === 'file')!;
+  assert.strictEqual(counts.running, 1);
+  assert.strictEqual(file.status, 'running');
+});
+
+test('a file stays running until its wrapper completes', () => {
+  const stream = [
+    ev('test:enqueue', WRAP),
+    ev('test:dequeue', WRAP),
+    ev('test:enqueue', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:dequeue', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:complete', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, details: done }),
+  ];
+  const mid = build(stream);
+  const midFile = mid.root.children.find((n) => n.type === 'file')!;
+  assert.strictEqual(midFile.status, 'running', 'all tests settled, but the wrapper is still open');
+
+  const end = build([
+    ...stream,
+    ev('test:complete', { ...WRAP, details: done }),
+    ev('test:start', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0 }),
+    ev('test:pass', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, details: done }),
+    ev('test:summary', { file: ENTRY, duration_ms: 5 }),
+  ]);
+  const endFile = end.root.children.find((n) => n.type === 'file')!;
+  assert.strictEqual(endFile.status, 'passed');
+  assert.strictEqual(end.counts.running, 0);
+});
+
+test('a file-level start opens the wrapper too (streams without eager wrapper events)', () => {
+  const { root } = build([
+    ev('test:start', WRAP),
+    ev('test:enqueue', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:dequeue', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:complete', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, details: done }),
+  ]);
+  const file = root.children.find((n) => n.type === 'file')!;
+  assert.strictEqual(file.status, 'running', 'the wrapper started and has not completed');
+});
+
+test('settled parents leave the final counts as leaves-only', () => {
+  const { counts } = build([
+    ev('test:enqueue', WRAP),
+    ev('test:dequeue', WRAP),
+    ev('test:enqueue', { name: 'backup on demand', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:dequeue', { name: 'backup on demand', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:enqueue', { name: 'validate snapshot', nesting: 1, file: ENTRY, testId: 2, parentId: 1, type: 'test' }),
+    ev('test:dequeue', { name: 'validate snapshot', nesting: 1, file: ENTRY, testId: 2, parentId: 1, type: 'test' }),
+    ev('test:complete', { name: 'validate snapshot', nesting: 1, file: ENTRY, testId: 2, parentId: 1, details: done }),
+    ev('test:complete', { name: 'backup on demand', nesting: 0, file: ENTRY, testId: 1, parentId: 0, details: done }),
+    ev('test:complete', { ...WRAP, details: done }),
+    ev('test:start', { name: 'backup on demand', nesting: 0, file: ENTRY, testId: 1, parentId: 0 }),
+    ev('test:start', { name: 'validate snapshot', nesting: 1, file: ENTRY, testId: 2, parentId: 1 }),
+    ev('test:pass', { name: 'validate snapshot', nesting: 1, file: ENTRY, testId: 2, parentId: 1, details: done }),
+    ev('test:pass', { name: 'backup on demand', nesting: 0, file: ENTRY, testId: 1, parentId: 0, details: done }),
+    ev('test:summary', { file: ENTRY, duration_ms: 5 }),
+  ]);
+  assert.strictEqual(counts.total, 1, 'a settled parent is not counted; only its leaves are');
+  assert.strictEqual(counts.passed, 1);
+  assert.strictEqual(counts.running, 0);
+});

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -111,10 +111,17 @@ export function liveNodeDuration(
   return node.children.reduce((total, child) => total + liveNodeDuration(child, now, since, clock), 0);
 }
 
-/** Container status = the worst status among descendants (severity order). */
+/**
+ * Container status = the worst status among descendants (severity order),
+ * folding in the container's own status while it is still open — a parent
+ * test awaiting subtests, or a file whose wrapper hasn't completed, must not
+ * read ✓ just because everything it produced so far has settled. Terminal own
+ * statuses stay out: descendants alone decide a finished container's color.
+ */
 export function rollup(node: TestNode): TestStatus {
   if (!isContainer(node)) return node.status;
-  for (const s of SEVERITY) if (node.counts[s] > 0) return s;
+  const own = node.status === 'running' || node.status === 'queued' ? node.status : undefined;
+  for (const s of SEVERITY) if (node.counts[s] > 0 || own === s) return s;
   return 'passed';
 }
 

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -106,6 +106,19 @@ test('rollup: leaves keep their status, containers take the worst descendant', (
   assert.strictEqual(rollup(node({ key: 'q', children: [leaf], counts: { ...zeroCounts(), passed: 1, queued: 1, total: 2 } })), 'queued', 'queued still outranks passed while a run is incomplete');
 });
 
+test('rollup: a container whose own status is still open outranks settled descendants', () => {
+  const leaf = node({ key: 'l' });
+  // A parent test still executing while every subtest so far has passed.
+  const runningParent = node({ key: 'r', status: 'running', children: [leaf], counts: { ...zeroCounts(), passed: 3, total: 3 } });
+  assert.strictEqual(rollup(runningParent), 'running');
+  // A descendant failure still outranks the container's own running status.
+  const failedUnder = node({ key: 'f', status: 'running', children: [leaf], counts: { ...zeroCounts(), failed: 1, total: 1 } });
+  assert.strictEqual(rollup(failedUnder), 'failed');
+  // A file whose wrapper hasn't completed (store-derived running status).
+  const wrapperOpen = node({ key: 'w', type: 'file', status: 'running', children: [leaf], counts: { ...zeroCounts(), passed: 2, total: 2 } });
+  assert.strictEqual(rollup(wrapperOpen), 'running');
+});
+
 test('reasonOf returns the skip/todo string, or undefined', () => {
   assert.strictEqual(reasonOf(node({ skip: 'not ready' })), 'not ready');
   assert.strictEqual(reasonOf(node({ todo: 'later' })), 'later');


### PR DESCRIPTION
## Problem

Replaying a real 40-file isolated run (eon-service, 47 minutes) in the web viewer showed two linked symptoms:

1. **Tests and files flipped done → running.** A parent test still executing (e.g. a 39-minute `should backup Atlas cluster on demand`) rendered ✓ the moment its subtests-so-far all settled, then flipped back to running when the next subtest arrived — 39 such terminal→non-terminal flips in one replay.
2. **Header said "Running" with no running row in sight.** For the last ~3 minutes of the run every visible row was terminal, while the only live thing — a file whose wrapper hadn't completed — rendered as passed.

Both trace to one defect: once a node has children, its **own** status is ignored — `build()` sums only child counts, and the client `rollup()` derives a container's displayed status purely from those counts.

## Fix

- `build()` counts a running/queued parent test or suite as a running test. It leaves the counts once terminal, so finished-run totals are unchanged (leaves-only).
- File groups track their wrapper's liveness (`wrapperOpen`: set on file-level dequeue/start, cleared on file-level complete/pass/fail and per-file summary) and derive `running` while it is open. Helper-file groups have no wrapper and keep the old derive-from-children behavior.
- `rollup()` folds a container's own running/queued status into the severity scan. Terminal own statuses stay out, so skipped-only containers still read skipped.

Bonus: `@reporters/live`'s done-detection (`counts.running === 0`) no longer declares a run finished while a parent test is still executing.

## Verification

- New regression tests: `packages/tree-core/tests/live-status.test.ts` (written failing-first) + a `rollup` case in `packages/web/tests/rowModel.test.ts`. Full suite: 317 passed, coverage 99.86%.
- Replayed the real 4,851-event log per-event: flips drop 39 → 16; the survivors are helper-file groups, which can't know "done" without upstream entry-file attribution (nodejs/node#64309).
- Served mid-run truncations of the log at the exact moments of the bug screenshots and drove the viewer with Playwright: running parents now show the running glyph with live-ticking durations, the still-open file backs the "Running" header, and the complete log settles to "✓ Passing" with identical totals to before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)