### PR TITLE
fix(tree-core,web): surface a file wrapper's own failure

### DIFF
--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -43,6 +43,11 @@ interface InternalNode {
   // completed — the file is alive even when every test in it has settled
   // (hooks, teardown, or subtests still to come).
   wrapperOpen?: boolean;
+  // File groups only: the wrapper closed with its own failure — a hook threw
+  // or the child process died — which node reports only on the wrapper, so it
+  // must survive here or a file whose tests all passed renders green.
+  wrapperFailed?: boolean;
+  wrapperError?: SerializedError;
   childKeys: string[];
 }
 
@@ -574,6 +579,10 @@ export function createTreeStore(): TreeStore {
           // The wrapper measures the file's real wall-clock — the file's
           // concurrent tests sum to much more than the run actually took.
           if (data.details?.duration_ms != null) group.durationMs = data.details.duration_ms;
+          if (data.details?.passed === false) {
+            group.wrapperFailed = true;
+            group.wrapperError ??= serializeError(data.details.error);
+          }
           break;
         }
         if (data.testId == null) break;
@@ -598,6 +607,10 @@ export function createTreeStore(): TreeStore {
           group.wrapperOpen = false;
           if (data.details?.duration_ms != null) {
             group.durationMs = group.durationMs ?? data.details.duration_ms;
+          }
+          if (type === 'test:fail') {
+            group.wrapperFailed = true;
+            group.wrapperError ??= serializeError(data.details?.error);
           }
           break;
         }
@@ -710,8 +723,19 @@ export function createTreeStore(): TreeStore {
     // status from their descendants — and from the wrapper's own liveness,
     // which outlives the last settled test (hooks, subtests still to come).
     let { status } = internal;
+    let error = internal.error;
     if (internal.type === 'file' || internal.type === 'root') {
       if (counts.failed > 0) status = 'failed';
+      else if (internal.wrapperFailed) {
+        // The wrapper failed with every child settled green: the failure is
+        // the file's own (a hook, the process exit), so the wrapper is the
+        // failed test — count it and surface its error. When a child failed,
+        // the wrapper's echo of it stays out of counts and off the node.
+        status = 'failed';
+        counts.failed += 1;
+        counts.total += 1;
+        error ??= internal.wrapperError;
+      }
       else if (counts.running > 0 || internal.wrapperOpen) status = 'running';
       else if (counts.queued > 0 && counts.passed + counts.skipped + counts.todo === 0) status = 'queued';
       else status = 'passed';
@@ -727,7 +751,7 @@ export function createTreeStore(): TreeStore {
       status,
       durationMs: internal.durationMs,
       startedAt: internal.startedAt,
-      error: internal.error,
+      error,
       diagnostics: internal.diagnostics,
       stdout: internal.stdout,
       stderr: internal.stderr,

--- a/packages/tree-core/tests/file-wrapper-failure.test.ts
+++ b/packages/tree-core/tests/file-wrapper-failure.test.ts
@@ -1,0 +1,77 @@
+// A file can fail even when every test inside it passed — a hook threw or the
+// child process exited non-zero — and node reports that only on the file-level
+// wrapper (test:complete passed:false, then test:fail). The wrapper's own
+// result must reach the file's status, error, and the counts, or the run
+// renders fully green while node's summary says it failed. Distilled from a
+// real isolated run (scheduledBackup.test.ts, eon-service run 28847073806).
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { build, done, ev } from './util.ts';
+
+const ENTRY = '/x/tests/scheduled.test.ts';
+const WRAP = { name: 'tests/scheduled.test.ts', nesting: 0, file: ENTRY, testId: 9, parentId: 0, type: 'test' as const };
+const failed = { passed: false, duration_ms: 2, error: { message: 'test failed', name: 'Error' } };
+
+test('a wrapper that fails with all children passed marks the file failed', () => {
+  const stream = [
+    ev('test:enqueue', WRAP),
+    ev('test:dequeue', WRAP),
+    ev('test:enqueue', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:dequeue', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:complete', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, details: done }),
+    ev('test:complete', { ...WRAP, details: failed }),
+  ];
+  const mid = build(stream);
+  const midFile = mid.root.children.find((n) => n.type === 'file')!;
+  assert.strictEqual(midFile.status, 'failed', 'the wrapper closed failed; the file cannot read passed');
+  assert.strictEqual(mid.counts.failed, 1, 'the wrapper\'s own failure is a failed test');
+  assert.strictEqual(mid.counts.total, 2);
+  assert.strictEqual(midFile.error?.message, 'test failed');
+
+  const end = build([
+    ...stream,
+    ev('test:start', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0 }),
+    ev('test:pass', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, details: done }),
+    ev('test:start', WRAP),
+    ev('test:fail', { ...WRAP, details: { duration_ms: 2, error: { message: 'test failed', name: 'Error' } } }),
+    ev('test:summary', { file: ENTRY, duration_ms: 5 }),
+  ]);
+  const endFile = end.root.children.find((n) => n.type === 'file')!;
+  assert.strictEqual(endFile.status, 'failed');
+  assert.strictEqual(end.counts.failed, 1);
+  assert.strictEqual(end.counts.passed, 1);
+  assert.strictEqual(end.counts.total, 2);
+});
+
+test('a wrapper failing because a child failed does not double-count', () => {
+  const { root, counts } = build([
+    ev('test:enqueue', WRAP),
+    ev('test:dequeue', WRAP),
+    ev('test:enqueue', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:dequeue', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:complete', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, details: failed }),
+    ev('test:complete', { ...WRAP, details: { ...failed, error: { message: '1 subtest failed', name: 'Error' } } }),
+    ev('test:summary', { file: ENTRY, duration_ms: 5 }),
+  ]);
+  const file = root.children.find((n) => n.type === 'file')!;
+  assert.strictEqual(file.status, 'failed');
+  assert.strictEqual(counts.failed, 1, 'the failing leaf is the failure; the wrapper echoes it');
+  assert.strictEqual(counts.total, 1);
+  assert.strictEqual(file.error, undefined, 'the wrapper\'s echo error is noise when a child carries the real one');
+});
+
+test('a wrapper that closes passed leaves the file passed', () => {
+  const { root, counts } = build([
+    ev('test:enqueue', WRAP),
+    ev('test:dequeue', WRAP),
+    ev('test:enqueue', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:dequeue', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'test' }),
+    ev('test:complete', { name: 'only test', nesting: 0, file: ENTRY, testId: 1, parentId: 0, details: done }),
+    ev('test:complete', { ...WRAP, details: done }),
+    ev('test:summary', { file: ENTRY, duration_ms: 5 }),
+  ]);
+  const file = root.children.find((n) => n.type === 'file')!;
+  assert.strictEqual(file.status, 'passed');
+  assert.strictEqual(counts.failed, 0);
+  assert.strictEqual(counts.total, 1);
+});

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -140,10 +140,13 @@ const SYNTHETIC_ROLLUP = /^\d+ subtests? failed$/i;
 /**
  * The error worth showing: only a *leaf* test's own error, and never Node's
  * synthetic container rollup. Containers communicate failure through their
- * status glyph and the failed child inside them, not an error block.
+ * status glyph and the failed child inside them, not an error block. The one
+ * container exception is a file: the store only puts an error there when the
+ * wrapper itself failed with no failed child to carry it, so it's always real.
  */
 export function realError(node: TestNode): { message: string; stack?: string } | undefined {
-  if (isContainer(node) || !node.error) return undefined;
+  if (!node.error) return undefined;
+  if (isContainer(node) && node.type !== 'file') return undefined;
   if (SYNTHETIC_ROLLUP.test((node.error.message ?? '').trim())) return undefined;
   return node.error;
 }
@@ -211,7 +214,11 @@ export function computeMatches(files: TestNode[], query: string, statuses: Reado
     const openContainer = node.children.length > 0
       && (node.type === 'test' || node.type === 'suite')
       && (node.status === 'running' || node.status === 'queued');
-    const leafMatch = (node.children.length === 0 || openContainer) && textOk && statusOk(node)
+    // Same rule for a file failed by its own wrapper (hook, process exit): its
+    // failure is in the counts with no failed leaf underneath to stand for it.
+    const ownFailedFile = node.type === 'file' && node.status === 'failed'
+      && !node.children.some((child) => child.counts.failed > 0);
+    const leafMatch = (node.children.length === 0 || openContainer || ownFailedFile) && textOk && statusOk(node)
       && (!onlyRerun || node.passedOnAttempt == null);
     if (leafMatch || descVis) {
       visible.add(node.key);

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -476,3 +476,26 @@ test('an all-carried file disappears under onlyRerun', () => {
   const rows = buildRows([file], { overrides: new Map(), query: '', statuses: new Set(), matches, onlyRerun: true });
   assert.deepStrictEqual(rows, []);
 });
+
+// A file whose wrapper failed on its own (hook threw, process died) is the
+// failure its counts include — with every child green, the filter and the
+// error block must point at the file itself or the failure is unfindable.
+function ownFailedFile(): TestNode {
+  const leaf = node({ key: 'l', name: 'only test', counts: { ...zeroCounts(), passed: 1, total: 1 } });
+  return node({
+    key: 'file', type: 'file', file: FILE, status: 'failed',
+    error: { message: 'test failed' },
+    children: [leaf],
+    counts: { ...zeroCounts(), passed: 1, failed: 1, total: 2 },
+  });
+}
+
+test('a file failed by its own wrapper matches the failed filter', () => {
+  const matches = computeMatches([ownFailedFile()], '', new Set(['failed']));
+  assert.ok(matches.visible.has('file'), 'the failure the counts include must be findable');
+  assert.ok(!matches.visible.has('l'), 'the passing leaf is not a failed match');
+});
+
+test('realError surfaces a file wrapper own failure', () => {
+  assert.deepStrictEqual(realError(ownFailedFile()), { message: 'test failed' });
+});


### PR DESCRIPTION
## Problem

A file can fail while every test inside it passed — a hook threw or the child process exited non-zero. node:test reports that only on the file-level wrapper: `test:complete` with `passed:false`, then a buffered `test:fail`. The store's file-level branches only harvested `wrapperOpen`/duration from those events and discarded the wrapper's own result and error; `build()` then derived the file's status purely from its (green) descendants, and the web run verdict (`counts.failed > 0`) read passed.

Real case: `scheduledBackup.test.ts` in eon-service run 28847073806 — node's summary said `failed: 1, success: false`, the viewer rendered the file and the whole run green with no failure to be found.

## Fix

- **tree-core**: file-level `test:complete passed:false` / `test:fail` now record `wrapperFailed` + the wrapper's error on the file group. `build()` marks such a file failed, and when no child carries the failure, counts the wrapper as the failed test and surfaces its error on the file node. A wrapper merely echoing a failed child stays out of the counts and carries no error — no double-counting.
- **web**: per the #249 invariant (the status filter matches exactly what the counts include), a file failed by its own wrapper matches the failed filter in its own right. `realError()` renders a file node's error — it only exists in the own-failure case — so the failure has a visible reason.

## Verification

- New regression tests: `packages/tree-core/tests/file-wrapper-failure.test.ts` (mid-stream + settled, echo no-double-count, passing wrapper) and two rowModel cases (filter match, error block). All 140+ workspace tests pass.
- Replayed the real eon-service log through the store and through a wire round-trip: file failed with error "test failed", root failed, `counts.failed: 1` — matching node's summary.
- Drove the built viewer over the real log with Playwright: header reads "Failing · 1 failed"; the failed filter surfaces exactly `scheduledBackup.test.ts` with its ERROR block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)