### PR TITLE
feat(web): renderHeaderActions slot; node actions before row indicators

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -79,6 +79,7 @@ startViewer({
   renderNodeActions: (node: TestNode) => (node.type === 'test'
     ? <button onClick={() => rerun(node)}>↻ rerun</button>
     : null),
+  renderHeaderActions: () => <button onClick={rerunAll}>↻ rerun all</button>,
 });
 ```
 
@@ -97,11 +98,12 @@ that never resolves is fine while an auth redirect is in flight.
 
 ### `renderNodeActions`
 
-Renders custom trailing content at the end of every tree row — containers and
-tests alike; return `null` to render nothing for a node. The result is wrapped
-in a `.node-actions` element that swallows clicks and keystrokes, so your
-buttons never toggle the row's disclosure. It is called on every render (which
-is frequent during a live run), so keep it cheap.
+Renders custom content on every tree row — containers and tests alike; return
+`null` to render nothing for a node. The result sits between the test name and
+the row's built-in trailing indicators (status pills, duration), wrapped in a
+`.node-actions` element that swallows clicks and keystrokes so your buttons
+never toggle the row's disclosure. It is called on every render (which is
+frequent during a live run), so keep it cheap.
 
 Visibility is yours to style — e.g. reveal on row hover:
 
@@ -109,3 +111,9 @@ Visibility is yours to style — e.g. reveal on row hover:
 .node-actions { visibility: hidden; }
 .row:hover .node-actions, .row:focus-within .node-actions { visibility: visible; }
 ```
+
+### `renderHeaderActions`
+
+Renders custom content in the header toolbar, to the right of the built-in
+buttons (search, theme, collapse all), wrapped in a `.header-actions` element.
+Same contract as `renderNodeActions`: called on every render, so keep it cheap.

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -561,6 +561,10 @@ const rowKey = (row: FlatRow): string => (row.kind === 'output' ? `${row.node.ke
  *  render, so it must be cheap; return null to render nothing for a node. */
 export type RenderNodeActions = (node: TestNode) => React.ReactNode;
 
+/** Embedder hook: render custom content in the header toolbar, after the
+ *  built-in buttons. Called on every render, so it must be cheap. */
+export type RenderHeaderActions = () => React.ReactNode;
+
 interface RowViewProps {
   row: FlatRow;
   toggle: (key: string, current: boolean) => void;
@@ -657,6 +661,18 @@ function RowView({
         <span className="todotag" data-soft="skipped">⊘ {trimTag(node.skip)}</span>
       ) : null}
       <span className="spacer" />
+      {renderNodeActions ? (
+        // Custom content is interactive on its own terms: clicks and keys
+        // inside must never toggle the row's disclosure.
+        <span
+          className="node-actions"
+          onClick={(e) => e.stopPropagation()}
+          onMouseDown={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          {renderNodeActions(node)}
+        </span>
+      ) : null}
       {container && !expanded ? (
         <span className="pills">
           {STATUS_ORDER.filter((s) => (s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]) > 0).map((s) => (
@@ -675,18 +691,6 @@ function RowView({
         </span>
       ) : null}
       <span className="dur" data-carried={carried || rollupMark ? 'true' : undefined} data-tip={durTip}>{formatDuration(ms) || '—'}</span>
-      {renderNodeActions ? (
-        // Custom content is interactive on its own terms: clicks and keys
-        // inside must never toggle the row's disclosure.
-        <span
-          className="node-actions"
-          onClick={(e) => e.stopPropagation()}
-          onMouseDown={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
-        >
-          {renderNodeActions(node)}
-        </span>
-      ) : null}
     </div>
   );
 }
@@ -738,10 +742,12 @@ export interface TreeViewProps {
   onRetry?: () => void;
   /** Render custom trailing content at the end of every tree row. */
   renderNodeActions?: RenderNodeActions;
+  /** Render custom content at the end of the header toolbar. */
+  renderHeaderActions?: RenderHeaderActions;
 }
 
 export function TreeView({
-  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions,
+  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions, renderHeaderActions,
 }: TreeViewProps) {
   const [theme, toggleTheme] = useTheme();
   // Filters live in the URL (?q, ?status, ?rerun) so a copied link shares the
@@ -941,6 +947,9 @@ export function TreeView({
             >
               {allCollapsed ? 'Expand all' : 'Collapse all'}
             </button>
+            {renderHeaderActions ? (
+              <span className="header-actions">{renderHeaderActions()}</span>
+            ) : null}
           </div>
         </div>
         <div className="hdr-bar-row">

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -4,12 +4,12 @@ import { createTreeStore, type TreeStore } from '@reporters/tree-core';
 import { createNdjsonReader } from '../poll.ts';
 import { resolveReportSource, type ViewerOptions as SourceOptions } from '../source.ts';
 import { STYLES } from '../template.ts';
-import { TreeView, type RenderNodeActions } from './TreeView.tsx';
+import { TreeView, type RenderHeaderActions, type RenderNodeActions } from './TreeView.tsx';
 import { initTooltips } from './tooltip.ts';
 
 export type { ReportSource } from '../source.ts';
 export type { FetchLike } from '../poll.ts';
-export type { RenderNodeActions } from './TreeView.tsx';
+export type { RenderHeaderActions, RenderNodeActions } from './TreeView.tsx';
 export type { TestNode } from '@reporters/tree-core';
 
 export interface ViewerOptions extends SourceOptions {
@@ -20,6 +20,10 @@ export interface ViewerOptions extends SourceOptions {
    *  return null to render nothing for a node. Visibility (e.g. reveal on row
    *  hover) is the embedder's own CSS: `.row:hover .node-actions { … }`. */
   renderNodeActions?: RenderNodeActions;
+  /** Render custom content in the header toolbar, to the right of the built-in
+   *  buttons (search, theme, collapse all), inside a `.header-actions` wrapper.
+   *  Called on each render (frequent during a live run), so keep it cheap. */
+  renderHeaderActions?: RenderHeaderActions;
 }
 
 const delay = (ms: number) => new Promise((resolve) => { setTimeout(resolve, ms); });
@@ -52,6 +56,7 @@ export async function startViewer(options: ViewerOptions = {}): Promise<void> {
       loadError={loadError}
       onRetry={retry}
       renderNodeActions={options.renderNodeActions}
+      renderHeaderActions={options.renderHeaderActions}
     />,
   );
 

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -168,6 +168,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 .dur { flex: none; color: var(--faint); font-size: 11.5px; font-family: var(--mono); min-width: 54px; text-align: right; font-variant-numeric: tabular-nums; }
 .dur[data-carried="true"] { font-style: italic; }
 .node-actions { flex: none; display: inline-flex; align-items: center; gap: 4px; }
+.header-actions { flex: none; display: inline-flex; align-items: center; gap: 4px; }
 
 /* shared floating tooltip: one body-level fixed node (client/tooltip.ts), so
    no overflow container or sticky-header stacking context can clip or cover


### PR DESCRIPTION
## What

Two follow-ups to #259:

1. **Node actions moved left of the row's built-in indicators** — the `.node-actions` wrapper now renders right after the flex spacer, before the status pills, carry gutter, and duration, so the viewer's own trailing indicators keep their aligned right edge and embedder buttons sit next to the test name's free space.

2. **New `renderHeaderActions?: () => ReactNode` option** — renders embedder content in the header toolbar, to the right of the built-in buttons (search, theme toggle, collapse all), inside a `.header-actions` wrapper. Same contract as `renderNodeActions`: called on every render, keep it cheap. Exported as `RenderHeaderActions` from `@reporters/web/viewer`.

## Verification

- All 107 package tests pass; lint clean.
- Driven in a real browser (Playwright) from an embed page bundling `dist/start.js`: row child order is `… name → spacer → node-actions → dur`, the header slot renders right of Collapse all, and one click on a header button fires its handler exactly once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)