### PR TITLE
feat(web)!: renderNodeActions — embedder TSX per tree row

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -61,14 +61,14 @@ Built on the shared [`@reporters/tree-core`](https://github.com/MoLow/reporters/
 model (also used by [`@reporters/live`](https://github.com/MoLow/reporters/tree/main/packages/live)) —
 the same run state, rendered in the browser instead of the terminal.
 
-## Custom report sources (`@reporters/web/viewer`)
+## Embedding the viewer (`@reporters/web/viewer`)
 
 The hosted viewer reads `?src=<url>` with plain `fetch`. To serve reports that
-need authentication (private buckets, SSO), build your own viewer page on the
-same UI with a custom source resolver:
+need authentication (private buckets, SSO), or to add your own controls to the
+tree, build your own viewer page on the same UI:
 
-```ts
-import { startViewer } from '@reporters/web/viewer';
+```tsx
+import { startViewer, type TestNode } from '@reporters/web/viewer';
 
 startViewer({
   resolveSource: async (params) => {
@@ -76,13 +76,36 @@ startViewer({
     const credentials = await acquireCredentialsSomehow();
     return { url: params.get('key')!, fetch: authenticatedFetch(credentials) };
   },
+  renderNodeActions: (node: TestNode) => (node.type === 'test'
+    ? <button onClick={() => rerun(node)}>↻ rerun</button>
+    : null),
 });
 ```
 
-`resolveSource` runs before anything renders. Return `null`/`undefined` to fall
-through to the default `?src=` handling; return `{ url, fetch?, pollMs? }` to
-take over. The custom `fetch` receives the reader's `Range` header and must
-return a standard `Response`; a thrown error shows the viewer's load-error
-screen, and a promise that never resolves is fine while an auth redirect is in
-flight. The export is a self-contained browser ESM module (React inlined) —
-bundle it with your resolver into a static HTML page.
+The export is a browser ESM module that bundles everything except React —
+`react` and `react-dom` are (optional) peer dependencies, so your page's TSX
+and the viewer share one React 19 instance. Bundle it with your resolver into a
+static HTML page.
+
+### `resolveSource`
+
+Runs before anything renders. Return `null`/`undefined` to fall through to the
+default `?src=` handling; return `{ url, fetch?, pollMs? }` to take over. The
+custom `fetch` receives the reader's `Range` header and must return a standard
+`Response`; a thrown error shows the viewer's load-error screen, and a promise
+that never resolves is fine while an auth redirect is in flight.
+
+### `renderNodeActions`
+
+Renders custom trailing content at the end of every tree row — containers and
+tests alike; return `null` to render nothing for a node. The result is wrapped
+in a `.node-actions` element that swallows clicks and keystrokes, so your
+buttons never toggle the row's disclosure. It is called on every render (which
+is frequent during a live run), so keep it cheap.
+
+Visibility is yours to style — e.g. reveal on row hover:
+
+```css
+.node-actions { visibility: hidden; }
+.row:hover .node-actions, .row:focus-within .node-actions { visibility: visible; }
+```

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -37,6 +37,18 @@
     "pretest": "rm -rf dist && tsup",
     "test": "node --test-reporter=@reporters/mux --test"
   },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@reporters/mux": "workspace:^",
     "@reporters/tree-core": "workspace:^",

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -554,6 +554,11 @@ const selectionClick = (): boolean => {
  *  and its nested output row share a node but are distinct rows. */
 const rowKey = (row: FlatRow): string => (row.kind === 'output' ? `${row.node.key}::out` : row.node.key);
 
+/** Embedder hook: render custom trailing content (e.g. action buttons) for a
+ *  tree row. Called for every node — containers and tests alike — on every
+ *  render, so it must be cheap; return null to render nothing for a node. */
+export type RenderNodeActions = (node: TestNode) => React.ReactNode;
+
 interface RowViewProps {
   row: FlatRow;
   toggle: (key: string, current: boolean) => void;
@@ -568,10 +573,11 @@ interface RowViewProps {
   carriedRun: boolean;
   /** The only-re-run filter is active (collapsed pills show re-run counts). */
   onlyRerun: boolean;
+  renderNodeActions?: RenderNodeActions;
 }
 
 function RowView({
-  row, toggle, enter, now, since, clock, carriedRun, onlyRerun,
+  row, toggle, enter, now, since, clock, carriedRun, onlyRerun, renderNodeActions,
 }: RowViewProps) {
   const {
     node, depth, status, expandable, expanded, hasDiag,
@@ -667,6 +673,18 @@ function RowView({
         </span>
       ) : null}
       <span className="dur" data-carried={carried || rollupMark ? 'true' : undefined} data-tip={durTip}>{formatDuration(ms) || '—'}</span>
+      {renderNodeActions ? (
+        // Custom content is interactive on its own terms: clicks and keys
+        // inside must never toggle the row's disclosure.
+        <span
+          className="node-actions"
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          {renderNodeActions(node)}
+        </span>
+      ) : null}
     </div>
   );
 }
@@ -716,10 +734,12 @@ export interface TreeViewProps {
   /** The viewer's `?src=` is missing or unreachable. */
   loadError?: boolean;
   onRetry?: () => void;
+  /** Render custom trailing content at the end of every tree row. */
+  renderNodeActions?: RenderNodeActions;
 }
 
 export function TreeView({
-  snapshot, streaming = false, pending = false, loadError = false, onRetry,
+  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions,
 }: TreeViewProps) {
   const [theme, toggleTheme] = useTheme();
   // Filters live in the URL (?q, ?status, ?rerun) so a copied link shares the
@@ -960,6 +980,7 @@ export function TreeView({
               clock={clock}
               carriedRun={carriedRun}
               onlyRerun={onlyRerun}
+              renderNodeActions={renderNodeActions}
             />
           )))
         ) : pending ? (

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -2,13 +2,25 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { createTreeStore, type TreeStore } from '@reporters/tree-core';
 import { createNdjsonReader } from '../poll.ts';
-import { resolveReportSource, type ViewerOptions } from '../source.ts';
+import { resolveReportSource, type ViewerOptions as SourceOptions } from '../source.ts';
 import { STYLES } from '../template.ts';
-import { TreeView } from './TreeView.tsx';
+import { TreeView, type RenderNodeActions } from './TreeView.tsx';
 import { initTooltips } from './tooltip.ts';
 
-export type { ReportSource, ViewerOptions } from '../source.ts';
+export type { ReportSource } from '../source.ts';
 export type { FetchLike } from '../poll.ts';
+export type { RenderNodeActions } from './TreeView.tsx';
+export type { TestNode } from '@reporters/tree-core';
+
+export interface ViewerOptions extends SourceOptions {
+  /** Render custom trailing content (e.g. action buttons) at the end of every
+   *  tree row, inside a `.node-actions` wrapper that swallows clicks/keys so
+   *  they never toggle the row. Called for every node — containers and tests
+   *  alike — on each render (frequent during a live run), so keep it cheap;
+   *  return null to render nothing for a node. Visibility (e.g. reveal on row
+   *  hover) is the embedder's own CSS: `.row:hover .node-actions { … }`. */
+  renderNodeActions?: RenderNodeActions;
+}
 
 const delay = (ms: number) => new Promise((resolve) => { setTimeout(resolve, ms); });
 
@@ -39,6 +51,7 @@ export async function startViewer(options: ViewerOptions = {}): Promise<void> {
       pending={pending}
       loadError={loadError}
       onRetry={retry}
+      renderNodeActions={options.renderNodeActions}
     />,
   );
 

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -167,6 +167,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 .carry-sum { flex: none; font-size: 11px; color: var(--dim); font-variant-numeric: tabular-nums; }
 .dur { flex: none; color: var(--faint); font-size: 11.5px; font-family: var(--mono); min-width: 54px; text-align: right; font-variant-numeric: tabular-nums; }
 .dur[data-carried="true"] { font-style: italic; }
+.node-actions { flex: none; display: inline-flex; align-items: center; gap: 4px; }
 
 /* shared floating tooltip: one body-level fixed node (client/tooltip.ts), so
    no overflow container or sticky-header stacking context can clip or cover

--- a/packages/web/tests/dist.test.ts
+++ b/packages/web/tests/dist.test.ts
@@ -12,10 +12,14 @@ test('the viewer library bundle exports startViewer', () => {
   assert.match(bundle, /export\s*\{[^}]*\bas\s+startViewer\b[^}]*\}/);
 });
 
-test('the viewer library bundle has no bare static imports', () => {
-  assert.doesNotMatch(bundle, /from\s*["'][^./]/);
+test('the viewer library bundle imports only react as a bare specifier', () => {
+  const bare = [...bundle.matchAll(/from\s*["']([^./"'][^"']*)["']/g)].map((m) => m[1]);
+  assert.ok(bare.some((spec) => /^react(\/|$)/.test(spec)));
+  for (const spec of bare) assert.match(spec, /^react(-dom)?(\/|$)/);
 });
 
-test('the viewer library bundle ships production React', () => {
-  assert.doesNotMatch(bundle, /react\.development/);
+test('the standalone viewer page still inlines React', () => {
+  const page = readFileSync(new URL('../dist/viewer/index.html', import.meta.url), 'utf8');
+  assert.doesNotMatch(page, /from\s*["']react["']/);
+  assert.doesNotMatch(page, /require\(\s*["']react["']\s*\)/);
 });

--- a/packages/web/tsup.config.ts
+++ b/packages/web/tsup.config.ts
@@ -13,7 +13,8 @@ export default defineConfig([
     noExternal: [/@reporters\/tree-core/],
   },
   // Browser clients: self-contained IIFE bundles (React + react-dom + tree-core
-  // inlined). `viewer` is assembled into a standalone page below.
+  // inlined; react is a peer dep, so force-bundle it here). `viewer` is
+  // assembled into a standalone page below.
   {
     entry: { viewer: 'src/client/viewer.tsx' },
     format: ['iife'],
@@ -22,6 +23,7 @@ export default defineConfig([
     dts: false,
     clean: false,
     minify: true,
+    noExternal: [/.*/],
     async onSuccess() {
       const viewerJs = readFileSync('dist/viewer.global.js', 'utf8');
       const page = `<!doctype html>
@@ -42,7 +44,9 @@ export default defineConfig([
     },
   },
   // Browser library entry: startViewer for hosts composing their own viewer
-  // page with a custom source resolver. Self-contained (React inlined).
+  // page with a custom source resolver and per-row TSX. React stays external
+  // (peer dep) so the host's TSX and the viewer share one React instance;
+  // everything else is inlined.
   {
     entry: { start: 'src/client/start.tsx' },
     format: ['esm'],
@@ -52,6 +56,7 @@ export default defineConfig([
     clean: false,
     minify: true,
     env: { NODE_ENV: 'production' },
-    noExternal: [/.*/],
+    external: [/^react(-dom)?(\/|$)/],
+    noExternal: [/@reporters\/tree-core/, 'fancy-ansi'],
   },
 ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -836,6 +836,14 @@ __metadata:
     react-dom: "npm:^19.0.0"
     tsup: "npm:^8.5.0"
     typescript: "npm:^5.7.0"
+  peerDependencies:
+    react: ^19.0.0
+    react-dom: ^19.0.0
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## What

`startViewer()` (the `@reporters/web/viewer` embed entry) gains a new option:

```tsx
startViewer({
  renderNodeActions: (node: TestNode) => (node.type === 'test'
    ? <button onClick={() => rerun(node)}>↻ rerun</button>
    : null),
});
```

- Called for every row — containers and tests alike; return `null` to render nothing for a node.
- The result renders at the end of the row (after the duration) inside a `.node-actions` wrapper that stops click/mousedown/keydown propagation, so custom buttons never toggle the row's disclosure.
- Visibility is the embedder's call via their own CSS (e.g. `.row:hover .node-actions { visibility: visible }`) — nothing is hardcoded.
- `TestNode` and `RenderNodeActions` are exported from `@reporters/web/viewer` for typing.

## BREAKING (packaging of `/viewer` entry only)

For the embedder's TSX and the viewer to share one React instance, `dist/start.js` no longer inlines React: `react`/`react-dom` are externalized (bundle 258 KB → 68 KB) and declared as **optional** peer dependencies — optional so reporter-only installs see no warnings. The standalone `viewer/index.html` page is unchanged and got an explicit `noExternal` so the new peer deps don't silently leak out of its IIFE build.

## Verification

- All 104 package tests pass; dist tests now assert the library bundle's only bare imports are `react`/`react-dom` and the standalone page still inlines React.
- Driven in a real browser (Playwright) from a page bundling `dist/start.js` with its own TSX over a served NDJSON run: buttons render only on test rows, the click handler fires without collapsing the expanded row, hover-reveal CSS works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)