### PR TITLE
fix(web): let the status filter match a still-running parent

### DIFF
--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -204,7 +204,14 @@ export function computeMatches(files: TestNode[], query: string, statuses: Reado
       descVis ||= r.vis;
       descOwn ||= r.own;
     }
-    const leafMatch = node.children.length === 0 && textOk && statusOk(node)
+    // A test/suite whose own body is still open is a match in its own right —
+    // it is what the running/queued counts include, so the status filter must
+    // surface it even when every leaf under it has settled. Terminal
+    // containers stay leaves-only, matching the counts.
+    const openContainer = node.children.length > 0
+      && (node.type === 'test' || node.type === 'suite')
+      && (node.status === 'running' || node.status === 'queued');
+    const leafMatch = (node.children.length === 0 || openContainer) && textOk && statusOk(node)
       && (!onlyRerun || node.passedOnAttempt == null);
     if (leafMatch || descVis) {
       visible.add(node.key);

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -377,6 +377,36 @@ test('a status filter shows matching leaves with their ancestors, force-expanded
   assert.deepStrictEqual(rows.map((r) => r.node.key), ['fa', 's1', 'f1']);
 });
 
+test('a running filter matches a still-running parent whose children have settled', () => {
+  // Mirrors the counts: the running parent IS the running test the header
+  // chip counts, so filtering by running must surface it — not hide the file
+  // because no leaf happens to be running right now.
+  const settled = node({ key: 'p1', name: 'validate snapshot', status: 'passed' });
+  const parent = node({
+    key: 'r1', name: 'backup on demand', status: 'running', children: [settled],
+    counts: { ...zeroCounts(), passed: 1, running: 1, total: 2 },
+  });
+  const file = node({
+    key: 'fr', type: 'file', file: '/atlas.test.js', status: 'running', children: [parent],
+    counts: { ...zeroCounts(), passed: 1, running: 1, total: 2 },
+  });
+  const matches = computeMatches([file], '', new Set(['running']));
+  assert.deepStrictEqual([...matches.visible].sort(), ['fr', 'r1']);
+  assert.ok(matches.force.has('fr'), 'the path to the matched parent is force-expanded');
+  // A settled parent must NOT self-match a terminal filter (counts are
+  // leaves-only once terminal): only its passed leaf brings it in as context.
+  const doneParent = node({
+    key: 'r2', name: 'backup on demand', status: 'passed', children: [settled],
+    counts: { ...zeroCounts(), passed: 1, total: 1 },
+  });
+  const doneFile = node({
+    key: 'fd', type: 'file', file: '/atlas.test.js', children: [doneParent],
+    counts: { ...zeroCounts(), passed: 1, total: 1 },
+  });
+  const running = computeMatches([doneFile], '', new Set(['running']));
+  assert.deepStrictEqual([...running.visible], [], 'nothing running remains');
+});
+
 test('multiple statuses union their matches', () => {
   const files = tree();
   const matches = computeMatches(files, '', new Set(['failed', 'todo']));


### PR DESCRIPTION
## Problem

Follow-up to #246. The header chip now counts a still-executing parent test/suite as running, but `computeMatches` only matched leaves under a status filter — so the viewer could show "3 running" while clicking the running chip surfaced only the one running leaf, hiding the running parents entirely (mongoAtlas parent at 31m in the repro run).

## Fix

A test/suite container whose **own** status is running or queued self-matches the status filter — exactly the set the counts include, so chip and filter agree by construction. Terminal containers stay leaves-only (a settled parent doesn't self-match "passed", matching the leaves-only terminal counts), and file groups stay out (their wrapper-open liveness isn't counted either).

## Verification

- Unit test: a running parent with settled children matches the running filter and force-expands its path; a settled parent does not self-match. Full suite: 319 passed, statements 100%.
- Served the repro log truncated at the screenshot moment and clicked the running chip in the real viewer: the filter now shows exactly the three rows the chip counts (suite, parent test, running leaf). On the completed log no running chip renders and nothing self-matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)