### PR TITLE
feat(web): TestReportViewer — the viewer as a React component

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -63,12 +63,44 @@ the same run state, rendered in the browser instead of the terminal.
 
 ## Embedding the viewer (`@reporters/web/viewer`)
 
-The hosted viewer reads `?src=<url>` with plain `fetch`. To serve reports that
-need authentication (private buckets, SSO), or to add your own controls to the
-tree, build your own viewer page on the same UI:
+The export is a browser ESM module that bundles everything except React —
+`react` and `react-dom` are (optional) peer dependencies, so your app's TSX and
+the viewer share one React 19 instance.
+
+### `<TestReportViewer>` — the viewer as a component
+
+Render the whole viewer anywhere in a React app — a tab, a modal, a split
+pane. It polls `src` with HTTP Range, live-updates until the run's final
+summary, and stops polling on unmount. Styles are injected into
+`document.head` on first mount.
 
 ```tsx
-import { startViewer, type TestNode } from '@reporters/web/viewer';
+import { TestReportViewer, type TestNode } from '@reporters/web/viewer';
+
+<TestReportViewer
+  src={reportUrl}
+  fetch={authenticatedFetch}  // optional; receives the Range header
+  pollMs={250}                // optional; default 1000
+  renderNodeActions={(node: TestNode) => (node.type === 'test'
+    ? <button onClick={() => rerun(node)}>↻ rerun</button>
+    : null)}
+  renderHeaderActions={() => <button onClick={rerunAll}>↻ rerun all</button>}
+/>
+```
+
+Filters (search, status chips, Only re-run) live in memory — the component
+never touches the host page's URL. Pass `syncUrl` to opt into the standalone
+page's shareable `?q`/`?status`/`?rerun` params.
+
+### `startViewer()` — a full viewer page
+
+For a dedicated static page on the same UI (the hosted viewer is exactly
+this), `startViewer` reads `?src=`/`?poll=` from the page URL, mounts into
+`#root`, and keeps filters in the URL so views are shareable. Reports that
+need authentication (private buckets, SSO) plug in a source resolver:
+
+```tsx
+import { startViewer } from '@reporters/web/viewer';
 
 startViewer({
   resolveSource: async (params) => {
@@ -76,25 +108,17 @@ startViewer({
     const credentials = await acquireCredentialsSomehow();
     return { url: params.get('key')!, fetch: authenticatedFetch(credentials) };
   },
-  renderNodeActions: (node: TestNode) => (node.type === 'test'
-    ? <button onClick={() => rerun(node)}>↻ rerun</button>
-    : null),
-  renderHeaderActions: () => <button onClick={rerunAll}>↻ rerun all</button>,
+  renderNodeActions: ...,   // both hooks work here too
+  renderHeaderActions: ...,
 });
 ```
 
-The export is a browser ESM module that bundles everything except React —
-`react` and `react-dom` are (optional) peer dependencies, so your page's TSX
-and the viewer share one React 19 instance. Bundle it with your resolver into a
-static HTML page.
-
-### `resolveSource`
-
-Runs before anything renders. Return `null`/`undefined` to fall through to the
-default `?src=` handling; return `{ url, fetch?, pollMs? }` to take over. The
-custom `fetch` receives the reader's `Range` header and must return a standard
-`Response`; a thrown error shows the viewer's load-error screen, and a promise
-that never resolves is fine while an auth redirect is in flight.
+`resolveSource` runs before anything renders. Return `null`/`undefined` to fall
+through to the default `?src=` handling; return `{ url, fetch?, pollMs? }` to
+take over. The custom `fetch` receives the reader's `Range` header and must
+return a standard `Response`; a thrown error shows the viewer's load-error
+screen, and a promise that never resolves is fine while an auth redirect is in
+flight.
 
 ### `renderNodeActions`
 

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -75,12 +75,15 @@ summary, and stops polling on unmount. Styles are injected into
 `document.head` on first mount.
 
 ```tsx
-import { TestReportViewer, type TestNode } from '@reporters/web/viewer';
+import { TestReportViewer, memoryFilterState, type TestNode } from '@reporters/web/viewer';
+
+const filters = memoryFilterState();
 
 <TestReportViewer
   src={reportUrl}
   fetch={authenticatedFetch}  // optional; receives the Range header
   pollMs={250}                // optional; default 1000
+  filters={filters}           // optional; defaults to the shareable page URL
   renderNodeActions={(node: TestNode) => (node.type === 'test'
     ? <button onClick={() => rerun(node)}>↻ rerun</button>
     : null)}
@@ -88,9 +91,22 @@ import { TestReportViewer, type TestNode } from '@reporters/web/viewer';
 />
 ```
 
-Filters (search, status chips, Only re-run) live in memory — the component
-never touches the host page's URL. Pass `syncUrl` to opt into the standalone
-page's shareable `?q`/`?status`/`?rerun` params.
+Filter state (search, status chips, Only re-run) lives in a pluggable
+`FilterStore`. The default is `urlFilterState()` — shareable
+`?q`/`?status`/`?rerun` params, exactly like the standalone page. Pass
+`memoryFilterState()` when the host app owns the address bar, or implement the
+three-method interface to bind filters to your router or state container:
+
+```ts
+interface FilterStore {
+  read(): FilterState;                                        // initial state on mount
+  write(state: FilterState): void;                            // called on every change
+  subscribe?(onChange: (s: FilterState) => void): () => void; // external changes
+}
+```
+
+The store instance must be stable for the life of the component — create it
+outside the render (or in `useState`/`useMemo`).
 
 ### `startViewer()` — a full viewer page
 

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -224,15 +224,17 @@ function currentSearch(): string {
 /** Shareable filter state: `?q`, `?status` and `?rerun` mirror the search box,
  *  status chips and Only re-run. Discrete toggles push a history entry
  *  immediately, typing debounces into one entry, and Back/Forward restore the
- *  previous filters. */
-function useUrlFilters() {
-  const [query, setQuery] = useState(() => parseFilterState(currentSearch()).query);
-  const [statuses, setStatuses] = useState<ReadonlySet<TestStatus>>(() => parseFilterState(currentSearch()).statuses);
-  const [onlyRerun, setOnlyRerun] = useState(() => parseFilterState(currentSearch()).onlyRerun);
+ *  previous filters. With `syncUrl` off (embedded in a host app that owns the
+ *  address bar), filters live purely in memory and history is never touched. */
+function useUrlFilters(syncUrl: boolean) {
+  const [query, setQuery] = useState(() => (syncUrl ? parseFilterState(currentSearch()).query : ''));
+  const [statuses, setStatuses] = useState<ReadonlySet<TestStatus>>(() => (syncUrl ? parseFilterState(currentSearch()).statuses : new Set()));
+  const [onlyRerun, setOnlyRerun] = useState(() => (syncUrl ? parseFilterState(currentSearch()).onlyRerun : false));
   const state: FilterState = { query, statuses, onlyRerun };
   const stateRef = useRef(state);
   stateRef.current = state;
   const sync = () => {
+    if (!syncUrl) return;
     const search = currentSearch();
     const next = serializeFilterState(stateRef.current, search);
     // Compare canonical forms so encoding quirks (%20 vs +) never push.
@@ -247,6 +249,7 @@ function useUrlFilters() {
     return () => clearTimeout(id);
   }, [query]);
   useEffect(() => {
+    if (!syncUrl) return undefined;
     const onPop = () => {
       const s = parseFilterState(currentSearch());
       setQuery(s.query);
@@ -255,7 +258,7 @@ function useUrlFilters() {
     };
     window.addEventListener('popstate', onPop);
     return () => window.removeEventListener('popstate', onPop);
-  }, []);
+  }, [syncUrl]);
   return {
     query, setQuery, statuses, setStatuses, onlyRerun, setOnlyRerun,
   };
@@ -744,17 +747,20 @@ export interface TreeViewProps {
   renderNodeActions?: RenderNodeActions;
   /** Render custom content at the end of the header toolbar. */
   renderHeaderActions?: RenderHeaderActions;
+  /** Mirror filters into the page URL (?q, ?status, ?rerun). On for the
+   *  standalone page; off when embedded so the host's router owns the URL. */
+  syncUrl?: boolean;
 }
 
 export function TreeView({
-  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions, renderHeaderActions,
+  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions, renderHeaderActions, syncUrl = true,
 }: TreeViewProps) {
   const [theme, toggleTheme] = useTheme();
   // Filters live in the URL (?q, ?status, ?rerun) so a copied link shares the
   // same view; statuses empty = unfiltered.
   const {
     query, setQuery, statuses, setStatuses, onlyRerun, setOnlyRerun,
-  } = useUrlFilters();
+  } = useUrlFilters(syncUrl);
   const [overrides, setOverrides] = useState<Map<string, boolean>>(new Map());
   const toggleStatus = (s: TestStatus) => {
     setStatuses((prev) => {

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -14,7 +14,7 @@ import { AnsiSpan } from './ansi.ts';
 import {
   classifyFrame, extractLevel, formatCount, levelSeverity, splitUrls, stripAnsi, type StackLine,
 } from './format.ts';
-import { parseFilterState, serializeFilterState, type FilterState } from './urlState.ts';
+import { urlFilterState, type FilterState, type FilterStore } from './urlState.ts';
 
 const GLYPH: Record<TestStatus, string> = {
   passed: '✓', failed: '✕', skipped: '⊘', todo: '◇', running: '◐', queued: '○',
@@ -217,50 +217,23 @@ function computeTheme(): 'dark' | 'light' {
   return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
 
-function currentSearch(): string {
-  try { return window.location.search; } catch { return ''; }
-}
-
-/** Shareable filter state: `?q`, `?status` and `?rerun` mirror the search box,
- *  status chips and Only re-run. Discrete toggles push a history entry
- *  immediately, typing debounces into one entry, and Back/Forward restore the
- *  previous filters. With `syncUrl` off (embedded in a host app that owns the
- *  address bar), filters live purely in memory and history is never touched. */
-function useUrlFilters(syncUrl: boolean) {
-  const [query, setQuery] = useState(() => (syncUrl ? parseFilterState(currentSearch()).query : ''));
-  const [statuses, setStatuses] = useState<ReadonlySet<TestStatus>>(() => (syncUrl ? parseFilterState(currentSearch()).statuses : new Set()));
-  const [onlyRerun, setOnlyRerun] = useState(() => (syncUrl ? parseFilterState(currentSearch()).onlyRerun : false));
-  const state: FilterState = { query, statuses, onlyRerun };
-  const stateRef = useRef(state);
-  stateRef.current = state;
-  const sync = () => {
-    if (!syncUrl) return;
-    const search = currentSearch();
-    const next = serializeFilterState(stateRef.current, search);
-    // Compare canonical forms so encoding quirks (%20 vs +) never push.
-    if (next === serializeFilterState(parseFilterState(search), search)) return;
-    try {
-      window.history.pushState(null, '', `${window.location.pathname}${next}${window.location.hash}`);
-    } catch { /* history may be unavailable (sandboxed iframe) */ }
-  };
-  useEffect(sync, [statuses, onlyRerun]);
+/** Filter state (search, status chips, Only re-run) bound to a FilterStore:
+ *  read once on mount, write on every change, re-read on external changes
+ *  (Back/Forward for the URL store, the host's own events for custom ones). */
+function useFilters(store: FilterStore) {
+  const [state, setState] = useState<FilterState>(() => store.read());
+  const first = useRef(true);
   useEffect(() => {
-    const id = setTimeout(sync, 400);
-    return () => clearTimeout(id);
-  }, [query]);
-  useEffect(() => {
-    if (!syncUrl) return undefined;
-    const onPop = () => {
-      const s = parseFilterState(currentSearch());
-      setQuery(s.query);
-      setStatuses(s.statuses);
-      setOnlyRerun(s.onlyRerun);
-    };
-    window.addEventListener('popstate', onPop);
-    return () => window.removeEventListener('popstate', onPop);
-  }, [syncUrl]);
+    // Mount state came from read(); only user changes are written back.
+    if (first.current) { first.current = false; return; }
+    store.write(state);
+  }, [state]);
+  useEffect(() => store.subscribe?.(setState), [store]);
+  const setQuery = (query: string) => setState((prev) => ({ ...prev, query }));
+  const setStatuses = (next: ReadonlySet<TestStatus> | ((prev: ReadonlySet<TestStatus>) => ReadonlySet<TestStatus>)) => setState((prev) => ({ ...prev, statuses: typeof next === 'function' ? next(prev.statuses) : next }));
+  const setOnlyRerun = (onlyRerun: boolean) => setState((prev) => ({ ...prev, onlyRerun }));
   return {
-    query, setQuery, statuses, setStatuses, onlyRerun, setOnlyRerun,
+    query: state.query, statuses: state.statuses, onlyRerun: state.onlyRerun, setQuery, setStatuses, setOnlyRerun,
   };
 }
 
@@ -747,20 +720,21 @@ export interface TreeViewProps {
   renderNodeActions?: RenderNodeActions;
   /** Render custom content at the end of the header toolbar. */
   renderHeaderActions?: RenderHeaderActions;
-  /** Mirror filters into the page URL (?q, ?status, ?rerun). On for the
-   *  standalone page; off when embedded so the host's router owns the URL. */
-  syncUrl?: boolean;
+  /** Where filter state lives; defaults to the shareable page URL (?q,
+   *  ?status, ?rerun). Pass memoryFilterState() (or your own store) when the
+   *  host app owns the address bar. Must be stable across renders. */
+  filters?: FilterStore;
 }
 
 export function TreeView({
-  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions, renderHeaderActions, syncUrl = true,
+  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions, renderHeaderActions, filters,
 }: TreeViewProps) {
   const [theme, toggleTheme] = useTheme();
-  // Filters live in the URL (?q, ?status, ?rerun) so a copied link shares the
-  // same view; statuses empty = unfiltered.
+  // The default store is per-mount so its debounce timer dies with the view.
+  const [defaultFilters] = useState(() => filters ?? urlFilterState());
   const {
     query, setQuery, statuses, setStatuses, onlyRerun, setOnlyRerun,
-  } = useUrlFilters(syncUrl);
+  } = useFilters(filters ?? defaultFilters);
   const [overrides, setOverrides] = useState<Map<string, boolean>>(new Map());
   const toggleStatus = (s: TestStatus) => {
     setStatuses((prev) => {

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -1,4 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, {
+  useCallback, useEffect, useInsertionEffect, useState,
+} from 'react';
 import { createRoot } from 'react-dom/client';
 import { createTreeStore, type TreeSnapshot } from '@reporters/tree-core';
 import { createNdjsonReader, DEFAULT_POLL_MS, type FetchLike } from '../poll.ts';
@@ -47,8 +49,9 @@ interface StreamView {
 
 /** Poll the NDJSON report and fold events into a live snapshot. Stops at the
  *  run's final summary, on unmount, or when the source identity changes;
- *  `retry` restarts the stream from scratch after a load error. */
-function useReportStream(src: string, fetchImpl: FetchLike | undefined, pollMs: number) {
+ *  `retry` restarts the stream from scratch after a load error. Without a
+ *  `src` there is nothing to poll — the view settles on the load-error state. */
+function useReportStream(src: string | undefined, fetchImpl: FetchLike | undefined, pollMs: number) {
   const [generation, setGeneration] = useState(0);
   const [view, setView] = useState<StreamView>(() => ({
     snapshot: createTreeStore().getSnapshot(), streaming: true, pending: true, loadError: false,
@@ -56,6 +59,12 @@ function useReportStream(src: string, fetchImpl: FetchLike | undefined, pollMs: 
   useEffect(() => {
     let cancelled = false;
     let store = createTreeStore();
+    if (!src) {
+      setView({
+        snapshot: store.getSnapshot(), streaming: false, pending: false, loadError: true,
+      });
+      return undefined;
+    }
     const reader = createNdjsonReader(src, fetchImpl);
     setView({
       snapshot: store.getSnapshot(), streaming: true, pending: true, loadError: false,
@@ -99,8 +108,10 @@ function useReportStream(src: string, fetchImpl: FetchLike | undefined, pollMs: 
 }
 
 export interface TestReportViewerProps {
-  /** URL of the NDJSON report; polled with HTTP Range while the run streams. */
-  src: string;
+  /** URL of the NDJSON report; polled with HTTP Range while the run streams.
+   *  Omit (e.g. while the host is still resolving where the report lives and
+   *  has nothing to show) to render the load-error screen. */
+  src?: string;
   /** Transport for reads; defaults to the global fetch. Receives the reader's
    *  Range header and must return a standard Response. */
   fetch?: FetchLike;
@@ -113,15 +124,20 @@ export interface TestReportViewerProps {
    *  address bar, or your own store to bind filters to a router or state
    *  container. Must be stable across renders. */
   filters?: FilterStore;
+  /** Replaces the load-error screen's default retry (restart the stream) —
+   *  e.g. re-run the host's own source resolution. With no `src` there is no
+   *  stream to restart, so without this the retry button is hidden. */
+  onRetry?: () => void;
 }
 
 /** The report viewer as a React component: render it anywhere in a host app.
  *  Polls `src`, live-updates until the run's summary, and stops polling on
- *  unmount. Styles are injected into document.head on first mount. */
+ *  unmount. Injects its stylesheet into document.head before first paint. */
 export function TestReportViewer({
-  src, fetch: fetchImpl, pollMs = DEFAULT_POLL_MS, renderNodeActions, renderHeaderActions, filters,
+  src, fetch: fetchImpl, pollMs = DEFAULT_POLL_MS, renderNodeActions, renderHeaderActions, filters, onRetry,
 }: TestReportViewerProps) {
-  useEffect(() => { injectStyles(); initTooltips(); }, []);
+  useInsertionEffect(() => { injectStyles(); }, []);
+  useEffect(() => { initTooltips(); }, []);
   const {
     snapshot, streaming, pending, loadError, retry,
   } = useReportStream(src, fetchImpl, pollMs);
@@ -131,7 +147,7 @@ export function TestReportViewer({
       streaming={streaming}
       pending={pending}
       loadError={loadError}
-      onRetry={retry}
+      onRetry={onRetry ?? (src ? retry : undefined)}
       renderNodeActions={renderNodeActions}
       renderHeaderActions={renderHeaderActions}
       filters={filters}
@@ -140,11 +156,8 @@ export function TestReportViewer({
 }
 
 export async function startViewer(options: ViewerOptions = {}): Promise<void> {
-  injectStyles();
-  initTooltips();
   const mount = document.getElementById('root');
   if (!mount) return;
-  const root = createRoot(mount);
 
   let source;
   try {
@@ -153,27 +166,16 @@ export async function startViewer(options: ViewerOptions = {}): Promise<void> {
     console.error(err);
     source = null;
   }
-  if (!source) {
-    // No usable source at all (missing/rejected ?src=): a retry must re-run
-    // source resolution, so reload the page rather than re-poll.
-    root.render(
-      <TreeView
-        snapshot={createTreeStore().getSnapshot()}
-        streaming={false}
-        loadError
-        onRetry={() => window.location.reload()}
-      />,
-    );
-    return;
-  }
-
-  root.render(
+  createRoot(mount).render(
     <TestReportViewer
-      src={source.url}
-      fetch={source.fetch}
-      pollMs={source.pollMs}
+      src={source?.url}
+      fetch={source?.fetch}
+      pollMs={source?.pollMs}
       renderNodeActions={options.renderNodeActions}
       renderHeaderActions={options.renderHeaderActions}
+      // No usable source (missing/rejected ?src=): a retry must re-run source
+      // resolution, so reload the page rather than restart a stream.
+      onRetry={source ? undefined : () => window.location.reload()}
     />,
   );
 }

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -6,11 +6,13 @@ import { resolveReportSource, type ViewerOptions as SourceOptions } from '../sou
 import { STYLES } from '../template.ts';
 import { TreeView, type RenderHeaderActions, type RenderNodeActions } from './TreeView.tsx';
 import { initTooltips } from './tooltip.ts';
+import type { FilterStore } from './urlState.ts';
 
 export type { ReportSource } from '../source.ts';
 export type { FetchLike } from '../poll.ts';
 export type { RenderHeaderActions, RenderNodeActions } from './TreeView.tsx';
 export type { TestNode } from '@reporters/tree-core';
+export { memoryFilterState, urlFilterState, type FilterState, type FilterStore } from './urlState.ts';
 
 export interface ViewerOptions extends SourceOptions {
   /** Render custom trailing content (e.g. action buttons) at the end of every
@@ -106,17 +108,18 @@ export interface TestReportViewerProps {
   pollMs?: number;
   renderNodeActions?: RenderNodeActions;
   renderHeaderActions?: RenderHeaderActions;
-  /** Mirror filters into the page URL (?q, ?status, ?rerun). Off by default:
-   *  an embedded viewer must not fight the host app's router. The standalone
-   *  page turns it on for shareable links. */
-  syncUrl?: boolean;
+  /** Where filter state (?q, ?status, ?rerun) lives; defaults to the
+   *  shareable page URL. Pass memoryFilterState() when the host app owns the
+   *  address bar, or your own store to bind filters to a router or state
+   *  container. Must be stable across renders. */
+  filters?: FilterStore;
 }
 
 /** The report viewer as a React component: render it anywhere in a host app.
  *  Polls `src`, live-updates until the run's summary, and stops polling on
  *  unmount. Styles are injected into document.head on first mount. */
 export function TestReportViewer({
-  src, fetch: fetchImpl, pollMs = DEFAULT_POLL_MS, renderNodeActions, renderHeaderActions, syncUrl = false,
+  src, fetch: fetchImpl, pollMs = DEFAULT_POLL_MS, renderNodeActions, renderHeaderActions, filters,
 }: TestReportViewerProps) {
   useEffect(() => { injectStyles(); initTooltips(); }, []);
   const {
@@ -131,7 +134,7 @@ export function TestReportViewer({
       onRetry={retry}
       renderNodeActions={renderNodeActions}
       renderHeaderActions={renderHeaderActions}
-      syncUrl={syncUrl}
+      filters={filters}
     />
   );
 }
@@ -171,7 +174,6 @@ export async function startViewer(options: ViewerOptions = {}): Promise<void> {
       pollMs={source.pollMs}
       renderNodeActions={options.renderNodeActions}
       renderHeaderActions={options.renderHeaderActions}
-      syncUrl
     />,
   );
 }

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { createTreeStore, type TreeStore } from '@reporters/tree-core';
-import { createNdjsonReader } from '../poll.ts';
+import { createTreeStore, type TreeSnapshot } from '@reporters/tree-core';
+import { createNdjsonReader, DEFAULT_POLL_MS, type FetchLike } from '../poll.ts';
 import { resolveReportSource, type ViewerOptions as SourceOptions } from '../source.ts';
 import { STYLES } from '../template.ts';
 import { TreeView, type RenderHeaderActions, type RenderNodeActions } from './TreeView.tsx';
@@ -36,29 +36,112 @@ function injectStyles(): void {
   document.head.appendChild(style);
 }
 
+interface StreamView {
+  snapshot: TreeSnapshot;
+  streaming: boolean;
+  pending: boolean;
+  loadError: boolean;
+}
+
+/** Poll the NDJSON report and fold events into a live snapshot. Stops at the
+ *  run's final summary, on unmount, or when the source identity changes;
+ *  `retry` restarts the stream from scratch after a load error. */
+function useReportStream(src: string, fetchImpl: FetchLike | undefined, pollMs: number) {
+  const [generation, setGeneration] = useState(0);
+  const [view, setView] = useState<StreamView>(() => ({
+    snapshot: createTreeStore().getSnapshot(), streaming: true, pending: true, loadError: false,
+  }));
+  useEffect(() => {
+    let cancelled = false;
+    let store = createTreeStore();
+    const reader = createNdjsonReader(src, fetchImpl);
+    setView({
+      snapshot: store.getSnapshot(), streaming: true, pending: true, loadError: false,
+    });
+    (async () => {
+      // Poll until the run reports a final summary, then stop.
+      for (;;) {
+        try {
+          const { events, reset } = await reader.pull();
+          if (cancelled) return;
+          if (reset) store = createTreeStore();
+          for (const event of events) store.apply(event);
+          const snapshot = store.getSnapshot();
+          if (snapshot.summary) {
+            setView({
+              snapshot, streaming: false, pending: false, loadError: false,
+            });
+            return;
+          }
+          setView((prev) => (events.length || reset || prev.pending || prev.loadError ? {
+            snapshot, streaming: true, pending: false, loadError: false,
+          } : prev));
+        } catch (err) {
+          // Never received any data yet: the source is missing/unreachable —
+          // surface the error screen. Once data has arrived, treat failures as
+          // transient and keep polling.
+          console.error(err);
+          if (cancelled) return;
+          setView((prev) => (prev.snapshot.root.children.length === 0 ? {
+            ...prev, pending: false, loadError: true,
+          } : prev));
+        }
+        await delay(pollMs);
+        if (cancelled) return;
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [src, fetchImpl, pollMs, generation]);
+  const retry = useCallback(() => setGeneration((g) => g + 1), []);
+  return { ...view, retry };
+}
+
+export interface TestReportViewerProps {
+  /** URL of the NDJSON report; polled with HTTP Range while the run streams. */
+  src: string;
+  /** Transport for reads; defaults to the global fetch. Receives the reader's
+   *  Range header and must return a standard Response. */
+  fetch?: FetchLike;
+  /** Poll cadence while the run is live. */
+  pollMs?: number;
+  renderNodeActions?: RenderNodeActions;
+  renderHeaderActions?: RenderHeaderActions;
+  /** Mirror filters into the page URL (?q, ?status, ?rerun). Off by default:
+   *  an embedded viewer must not fight the host app's router. The standalone
+   *  page turns it on for shareable links. */
+  syncUrl?: boolean;
+}
+
+/** The report viewer as a React component: render it anywhere in a host app.
+ *  Polls `src`, live-updates until the run's summary, and stops polling on
+ *  unmount. Styles are injected into document.head on first mount. */
+export function TestReportViewer({
+  src, fetch: fetchImpl, pollMs = DEFAULT_POLL_MS, renderNodeActions, renderHeaderActions, syncUrl = false,
+}: TestReportViewerProps) {
+  useEffect(() => { injectStyles(); initTooltips(); }, []);
+  const {
+    snapshot, streaming, pending, loadError, retry,
+  } = useReportStream(src, fetchImpl, pollMs);
+  return (
+    <TreeView
+      snapshot={snapshot}
+      streaming={streaming}
+      pending={pending}
+      loadError={loadError}
+      onRetry={retry}
+      renderNodeActions={renderNodeActions}
+      renderHeaderActions={renderHeaderActions}
+      syncUrl={syncUrl}
+    />
+  );
+}
+
 export async function startViewer(options: ViewerOptions = {}): Promise<void> {
   injectStyles();
   initTooltips();
   const mount = document.getElementById('root');
   if (!mount) return;
   const root = createRoot(mount);
-
-  let store: TreeStore = createTreeStore();
-  let streaming = true;
-  let pending = true;
-  let loadError = false;
-  const retry = () => window.location.reload();
-  const draw = () => root.render(
-    <TreeView
-      snapshot={store.getSnapshot()}
-      streaming={streaming}
-      pending={pending}
-      loadError={loadError}
-      onRetry={retry}
-      renderNodeActions={options.renderNodeActions}
-      renderHeaderActions={options.renderHeaderActions}
-    />,
-  );
 
   let source;
   try {
@@ -68,32 +151,27 @@ export async function startViewer(options: ViewerOptions = {}): Promise<void> {
     source = null;
   }
   if (!source) {
-    streaming = false;
-    loadError = true;
-    draw();
+    // No usable source at all (missing/rejected ?src=): a retry must re-run
+    // source resolution, so reload the page rather than re-poll.
+    root.render(
+      <TreeView
+        snapshot={createTreeStore().getSnapshot()}
+        streaming={false}
+        loadError
+        onRetry={() => window.location.reload()}
+      />,
+    );
     return;
   }
 
-  const reader = createNdjsonReader(source.url, source.fetch);
-  draw();
-
-  // Poll until the run reports a final summary, then stop.
-  for (;;) {
-    try {
-      const { events, reset } = await reader.pull();
-      const firstCheck = pending;
-      pending = false;
-      if (reset) store = createTreeStore();
-      for (const event of events) store.apply(event);
-      loadError = false;
-      if (store.getSnapshot().summary) { streaming = false; draw(); break; }
-      if (events.length || reset || firstCheck) draw();
-    } catch (err) {
-      // Never received any data yet: the source is missing/unreachable — surface
-      // the error screen. Once data has arrived, treat failures as transient.
-      if (store.getSnapshot().root.children.length === 0) { pending = false; loadError = true; draw(); }
-      console.error(err);
-    }
-    await delay(source.pollMs);
-  }
+  root.render(
+    <TestReportViewer
+      src={source.url}
+      fetch={source.fetch}
+      pollMs={source.pollMs}
+      renderNodeActions={options.renderNodeActions}
+      renderHeaderActions={options.renderHeaderActions}
+      syncUrl
+    />,
+  );
 }

--- a/packages/web/src/client/urlState.ts
+++ b/packages/web/src/client/urlState.ts
@@ -31,3 +31,65 @@ export function serializeFilterState(state: FilterState, currentSearch: string):
   const out = params.toString();
   return out ? `?${out}` : '';
 }
+
+/** Where the viewer's filter state (search, status chips, Only re-run) lives.
+ *  The viewer reads once on mount, writes on every change, and re-reads when
+ *  the store reports an external change. Store instances must be stable for
+ *  the life of the viewer. */
+export interface FilterStore {
+  read(): FilterState;
+  write(state: FilterState): void;
+  subscribe?(onChange: (state: FilterState) => void): () => void;
+}
+
+function currentSearch(): string {
+  try { return window.location.search; } catch { return ''; }
+}
+
+/** How long typing coalesces into one history entry. */
+const QUERY_DEBOUNCE_MS = 400;
+
+/** The default store: shareable filters in the page URL (`?q`, `?status`,
+ *  `?rerun`). Discrete toggles push a history entry immediately, typing
+ *  debounces into one entry, and Back/Forward restore the previous filters. */
+export function urlFilterState(): FilterStore {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const push = (state: FilterState): void => {
+    const search = currentSearch();
+    const next = serializeFilterState(state, search);
+    // Compare canonical forms so encoding quirks (%20 vs +) never push.
+    if (next === serializeFilterState(parseFilterState(search), search)) return;
+    try {
+      window.history.pushState(null, '', `${window.location.pathname}${next}${window.location.hash}`);
+    } catch { /* history may be unavailable (sandboxed iframe) */ }
+  };
+  return {
+    read: () => parseFilterState(currentSearch()),
+    write(state) {
+      clearTimeout(timer);
+      const current = parseFilterState(currentSearch());
+      const discreteChanged = state.onlyRerun !== current.onlyRerun
+        || state.statuses.size !== current.statuses.size
+        || [...state.statuses].some((s) => !current.statuses.has(s));
+      if (discreteChanged) push(state);
+      else timer = setTimeout(() => push(state), QUERY_DEBOUNCE_MS);
+    },
+    subscribe(onChange) {
+      const onPop = () => onChange(parseFilterState(currentSearch()));
+      window.addEventListener('popstate', onPop);
+      return () => { window.removeEventListener('popstate', onPop); clearTimeout(timer); };
+    },
+  };
+}
+
+/** Filters held in memory only — an embedded viewer that must not touch the
+ *  host page's URL. State survives remounts that reuse the store instance. */
+export function memoryFilterState(initial?: Partial<FilterState>): FilterStore {
+  let state: FilterState = {
+    query: '', statuses: new Set(), onlyRerun: false, ...initial,
+  };
+  return {
+    read: () => state,
+    write(next) { state = next; },
+  };
+}

--- a/packages/web/tests/filterStore.test.ts
+++ b/packages/web/tests/filterStore.test.ts
@@ -63,6 +63,18 @@ test('urlFilterState: a write matching the URL pushes nothing', async () => {
   resetUrl();
 });
 
+test('urlFilterState: tolerates a window without location/history (sandboxed iframe)', () => {
+  const real = (globalThis as any).window;
+  (globalThis as any).window = new Proxy({}, { get() { throw new Error('denied'); } });
+  try {
+    const store = urlFilterState();
+    assert.deepStrictEqual(store.read(), state(), 'read falls back to defaults');
+    store.write(state({ onlyRerun: true })); // a discrete change pushes — must not throw
+  } finally {
+    (globalThis as any).window = real;
+  }
+});
+
 test('urlFilterState: subscribe reports Back/Forward, unsubscribe stops it', async () => {
   const store = urlFilterState();
   const seen: FilterState[] = [];

--- a/packages/web/tests/filterStore.test.ts
+++ b/packages/web/tests/filterStore.test.ts
@@ -1,0 +1,82 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import { memoryFilterState, urlFilterState, type FilterState } from '../src/client/urlState.ts';
+
+const dom = new JSDOM('', { url: 'http://localhost/?src=/run.ndjson' });
+(globalThis as any).window = dom.window;
+
+const state = (patch?: Partial<FilterState>): FilterState => ({
+  query: '', statuses: new Set(), onlyRerun: false, ...patch,
+});
+const wait = (ms: number) => new Promise((r) => { setTimeout(r, ms); });
+const resetUrl = () => dom.window.history.replaceState(null, '', '/?src=/run.ndjson');
+
+test('memoryFilterState: starts at defaults, remembers writes across reads', () => {
+  const store = memoryFilterState();
+  assert.deepStrictEqual(store.read(), state());
+  store.write(state({ query: 'adds', onlyRerun: true }));
+  assert.deepStrictEqual(store.read(), state({ query: 'adds', onlyRerun: true }));
+});
+
+test('memoryFilterState: seeds from the initial partial', () => {
+  const store = memoryFilterState({ statuses: new Set(['failed']) });
+  assert.deepStrictEqual([...store.read().statuses], ['failed']);
+  assert.strictEqual(store.read().query, '');
+});
+
+test('urlFilterState: read parses the current search', () => {
+  dom.window.history.replaceState(null, '', '/?src=/run.ndjson&q=x&status=failed&rerun=1');
+  const store = urlFilterState();
+  assert.deepStrictEqual(store.read(), state({ query: 'x', statuses: new Set(['failed']), onlyRerun: true }));
+  resetUrl();
+});
+
+test('urlFilterState: discrete changes push immediately, preserving other params', () => {
+  const store = urlFilterState();
+  store.write(state({ statuses: new Set(['failed']) }));
+  assert.strictEqual(dom.window.location.search, '?src=%2Frun.ndjson&status=failed');
+  resetUrl();
+});
+
+test('urlFilterState: query changes debounce into one history entry', async () => {
+  const store = urlFilterState();
+  const entries = dom.window.history.length;
+  store.write(state({ query: 'a' }));
+  store.write(state({ query: 'ad' }));
+  store.write(state({ query: 'adds' }));
+  assert.strictEqual(new URLSearchParams(dom.window.location.search).get('q'), null, 'nothing pushed synchronously');
+  await wait(450);
+  assert.strictEqual(new URLSearchParams(dom.window.location.search).get('q'), 'adds');
+  assert.strictEqual(new URLSearchParams(dom.window.location.search).get('src'), '/run.ndjson', 'unrelated params preserved');
+  assert.strictEqual(dom.window.history.length, entries + 1, 'keystrokes coalesce into one entry');
+  resetUrl();
+});
+
+test('urlFilterState: a write matching the URL pushes nothing', async () => {
+  dom.window.history.replaceState(null, '', '/?src=/run.ndjson&q=adds');
+  const store = urlFilterState();
+  const entries = dom.window.history.length;
+  store.write(state({ query: 'adds' }));
+  await wait(450);
+  assert.strictEqual(dom.window.history.length, entries);
+  resetUrl();
+});
+
+test('urlFilterState: subscribe reports Back/Forward, unsubscribe stops it', async () => {
+  const store = urlFilterState();
+  const seen: FilterState[] = [];
+  const unsubscribe = store.subscribe!((s) => seen.push(s));
+  store.write(state({ statuses: new Set(['failed']) }));
+  dom.window.history.back();
+  await wait(50); // jsdom dispatches popstate asynchronously
+  assert.strictEqual(seen.length, 1);
+  assert.deepStrictEqual([...seen[0].statuses], []);
+  unsubscribe();
+  dom.window.history.forward();
+  await wait(50);
+  assert.strictEqual(seen.length, 1, 'no callbacks after unsubscribe');
+  dom.window.history.back();
+  await wait(50);
+  resetUrl();
+});

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -1,0 +1,113 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost/' });
+(globalThis as any).window = dom.window;
+(globalThis as any).document = dom.window.document;
+Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The built bundle, not the source: node:test can't load .tsx, and the dist
+// artifact (React external) is what embedders actually run. Imported after
+// the DOM globals exist.
+const { TestReportViewer } = await import('../dist/start.js' as string) as {
+  TestReportViewer: React.FunctionComponent<Record<string, unknown>>;
+};
+
+const LOG = [
+  '{"type":"test:dequeue","data":{"name":"adds","nesting":0,"file":"math.test.js"}}',
+  '{"type":"test:pass","data":{"name":"adds","nesting":0,"file":"math.test.js","details":{"duration_ms":1},"testNumber":1}}',
+].join('\n');
+const SUMMARY = '{"type":"test:summary","data":{"counts":{"tests":1,"failed":0,"passed":1,"cancelled":0,"skipped":0,"todo":0,"topLevel":1,"suites":0},"duration_ms":2,"success":true}}';
+
+/** In-memory Range-honoring fetch over a mutable NDJSON buffer. */
+function fakeSource(initial: string) {
+  const state = { body: initial, calls: 0 };
+  const fetchImpl = async (_url: string, init?: { headers?: Record<string, string> }) => {
+    state.calls += 1;
+    const start = Number(/^bytes=(\d+)-/.exec(init?.headers?.Range ?? '')?.[1] ?? 0);
+    if (start >= Buffer.byteLength(state.body)) return new Response(null, { status: 416 });
+    return new Response(Buffer.from(state.body).subarray(start), { status: start > 0 ? 206 : 200 });
+  };
+  return { state, fetchImpl };
+}
+
+function mount(): { root: Root; el: HTMLElement } {
+  const el = dom.window.document.createElement('div');
+  dom.window.document.body.appendChild(el);
+  return { root: createRoot(el), el };
+}
+
+const tick = (ms: number) => act(async () => { await new Promise((r) => { setTimeout(r, ms); }); });
+
+test('renders rows from the stream and stops polling at the summary', async () => {
+  const { state, fetchImpl } = fakeSource(`${LOG}\n`);
+  const { root, el } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10 }));
+  });
+  await tick(20);
+  assert.ok(el.textContent!.includes('adds'), 'test row should render');
+  assert.ok(el.textContent!.includes('Running'), 'run should still stream without a summary');
+
+  state.body += `${SUMMARY}\n`;
+  await tick(30);
+  assert.ok(el.textContent!.includes('Passing'), 'summary should settle the run');
+  const settled = state.calls;
+  await tick(50);
+  assert.strictEqual(state.calls, settled, 'polling must stop after the summary');
+  await act(async () => root.unmount());
+});
+
+test('unmount stops polling a live stream', async () => {
+  const { state, fetchImpl } = fakeSource(`${LOG}\n`);
+  const { root } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10 }));
+  });
+  await tick(30);
+  assert.ok(state.calls > 0);
+  await act(async () => root.unmount());
+  const atUnmount = state.calls;
+  await new Promise((r) => { setTimeout(r, 60); });
+  assert.strictEqual(state.calls, atUnmount, 'no fetches after unmount');
+});
+
+test('renderNodeActions and renderHeaderActions render in the embedded component', async () => {
+  const { fetchImpl } = fakeSource(`${LOG}\n${SUMMARY}\n`);
+  const { root, el } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, {
+      src: '/run.ndjson',
+      fetch: fetchImpl,
+      pollMs: 10,
+      renderNodeActions: (node) => React.createElement('button', { className: 'x-node' }, `go ${node.name}`),
+      renderHeaderActions: () => React.createElement('button', { className: 'x-header' }, 'all'),
+    }));
+  });
+  await tick(30);
+  assert.ok(el.querySelector('.node-actions .x-node'), 'node action button should render');
+  assert.ok(el.querySelector('.header-actions .x-header'), 'header action button should render');
+  await act(async () => root.unmount());
+});
+
+test('does not touch the page URL by default', async () => {
+  const { fetchImpl } = fakeSource(`${LOG}\n${SUMMARY}\n`);
+  const { root, el } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10 }));
+  });
+  await tick(30);
+  const input = el.querySelector('input')!;
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, 'value')!.set!;
+    setter.call(input, 'adds');
+    input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+  });
+  await tick(450); // past the 400ms URL-sync debounce
+  assert.strictEqual(dom.window.location.search, '', 'embedded viewer must not write query params');
+  await act(async () => root.unmount());
+});

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -1,8 +1,8 @@
 import { test } from 'node:test';
 import assert from 'node:assert';
 import { JSDOM } from 'jsdom';
-import React, { act } from 'react';
-import { createRoot, type Root } from 'react-dom/client';
+import type ReactTypes from 'react';
+import type { Root } from 'react-dom/client';
 
 const dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost/' });
 (globalThis as any).window = dom.window;
@@ -10,11 +10,17 @@ const dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost/' });
 Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
-// The built bundle, not the source: node:test can't load .tsx, and the dist
-// artifact (React external) is what embedders actually run. Imported after
-// the DOM globals exist.
-const { TestReportViewer } = await import('../dist/start.js' as string) as {
-  TestReportViewer: React.FunctionComponent<Record<string, unknown>>;
+// Everything below is imported dynamically, after the DOM globals exist:
+// react-dom snapshots the environment at module evaluation, and with no
+// document its event system goes inert — dispatched events silently reach no
+// handler. The dist bundle (React external) is what embedders actually run;
+// node:test couldn't load the .tsx source anyway.
+const React = (await import('react')).default;
+const { act } = await import('react');
+const { createRoot } = await import('react-dom/client');
+const { TestReportViewer, memoryFilterState } = await import('../dist/start.js' as string) as {
+  TestReportViewer: ReactTypes.FunctionComponent<Record<string, unknown>>;
+  memoryFilterState: (initial?: object) => object;
 };
 
 const LOG = [
@@ -94,20 +100,39 @@ test('renderNodeActions and renderHeaderActions render in the embedded component
   await act(async () => root.unmount());
 });
 
-test('does not touch the page URL by default', async () => {
+async function typeQuery(el: HTMLElement, text: string): Promise<void> {
+  const input = el.querySelector('input')!;
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, 'value')!.set!;
+    setter.call(input, text);
+    input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+  });
+  await tick(450); // past the URL store's 400ms typing debounce
+}
+
+test('the default filter store syncs the page URL', async () => {
   const { fetchImpl } = fakeSource(`${LOG}\n${SUMMARY}\n`);
   const { root, el } = mount();
   await act(async () => {
     root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10 }));
   });
   await tick(30);
-  const input = el.querySelector('input')!;
+  await typeQuery(el, 'adds');
+  assert.strictEqual(dom.window.location.search, '?q=adds');
+  await act(async () => root.unmount());
+  dom.window.history.replaceState(null, '', '/');
+});
+
+test('memoryFilterState keeps the page URL untouched', async () => {
+  const { fetchImpl } = fakeSource(`${LOG}\n${SUMMARY}\n`);
+  const { root, el } = mount();
   await act(async () => {
-    const setter = Object.getOwnPropertyDescriptor(dom.window.HTMLInputElement.prototype, 'value')!.set!;
-    setter.call(input, 'adds');
-    input.dispatchEvent(new dom.window.Event('input', { bubbles: true }));
+    root.render(React.createElement(TestReportViewer, {
+      src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filters: memoryFilterState(),
+    }));
   });
-  await tick(450); // past the 400ms URL-sync debounce
-  assert.strictEqual(dom.window.location.search, '', 'embedded viewer must not write query params');
+  await tick(30);
+  await typeQuery(el, 'adds');
+  assert.strictEqual(dom.window.location.search, '', 'memory store must not write query params');
   await act(async () => root.unmount());
 });

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -123,6 +123,23 @@ test('the default filter store syncs the page URL', async () => {
   dom.window.history.replaceState(null, '', '/');
 });
 
+test('without src renders the load-error screen; retry button only with onRetry', async () => {
+  const { root, el } = mount();
+  await act(async () => { root.render(React.createElement(TestReportViewer, {})); });
+  assert.ok(el.textContent!.includes('Couldn’t load the live log'), 'load-error screen renders');
+  assert.strictEqual(el.querySelector('.state button'), null, 'no retry without a handler');
+
+  let retried = 0;
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { onRetry: () => { retried += 1; } }));
+  });
+  const button = el.querySelector('.state button') as HTMLButtonElement;
+  assert.ok(button, 'retry button renders with a handler');
+  await act(async () => { button.click(); });
+  assert.strictEqual(retried, 1);
+  await act(async () => root.unmount());
+});
+
 test('memoryFilterState keeps the page URL untouched', async () => {
   const { fetchImpl } = fakeSource(`${LOG}\n${SUMMARY}\n`);
   const { root, el } = mount();


### PR DESCRIPTION
## What

The `@reporters/web/viewer` entry now exports the viewer as a React component:

```tsx
import { TestReportViewer, memoryFilterState } from '@reporters/web/viewer';

<TestReportViewer
  src={reportUrl}
  fetch={authenticatedFetch}    // optional, same Range contract as before
  pollMs={250}
  filters={memoryFilterState()} // optional, defaults to shareable URL params
  renderNodeActions={(node) => ...}
  renderHeaderActions={() => ...}
/>
```

- **Placement is the host's** — render it in a tab, modal, or split pane; no `#root` contract.
- **Lifecycle** — the poll loop moves from `startViewer`'s infinite `for(;;)` into a `useReportStream` hook with cancellation; polling stops at the run's summary **and on unmount** (fixing a latent leak: nothing could ever stop the old loop). Retry after a load error restarts the stream instead of reloading the page.
- **Pluggable filter state** — filters (`?q`/`?status`/`?rerun`) bind to a three-method `FilterStore` (`read`/`write`/`subscribe?`). Default is `urlFilterState()` — today's pushState/popstate behavior, typing debounce included. `memoryFilterState()` keeps an embedded viewer off the host SPA's address bar, and a custom store binds filters to a router or state container.
- `startViewer` becomes a thin wrapper: resolve `?src=`/`resolveSource` from the page URL, render `<TestReportViewer>` — standalone/hosted page behavior is unchanged, non-breaking.

## Verification

- 5 jsdom tests against the built `dist/start.js` (the artifact embedders load): rows render from a Range-honoring fake stream, polling stops at the summary and on unmount, both render hooks work, the default store writes `?q=` and `memoryFilterState()` leaves the URL untouched. Test-infra fix along the way: importing react-dom before the jsdom globals leaves its event system inert, so typing never fired and a URL assertion passed vacuously — React is now imported dynamically after the DOM exists.
- Full package suite: 112 passing; lint clean.
- Driven in a real browser (Playwright): component embedded in a host page renders inside host chrome; the standalone page still syncs `?q=` on typing, filters rows, and restores filters + URL on history Back (popstate → store.subscribe), and still shows the missing-`?src=` error screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)