### PR TITLE
fix(web): show the loading state before filters can declare no matches

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -956,6 +956,8 @@ export function TreeView({
               onlyRerun={onlyRerun}
             />
           )))
+        ) : pending ? (
+          <CenteredState icon="◐" iconStatus="running" spin title="Loading test log…" />
         ) : q || statuses.size > 0 || onlyRerun ? (
           <CenteredState
             icon="⌕"
@@ -975,8 +977,6 @@ export function TreeView({
               Clear filters
             </button>
           </CenteredState>
-        ) : pending ? (
-          <CenteredState icon="◐" iconStatus="running" spin title="Loading test log…" />
         ) : (
           <CenteredState icon="◴" iconStatus="queued" pulse title="Waiting for the first results">
             <div className="state-sub">


### PR DESCRIPTION
## Summary
- Since #251 hydrates status/search filters from the URL synchronously on mount, refreshing a filtered view showed "No tests match the active filters" during the window before the first NDJSON fetch resolved.
- Reorder the empty-tree branches in `TreeView` so `pending` wins over the filter empty-state: an empty tree shows "Loading test log…" until data arrives, then falls through to the filter/no-match/waiting states as before.

## Test plan
- Served a real `report.ndjson` via `startViewerServer` and delayed the NDJSON response with a Playwright route: with `?status=failed` in the URL, the pre-load window now shows "Loading test log…", and once the log arrives the filter applies (only the failing test shown).
- Verified the genuine no-match empty state still renders after data loads (bogus search query).
- `yarn workspace @reporters/web test` — 104 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)