### PR TITLE
fix(web): allow selecting text in the viewer

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -392,8 +392,9 @@ function DiagSection({
           tabIndex={0}
           aria-expanded={open}
           aria-label={`${open ? 'Hide' : 'Show'} ${block.title.toLowerCase()} of ${displayName(node)}`}
-          onClick={onToggle}
-          onMouseDown={(e) => e.preventDefault()}
+          onClick={() => { if (!selectionClick()) onToggle(); }}
+          onMouseDown={markPointerFocus}
+          onBlur={clearPointerFocus}
           onKeyDown={(e) => {
             if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(); }
             else if (e.key === 'ArrowRight' && !open) { e.preventDefault(); onToggle(); }
@@ -543,6 +544,19 @@ function useSettle(status: TestStatus): boolean {
 
 const trimTag = (s: string): string => (s.length > 32 ? `${s.slice(0, 31)}…` : s);
 
+/** Focus that arrived from a pointer press gets tagged so CSS can skip the
+ *  ring (Safari matches :focus-visible on clicked tabindex elements); we
+ *  can't preventDefault the mousedown instead — that blocks text selection. */
+const markPointerFocus = (e: React.MouseEvent<HTMLElement>) => { e.currentTarget.dataset.pointer = 'true'; };
+const clearPointerFocus = (e: React.FocusEvent<HTMLElement>) => { delete e.currentTarget.dataset.pointer; };
+
+/** A click that ends a text-selection drag shouldn't also fire the row's
+ *  toggle — the toggle would reflow the tree and destroy the selection. */
+const selectionClick = (): boolean => {
+  const sel = window.getSelection();
+  return sel != null && !sel.isCollapsed && sel.toString() !== '';
+};
+
 /** Stable identity for enter-animation bookkeeping and React keys — a node row
  *  and its nested output row share a node but are distinct rows. */
 const rowKey = (row: FlatRow): string => (row.kind === 'output' ? `${row.node.key}::out` : row.node.key);
@@ -613,10 +627,9 @@ function RowView({
       data-clickable={expandable}
       data-fail={isTest && status === 'failed'}
       data-running={status === 'running' ? 'true' : undefined}
-      onClick={expandable ? activate : undefined}
-      // A pointer click shouldn't paint the keyboard focus ring on the row
-      // (Safari matches :focus-visible on clicked tabindex elements).
-      onMouseDown={(e) => e.preventDefault()}
+      onClick={expandable ? () => { if (!selectionClick()) activate(); } : undefined}
+      onMouseDown={markPointerFocus}
+      onBlur={clearPointerFocus}
       onKeyDown={onKeyDown}
     >
       <span className="guides">

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -51,6 +51,8 @@ body {
 #root { height: 100%; }
 button { font-family: inherit; } input { font-family: inherit; }
 :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; border-radius: 6px; }
+/* pointer-origin focus (tagged in TreeView) never paints the keyboard ring */
+[data-pointer]:focus-visible { outline: none; }
 ::-webkit-scrollbar { width: 11px; height: 11px; }
 ::-webkit-scrollbar-thumb { background: var(--line-2); border-radius: 7px; border: 3px solid transparent; background-clip: padding-box; }
 ::-webkit-scrollbar-track { background: transparent; }


### PR DESCRIPTION
## Summary
- Tree rows and diagnostic section headers called `preventDefault()` on `mousedown` to stop Safari painting a focus ring on clicked `tabindex` elements — which also prevented starting any text selection, so nothing in the viewer could be selected or copied.
- Replace the hack with a `data-pointer` tag set on mousedown and cleared on blur, plus `[data-pointer]:focus-visible { outline: none }`, so pointer clicks paint no ring while keyboard focus keeps it.
- Skip the click-to-toggle on rows and section headers when the click ends a text-selection drag, so expanding/collapsing doesn't reflow the tree and destroy the selection.

## Test plan
- Verified in the served viewer over a real `report.ndjson` with Playwright:
  - drag-selecting a row name yields the text and does not toggle the row
  - section-header titles and log-body lines are selectable
  - plain clicks still expand/collapse
  - keyboard focus ring appears on Tab; mouse clicks paint none
- `yarn lint` and `yarn test` pass (334 tests, coverage unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)