### PR TITLE
fix(tree-core): fall back to the stack first line when a cause message is empty

### DIFF
--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -72,8 +72,11 @@ function serializeError(raw: unknown): SerializedError | undefined {
   if (raw == null) return undefined;
   const err = raw as { message?: string; stack?: string; name?: string; cause?: unknown };
   const cause = (err.cause ?? err) as { message?: string; stack?: string; name?: string };
+  // A cause whose message/name live on prototype getters (e.g. DOMException) loses them
+  // when v8-serialized across the test-runner IPC boundary; the stack string keeps the
+  // real "Name: message" first line, so fall back to it before the generic String().
   return {
-    message: cause?.message ?? String(cause),
+    message: cause?.message || cause?.stack?.split('\n', 1)[0] || String(cause),
     stack: cause?.stack,
     name: cause?.name,
   };

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -67,6 +67,24 @@ test('failed test carries the unwrapped cause error', () => {
   assert.strictEqual(node.error?.message, 'actual failure');
 });
 
+test('empty-message cause falls back to the stack first line', () => {
+  const store = createTreeStore();
+  // A DOMException cause (e.g. AbortSignal.timeout's TimeoutError) crossing the
+  // child-process IPC boundary deserializes as an Error whose message/name getters
+  // were lost (own-property snapshot), while the stack string keeps the real text.
+  const cause = new Error('');
+  cause.stack = 'TimeoutError: The operation was aborted due to timeout\n    at Timeout._onTimeout';
+  const wrapper = new Error('The operation was aborted due to timeout');
+  // @ts-expect-error test cause shape
+  wrapper.cause = cause;
+  apply(store, [
+    { type: 'test:start', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1 } },
+    { type: 'test:fail', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, details: { error: wrapper } } },
+  ]);
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(node.error?.message, 'TimeoutError: The operation was aborted due to timeout');
+});
+
 test('skip maps to its own status; todo status is reserved for failing todos', () => {
   const store = createTreeStore();
   apply(store, [

--- a/packages/web/tests/reporter.test.ts
+++ b/packages/web/tests/reporter.test.ts
@@ -2,6 +2,7 @@ import { test } from 'node:test';
 import assert from 'node:assert';
 import web from '../src/index.ts';
 import { internals } from '../src/open.ts';
+import { createTreeStore } from '@reporters/tree-core';
 import type { TestEvent } from '@reporters/tree-core';
 
 const events: TestEvent[] = [
@@ -66,6 +67,27 @@ test('web with open:true and a file destination serves + opens AND writes NDJSON
     internals.openInBrowser = origOpen;
     process.execArgv = origArgv;
   }
+});
+
+test('an empty-message cause still yields a real message after the viewer store replay', async () => {
+  // A DOMException cause (AbortSignal.timeout's TimeoutError) crossing the test-runner
+  // process-isolation IPC deserializes with an empty message but an intact stack; the
+  // viewer must surface the stack's first line, not an empty string.
+  const cause = new Error('');
+  cause.stack = 'TimeoutError: The operation was aborted due to timeout\n    at Timeout._onTimeout';
+  const wrapper = new Error('The operation was aborted due to timeout');
+  // @ts-expect-error test cause shape
+  wrapper.cause = cause;
+  const failing: TestEvent[] = [
+    { type: 'test:start', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1 } },
+    { type: 'test:fail', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, details: { duration_ms: 1, error: wrapper } } },
+  ];
+  const out: string[] = [];
+  for await (const chunk of web(failing, { open: false })) out.push(chunk);
+  const store = createTreeStore();
+  for (const line of out) store.apply(JSON.parse(line));
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(node.error?.message, 'TimeoutError: The operation was aborted due to timeout');
 });
 
 test('web declares under-mux defaults so mux drives it as a pure emitter', () => {


### PR DESCRIPTION
A DOMException cause (e.g. AbortSignal.timeout's TimeoutError) loses its message/name prototype getters when v8-serialized across the test-runner process-isolation IPC boundary, deserializing as an Error with an empty own message while the stack string keeps the real "TimeoutError: ..." first line. serializeError stored that empty message, so consumers rendering or forwarding error.message got "".