### PR TITLE
feat(tree-core): keep failureType and code on the wire error

### DIFF
--- a/packages/tree-core/src/wire.ts
+++ b/packages/tree-core/src/wire.ts
@@ -18,11 +18,16 @@ function inspectedStack(raw: unknown): string | undefined {
 
 function flattenError(raw: unknown): unknown {
   if (raw == null) return undefined;
-  const err = raw as { message?: string; stack?: string; name?: string; cause?: unknown };
+  const err = raw as {
+    message?: string; stack?: string; name?: string; cause?: unknown;
+    code?: unknown; failureType?: unknown;
+  };
   return {
     message: err.message ?? String(err),
     stack: inspectedStack(raw) ?? err.stack,
     name: err.name,
+    code: typeof err.code === 'string' ? err.code : undefined,
+    failureType: typeof err.failureType === 'string' ? err.failureType : undefined,
     cause: err.cause instanceof Error ? flattenError(err.cause) : err.cause,
   };
 }

--- a/packages/tree-core/tests/helpers.test.ts
+++ b/packages/tree-core/tests/helpers.test.ts
@@ -201,6 +201,40 @@ test('toWireEvent appends cause props to the cause stack but skips the test-runn
   assert.ok(stripAnsi(flat.cause.stack).endsWith(" {\n  jobId: 'abc'\n}"));
 });
 
+test('toWireEvent keeps failureType and code on the wire error, recursively', () => {
+  const cause = Object.assign(new Error('read failed'), { code: 'ENOENT' });
+  const wrapper = Object.assign(new Error('1 subtest failed'), {
+    code: 'ERR_TEST_FAILURE', failureType: 'subtestsFailed', exitCode: 1, cause,
+  });
+  const wire = toWireEvent({ type: 'test:fail', data: { details: { duration_ms: 1, error: wrapper } } });
+  const flat = JSON.parse(JSON.stringify(wire.data.details?.error)) as {
+    code?: string; failureType?: string; cause?: { code?: string; failureType?: string };
+  };
+  assert.strictEqual(flat.failureType, 'subtestsFailed');
+  assert.strictEqual(flat.code, 'ERR_TEST_FAILURE');
+  assert.strictEqual(flat.cause?.code, 'ENOENT');
+  assert.ok(!('failureType' in flat.cause!));
+});
+
+test('non-string code and failureType stay off the wire fields', () => {
+  const error = Object.assign(new Error('boom'), { code: 10n, failureType: 42 });
+  const line = serializeWireLine({ type: 'test:fail', data: { details: { duration_ms: 1, error } } });
+  const [event] = parseWireLines(line);
+  const flat = event.data.details?.error as { code?: unknown; failureType?: unknown; stack: string };
+  assert.ok(!('code' in flat));
+  assert.ok(!('failureType' in flat));
+  assert.ok(stripAnsi(flat.stack).includes('code: 10n'));
+});
+
+test('failureType and code survive re-flattening', () => {
+  const error = Object.assign(new Error('wrapped'), { code: 'ERR_TEST_FAILURE', failureType: 'subtestsFailed' });
+  const once = toWireEvent({ type: 'test:fail', data: { details: { duration_ms: 1, error } } });
+  const twice = toWireEvent(once);
+  const flat = twice.data.details?.error as { code?: string; failureType?: string };
+  assert.strictEqual(flat.code, 'ERR_TEST_FAILURE');
+  assert.strictEqual(flat.failureType, 'subtestsFailed');
+});
+
 test('re-flattening an already-flattened error does not duplicate the props block', () => {
   const error = Object.assign(new Error('boom'), { jobId: 'abc' });
   const once = toWireEvent({ type: 'test:fail', data: { details: { duration_ms: 1, error } } });


### PR DESCRIPTION
## Summary
- `flattenError` whitelisted only `message`/`stack`/`name`/`cause`, so the NDJSON error object dropped the test-runner's `failureType` and `code` — consumers of the stream (unlike in-process reporters) could not check `error.failureType === 'subtestsFailed'` and had to match on message text.
- Copy `code` and `failureType` onto the wire error, recursively through `cause` chains.
- Only string values are copied: non-string props (e.g. a bigint `code`) still land in the inspect-style props block on the stack instead of breaking `JSON.stringify`.
- Fields survive re-flattening an already-flattened error.

## Test plan
- [x] New tests: preservation (wrapper + cause), non-string guard, re-flatten survival — each verified to fail against the unfixed/mutated implementation
- [x] Full monorepo suite: 361 passed, 100% statement coverage
- [x] `yarn lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)