### PR TITLE
fix(tree-core,web): never hide a container's own error

### DIFF
--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -723,18 +723,17 @@ export function createTreeStore(): TreeStore {
     // status from their descendants — and from the wrapper's own liveness,
     // which outlives the last settled test (hooks, subtests still to come).
     let { status } = internal;
-    let error = internal.error;
+    let error = internal.error ?? internal.wrapperError;
     if (internal.type === 'file' || internal.type === 'root') {
       if (counts.failed > 0) status = 'failed';
       else if (internal.wrapperFailed) {
         // The wrapper failed with every child settled green: the failure is
         // the file's own (a hook, the process exit), so the wrapper is the
-        // failed test — count it and surface its error. When a child failed,
-        // the wrapper's echo of it stays out of counts and off the node.
+        // failed test — count it. When a child failed, the wrapper's echo
+        // stays out of the counts, but its error still lands on the node.
         status = 'failed';
         counts.failed += 1;
         counts.total += 1;
-        error ??= internal.wrapperError;
       }
       else if (counts.running > 0 || internal.wrapperOpen) status = 'running';
       else if (counts.queued > 0 && counts.passed + counts.skipped + counts.todo === 0) status = 'queued';

--- a/packages/tree-core/tests/file-wrapper-failure.test.ts
+++ b/packages/tree-core/tests/file-wrapper-failure.test.ts
@@ -57,7 +57,7 @@ test('a wrapper failing because a child failed does not double-count', () => {
   assert.strictEqual(file.status, 'failed');
   assert.strictEqual(counts.failed, 1, 'the failing leaf is the failure; the wrapper echoes it');
   assert.strictEqual(counts.total, 1);
-  assert.strictEqual(file.error, undefined, 'the wrapper\'s echo error is noise when a child carries the real one');
+  assert.strictEqual(file.error?.message, '1 subtest failed', 'the wrapper\'s own error stays on the node even when a child failed');
 });
 
 test('a wrapper that closes passed leaves the file passed', () => {

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -133,21 +133,12 @@ export function reasonOf(node: TestNode): string | undefined {
   return undefined;
 }
 
-/** Node's aggregate "N subtests failed" error — redundant with the real error on
- *  the failing leaf, so we never render it. */
-const SYNTHETIC_ROLLUP = /^\d+ subtests? failed$/i;
-
 /**
- * The error worth showing: only a *leaf* test's own error, and never Node's
- * synthetic container rollup. Containers communicate failure through their
- * status glyph and the failed child inside them, not an error block. The one
- * container exception is a file: the store only puts an error there when the
- * wrapper itself failed with no failed child to carry it, so it's always real.
+ * Any error the node reported is shown — containers included. A container's
+ * error can be the only place the real cause lives (a suite whose before hook
+ * failed cancels its children with a generic message), so nothing is filtered.
  */
 export function realError(node: TestNode): { message: string; stack?: string } | undefined {
-  if (!node.error) return undefined;
-  if (isContainer(node) && node.type !== 'file') return undefined;
-  if (SYNTHETIC_ROLLUP.test((node.error.message ?? '').trim())) return undefined;
   return node.error;
 }
 

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -207,37 +207,36 @@ test('buildRows drops nodes filtered out by an active query', () => {
   assert.ok(!rows.some((r) => r.node.key === 'l2'), 'the non-matching sibling is filtered out');
 });
 
-test('realError shows a failed leaf error but suppresses synthetic and container rollups', () => {
+test('realError shows every recorded error — leaves, containers, and rollups alike', () => {
   // a real leaf error is returned as-is
   const leaf = node({ error: { message: 'expected 3 to equal 4', stack: 'at x' } });
   assert.deepStrictEqual(realError(leaf), { message: 'expected 3 to equal 4', stack: 'at x' });
-  // Node's synthetic "N subtests failed" rollup on a leaf is dropped
-  assert.strictEqual(realError(node({ error: { message: '1 subtest failed' } })), undefined);
-  assert.strictEqual(realError(node({ error: { message: '3 subtests failed' } })), undefined);
-  // a container never renders its own error, even a genuine-looking one
+  // Node's "N subtests failed" rollup is still an error the node reported — shown
+  const rollup = { message: '3 subtests failed' };
+  assert.strictEqual(realError(node({ error: rollup })), rollup);
+  // a container's own error (e.g. a failed before hook) is shown too
+  const containerError = { message: 'failed running before hook' };
   const container = node({
-    error: { message: 'boom' },
+    error: containerError,
     children: [node({ key: 'c' })],
     counts: { ...zeroCounts(), failed: 1, total: 1 },
   });
-  assert.strictEqual(realError(container), undefined);
+  assert.strictEqual(realError(container), containerError);
   // a leaf with no error has none
   assert.strictEqual(realError(node()), undefined);
-  // a leaf error with no message isn't synthetic — it's shown as-is
-  const noMsg = { message: undefined as unknown as string };
-  assert.strictEqual(realError(node({ error: noMsg })), noMsg);
 });
 
-test('hasDiagnostics ignores a suppressed (synthetic/container) error', () => {
-  // a container whose only "diagnostic" is a synthetic rollup error has nothing to show
+test('hasDiagnostics sees a container error', () => {
   const container = node({
     error: { message: '1 subtest failed' },
     children: [node({ key: 'c' })],
     counts: { ...zeroCounts(), failed: 1, total: 1 },
   });
-  assert.strictEqual(hasDiagnostics(container), false);
+  assert.strictEqual(hasDiagnostics(container), true);
   // a failed leaf with a real error does have diagnostics
   assert.strictEqual(hasDiagnostics(node({ error: { message: 'real' } })), true);
+  // and a node with nothing recorded has none
+  assert.strictEqual(hasDiagnostics(node()), false);
 });
 
 test('nodeDuration prefers a measured wall-clock over summing concurrent children', () => {


### PR DESCRIPTION
## Summary
- A suite whose `before` hook fails is the only node carrying the real cause — its children are cancelled with the generic "test did not finish before its parent and was cancelled" — yet the web viewer suppressed every non-file container error, so the cause never rendered (while the GitHub Actions log showed it, e.g. the EKS 401 in eon-service run 28852752269).
- `realError()` now returns the node's error unfiltered: suites, file wrappers, and Node's synthetic "N subtests failed" rollups all render their error block.
- tree-core now keeps a file wrapper's own error on the node even when a failed child exists (previously dropped as an echo); counts are unchanged — the wrapper is still not double-counted.

## Test plan
- Updated `rowModel` tests: container errors and rollup errors are shown; `hasDiagnostics` sees them.
- Updated `file-wrapper-failure` test: wrapper error stays on the node alongside a failed child.
- Full suite passes (334 tests, 100% statement coverage).
- Verified in the real viewer over the failing run's `report.ndjson` with Playwright: the EKS Namespace suite now shows the full 401 error and stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)