### PR TITLE
feat(web): persist filters in the URL for shareable views

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -14,6 +14,7 @@ import { AnsiHtml } from 'fancy-ansi/react';
 import {
   classifyFrame, classifyStack, extractLevel, formatCount, levelSeverity, splitUrls, stripAnsi, type StackLine,
 } from './format.ts';
+import { parseFilterState, serializeFilterState, type FilterState } from './urlState.ts';
 
 const GLYPH: Record<TestStatus, string> = {
   passed: '✓', failed: '✕', skipped: '⊘', todo: '◇', running: '◐', queued: '○',
@@ -219,6 +220,50 @@ function computeTheme(): 'dark' | 'light' {
     if (forced === 'dark' || forced === 'light') return forced;
   } catch { /* location may be unavailable */ }
   return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function currentSearch(): string {
+  try { return window.location.search; } catch { return ''; }
+}
+
+/** Shareable filter state: `?q`, `?status` and `?rerun` mirror the search box,
+ *  status chips and Only re-run. Discrete toggles push a history entry
+ *  immediately, typing debounces into one entry, and Back/Forward restore the
+ *  previous filters. */
+function useUrlFilters() {
+  const [query, setQuery] = useState(() => parseFilterState(currentSearch()).query);
+  const [statuses, setStatuses] = useState<ReadonlySet<TestStatus>>(() => parseFilterState(currentSearch()).statuses);
+  const [onlyRerun, setOnlyRerun] = useState(() => parseFilterState(currentSearch()).onlyRerun);
+  const state: FilterState = { query, statuses, onlyRerun };
+  const stateRef = useRef(state);
+  stateRef.current = state;
+  const sync = () => {
+    const search = currentSearch();
+    const next = serializeFilterState(stateRef.current, search);
+    // Compare canonical forms so encoding quirks (%20 vs +) never push.
+    if (next === serializeFilterState(parseFilterState(search), search)) return;
+    try {
+      window.history.pushState(null, '', `${window.location.pathname}${next}${window.location.hash}`);
+    } catch { /* history may be unavailable (sandboxed iframe) */ }
+  };
+  useEffect(sync, [statuses, onlyRerun]);
+  useEffect(() => {
+    const id = setTimeout(sync, 400);
+    return () => clearTimeout(id);
+  }, [query]);
+  useEffect(() => {
+    const onPop = () => {
+      const s = parseFilterState(currentSearch());
+      setQuery(s.query);
+      setStatuses(s.statuses);
+      setOnlyRerun(s.onlyRerun);
+    };
+    window.addEventListener('popstate', onPop);
+    return () => window.removeEventListener('popstate', onPop);
+  }, []);
+  return {
+    query, setQuery, statuses, setStatuses, onlyRerun, setOnlyRerun,
+  };
 }
 
 function useTheme(): ['dark' | 'light', () => void] {
@@ -671,10 +716,12 @@ export function TreeView({
   snapshot, streaming = false, pending = false, loadError = false, onRetry,
 }: TreeViewProps) {
   const [theme, toggleTheme] = useTheme();
-  const [query, setQuery] = useState('');
+  // Filters live in the URL (?q, ?status, ?rerun) so a copied link shares the
+  // same view; statuses empty = unfiltered.
+  const {
+    query, setQuery, statuses, setStatuses, onlyRerun, setOnlyRerun,
+  } = useUrlFilters();
   const [overrides, setOverrides] = useState<Map<string, boolean>>(new Map());
-  // Active status-chip filters; empty = unfiltered.
-  const [statuses, setStatuses] = useState<ReadonlySet<TestStatus>>(new Set());
   const toggleStatus = (s: TestStatus) => {
     setStatuses((prev) => {
       const next = new Set(prev);
@@ -692,8 +739,6 @@ export function TreeView({
   const clockRef = useRef<LiveClock | null>(null);
   // A steadily-incrementing tick that drives live duration re-renders.
   const [, setTick] = useState(0);
-
-  const [onlyRerun, setOnlyRerun] = useState(false);
 
   const files = snapshot.root.children;
   const { counts } = snapshot;

--- a/packages/web/src/client/urlState.ts
+++ b/packages/web/src/client/urlState.ts
@@ -1,0 +1,33 @@
+import type { TestStatus } from '@reporters/tree-core';
+
+export interface FilterState {
+  query: string;
+  statuses: ReadonlySet<TestStatus>;
+  onlyRerun: boolean;
+}
+
+const STATUSES: readonly TestStatus[] = ['passed', 'failed', 'skipped', 'todo', 'running', 'queued'];
+
+export function parseFilterState(search: string): FilterState {
+  const params = new URLSearchParams(search);
+  const statuses = new Set<TestStatus>();
+  for (const token of (params.get('status') ?? '').split(',')) {
+    if ((STATUSES as readonly string[]).includes(token)) statuses.add(token as TestStatus);
+  }
+  return {
+    query: params.get('q') ?? '',
+    statuses,
+    onlyRerun: params.get('rerun') === '1',
+  };
+}
+
+/** New search string for `state`, preserving unrelated params (`src`, `theme`). */
+export function serializeFilterState(state: FilterState, currentSearch: string): string {
+  const params = new URLSearchParams(currentSearch);
+  if (state.query) params.set('q', state.query); else params.delete('q');
+  const statuses = STATUSES.filter((s) => state.statuses.has(s));
+  if (statuses.length > 0) params.set('status', statuses.join(',')); else params.delete('status');
+  if (state.onlyRerun) params.set('rerun', '1'); else params.delete('rerun');
+  const out = params.toString();
+  return out ? `?${out}` : '';
+}

--- a/packages/web/tests/urlState.test.ts
+++ b/packages/web/tests/urlState.test.ts
@@ -1,0 +1,76 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { parseFilterState, serializeFilterState } from '../src/client/urlState.ts';
+import type { FilterState } from '../src/client/urlState.ts';
+
+const state = (over: Partial<FilterState> = {}): FilterState => ({
+  query: '', statuses: new Set(), onlyRerun: false, ...over,
+});
+
+test('parse: empty search yields defaults', () => {
+  const s = parseFilterState('');
+  assert.strictEqual(s.query, '');
+  assert.strictEqual(s.statuses.size, 0);
+  assert.strictEqual(s.onlyRerun, false);
+});
+
+test('parse: reads q, status and rerun', () => {
+  const s = parseFilterState('?q=login%20flow&status=failed,skipped&rerun=1');
+  assert.strictEqual(s.query, 'login flow');
+  assert.deepStrictEqual([...s.statuses].sort(), ['failed', 'skipped']);
+  assert.strictEqual(s.onlyRerun, true);
+});
+
+test('parse: drops unknown status tokens', () => {
+  const s = parseFilterState('?status=failed,bogus,,passed');
+  assert.deepStrictEqual([...s.statuses].sort(), ['failed', 'passed']);
+});
+
+test('parse: rerun only turns on for "1"', () => {
+  assert.strictEqual(parseFilterState('?rerun=0').onlyRerun, false);
+  assert.strictEqual(parseFilterState('?rerun=').onlyRerun, false);
+  assert.strictEqual(parseFilterState('?rerun=1').onlyRerun, true);
+});
+
+test('serialize: defaults produce no filter params', () => {
+  assert.strictEqual(serializeFilterState(state(), ''), '');
+});
+
+test('serialize: keeps unrelated params like src and theme', () => {
+  const out = serializeFilterState(state(), '?src=http%3A%2F%2Fx%2Flog.ndjson&theme=dark');
+  const params = new URLSearchParams(out);
+  assert.strictEqual(params.get('src'), 'http://x/log.ndjson');
+  assert.strictEqual(params.get('theme'), 'dark');
+  assert.strictEqual(params.has('q'), false);
+});
+
+test('serialize: writes active filters and clears stale ones', () => {
+  const out = serializeFilterState(
+    state({ query: 'a b', statuses: new Set(['failed']), onlyRerun: true }),
+    '?src=s&status=passed',
+  );
+  const params = new URLSearchParams(out);
+  assert.strictEqual(params.get('q'), 'a b');
+  assert.strictEqual(params.get('status'), 'failed');
+  assert.strictEqual(params.get('rerun'), '1');
+  assert.strictEqual(params.get('src'), 's');
+});
+
+test('serialize: removing filters removes their params', () => {
+  const out = serializeFilterState(state(), '?q=x&status=failed&rerun=1&src=s');
+  assert.strictEqual(out, '?src=s');
+});
+
+test('round-trip preserves state', () => {
+  const original = state({ query: '  spa ces & ?#', statuses: new Set(['todo', 'running']), onlyRerun: true });
+  const back = parseFilterState(serializeFilterState(original, ''));
+  assert.strictEqual(back.query, original.query);
+  assert.deepStrictEqual([...back.statuses].sort(), [...original.statuses].sort());
+  assert.strictEqual(back.onlyRerun, true);
+});
+
+test('serialize: status order is stable regardless of set insertion order', () => {
+  const a = serializeFilterState(state({ statuses: new Set(['skipped', 'failed']) }), '');
+  const b = serializeFilterState(state({ statuses: new Set(['failed', 'skipped']) }), '');
+  assert.strictEqual(a, b);
+});


### PR DESCRIPTION
Filter state in the web viewer now lives in the URL, so copying the address bar shares the exact filtered view.

- `?q=` — search box text
- `?status=failed,skipped` — active status-chip filters
- `?rerun=1` — the Only re-run toggle

Params are omitted at their defaults; existing `src`/`theme` params are preserved. Discrete toggles (chips, Only re-run, Clear filters) push a history entry immediately; typing in search debounces ~400 ms into a single entry, so a typed word is one Back step. A `popstate` listener restores filters on Back/Forward without a reload.

Verified in the real viewer over a served `report.ndjson`: chip clicks update the URL, typing adds exactly one history entry, reloading a filtered URL reproduces the view, and Back/Forward walk the filter history live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)