### PR TITLE
feat!: support test:log for real-time per-test logging

### DIFF
--- a/packages/gh/index.js
+++ b/packages/gh/index.js
@@ -9,6 +9,20 @@ import {
 import { Command } from '@reporters/github/gh_core';
 
 const diagnosticColorMap = { __proto__: null, warn: 'yellow', error: 'red' };
+const LEVELS = new Set(['info', 'warn', 'error']);
+
+function logLevel(data) {
+  const level = data.data?.level;
+  return typeof level === 'string' && LEVELS.has(level) ? level : 'info';
+}
+
+function safeJson(value) {
+  try {
+    return JSON.stringify(value) ?? '';
+  } catch {
+    return String(value);
+  }
+}
 
 const indentMemo = new Map();
 function indent(nesting) {
@@ -157,6 +171,14 @@ class SpecReporter extends Transform {
         }
         const diagnosticColor = diagnosticColorMap[data.level] || 'white';
         return `${res}${indent(data.nesting)}${styleText(diagnosticColor, `${data.message}`, { validateStream: !this.#isGitHubActions })}\n`;
+      }
+      case 'test:log': {
+        // A log always names a real test, so it is never a run-level counts
+        // line the way a top-level diagnostic is. The runner passes the payload
+        // through untouched, so a `level` in it is a reporter-side convention.
+        const logColor = diagnosticColorMap[logLevel(data)] || 'white';
+        const payload = data.data === undefined ? '' : ` ${safeJson(data.data)}`;
+        return `${res}${indent(data.nesting)}${styleText(logColor, `${data.message}${payload}`, { validateStream: !this.#isGitHubActions })}\n`;
       }
       case 'test:summary':
         // We report only the root test summary

--- a/packages/gh/tests/index.test.js
+++ b/packages/gh/tests/index.test.js
@@ -83,8 +83,9 @@ describe('test:log rendering', () => {
   });
 
   test('a payload JSON cannot render falls back instead of throwing', async () => {
-    // gh reads raw node events, not wire-sanitized ones, so a circular payload
-    // reaches it intact: under --test-isolation=none this is what a user gets.
+    // This reporter reads raw node events, not wire-sanitized ones, so a
+    // circular payload reaches it intact — what a user gets under
+    // --test-isolation=none.
     const circular = { name: 'c' };
     circular.self = circular;
     const out = await emit({

--- a/packages/gh/tests/index.test.js
+++ b/packages/gh/tests/index.test.js
@@ -1,4 +1,5 @@
 import { test, describe, beforeEach } from 'node:test';
+import assert from 'node:assert';
 import { spawnSync } from 'node:child_process';
 import { tmpdir } from 'node:os';
 import path, { join } from 'node:path';
@@ -48,5 +49,56 @@ describe('github spec reporter', () => {
     });
 
     await snapshot(child, readFileSync(GITHUB_STEP_SUMMARY).toString('utf-8'));
+  });
+});
+
+/* eslint-disable no-underscore-dangle */
+describe('test:log rendering', () => {
+  // Driven with synthetic events rather than a t.log() fixture: t.log lands in
+  // v26.6.0, and the snapshots are keyed by node major, so a fixture would make
+  // v26.4 and v26.6 disagree over one snapshot.
+  const emit = async (data) => {
+    const reporter = (await import('../index.js')).default;
+    let out = '';
+    reporter._transform({ type: 'test:log', data }, null, (err, chunk) => {
+      if (err) throw err;
+      out = chunk ?? '';
+    });
+    return out;
+  };
+
+  test('a log renders inline at its nesting', async () => {
+    const out = await emit({
+      name: 't', nesting: 2, file: 'x.js', line: 3, column: 1, message: 'fetched user',
+    });
+    assert.match(out, /fetched user/);
+    assert.match(out, /^ {4}/, 'indented two levels');
+  });
+
+  test('a log payload renders after the message', async () => {
+    const out = await emit({
+      name: 't', nesting: 0, file: 'x.js', line: 3, column: 1, message: 'fetched', data: { userId: 42 },
+    });
+    assert.match(out, /fetched \{"userId":42\}/);
+  });
+
+  test('a payload JSON cannot render falls back instead of throwing', async () => {
+    // gh reads raw node events, not wire-sanitized ones, so a circular payload
+    // reaches it intact: under --test-isolation=none this is what a user gets.
+    const circular = { name: 'c' };
+    circular.self = circular;
+    const out = await emit({
+      name: 't', nesting: 0, file: 'x.js', line: 3, column: 1, message: 'circular', data: circular,
+    });
+    assert.match(out, /circular \[object Object\]/);
+  });
+
+  test('a log at line 1 column 1 still renders, unlike a top-level diagnostic', async () => {
+    // A run-level counts line is what isTopLevelDiagnostic() suppresses; a log
+    // always names a real test, so the same rule must not filter it.
+    const out = await emit({
+      name: 't', nesting: 0, file: 'x.js', line: 1, column: 1, message: 'still shown',
+    });
+    assert.match(out, /still shown/);
   });
 });

--- a/packages/github/index.js
+++ b/packages/github/index.js
@@ -96,6 +96,13 @@ export function transformEvent(event) {
         return new Command('notice', toCommandProperties(extractLocation(event.data)), `${event.data.message}`).toString();
       }
       break;
+    case 'test:log':
+      // A log never carries the run-level counts a top-level diagnostic does,
+      // but annotations are rate-limited, so it stays behind the same opt-in.
+      if (process.env.GITHUB_ACTIONS_REPORTER_VERBOSE) {
+        return new Command('notice', toCommandProperties(extractLocation(event.data)), `${event.data.message}`).toString();
+      }
+      break;
     /* c8 ignore start */
     case 'test:interrupted': {
       const { tests } = event.data;

--- a/packages/github/tests/index.test.js
+++ b/packages/github/tests/index.test.js
@@ -78,3 +78,26 @@ describe('github reporter', () => {
     }));
   });
 });
+
+describe('test:log annotations', () => {
+  const LOG = {
+    type: 'test:log',
+    data: {
+      name: 't', nesting: 0, file: 'x.js', line: 3, column: 1, message: 'fetched user',
+    },
+  };
+
+  test('a log becomes a notice only when verbose is enabled', () => {
+    delete process.env.GITHUB_ACTIONS_REPORTER_VERBOSE;
+    assert.strictEqual(transformEvent(LOG), '');
+
+    process.env.GITHUB_ACTIONS_REPORTER_VERBOSE = '1';
+    try {
+      const out = transformEvent(LOG);
+      assert.match(out, /^::notice /);
+      assert.match(out, /fetched user/);
+    } finally {
+      delete process.env.GITHUB_ACTIONS_REPORTER_VERBOSE;
+    }
+  });
+});

--- a/packages/junit/.snapshots/1e467e89966f1dc487140f1b18eaffad/0.snap
+++ b/packages/junit/.snapshots/1e467e89966f1dc487140f1b18eaffad/0.snap
@@ -20,6 +20,7 @@ Error [ERR_TEST_FAILURE]: this is an error
 			</failure>
 		</testcase>
 		<testcase name=\"is a diagnostic\" time=\"*\" classname=\"test\"/>
+		<!-- this is a diagnostic -->
 		<testcase name=\"should fail\" time=\"*\" classname=\"test\" failure=\"The expression evaluated to a falsy value:  assert(false)\">
 			<failure type=\"testCodeFailure\" message=\"The expression evaluated to a falsy value:  assert(false)\">
 [Error [ERR_TEST_FAILURE]: The expression evaluated to a falsy value:
@@ -80,6 +81,15 @@ Error [ERR_TEST_FAILURE]: this is an error
 		</failure>
 	</testcase>
 	<testcase name=\"top level diagnostic\" time=\"*\" classname=\"test\"/>
+	<!-- top level diagnostic -->
+	<!-- tests 9 -->
+	<!-- suites 2 -->
+	<!-- pass 4 -->
+	<!-- fail 2 -->
+	<!-- cancelled 0 -->
+	<!-- skipped 1 -->
+	<!-- todo 2 -->
+	<!-- duration_ms * -->
 </testsuites>
 ",
 }

--- a/packages/junit/.snapshots/1e467e89966f1dc487140f1b18eaffad/1.snap
+++ b/packages/junit/.snapshots/1e467e89966f1dc487140f1b18eaffad/1.snap
@@ -28,6 +28,14 @@ Object {
 		</failure>
 	</testcase>
 	<testcase name=\"should pass\" time=\"*\" classname=\"test\"/>
+	<!-- tests 2 -->
+	<!-- suites 0 -->
+	<!-- pass 1 -->
+	<!-- fail 1 -->
+	<!-- cancelled 0 -->
+	<!-- skipped 0 -->
+	<!-- todo 0 -->
+	<!-- duration_ms * -->
 </testsuites>
 ",
 }

--- a/packages/junit/.snapshots/96a58cb0ea70661fbc431b75977b8d8e/0.snap
+++ b/packages/junit/.snapshots/96a58cb0ea70661fbc431b75977b8d8e/0.snap
@@ -20,6 +20,7 @@ Error [ERR_TEST_FAILURE]: this is an error
 			</failure>
 		</testcase>
 		<testcase name=\"is a diagnostic\" time=\"*\" classname=\"test\"/>
+		<!-- this is a diagnostic -->
 		<testcase name=\"should fail\" time=\"*\" classname=\"test\" failure=\"The expression evaluated to a falsy value:  assert(false)\">
 			<failure type=\"testCodeFailure\" message=\"The expression evaluated to a falsy value:  assert(false)\">
 [Error [ERR_TEST_FAILURE]: The expression evaluated to a falsy value:
@@ -80,6 +81,15 @@ Error [ERR_TEST_FAILURE]: this is an error
 		</failure>
 	</testcase>
 	<testcase name=\"top level diagnostic\" time=\"*\" classname=\"test\"/>
+	<!-- top level diagnostic -->
+	<!-- tests 9 -->
+	<!-- suites 2 -->
+	<!-- pass 4 -->
+	<!-- fail 2 -->
+	<!-- cancelled 0 -->
+	<!-- skipped 1 -->
+	<!-- todo 2 -->
+	<!-- duration_ms * -->
 </testsuites>
 ",
 }

--- a/packages/junit/.snapshots/96a58cb0ea70661fbc431b75977b8d8e/1.snap
+++ b/packages/junit/.snapshots/96a58cb0ea70661fbc431b75977b8d8e/1.snap
@@ -28,6 +28,14 @@ Object {
 		</failure>
 	</testcase>
 	<testcase name=\"should pass\" time=\"*\" classname=\"test\"/>
+	<!-- tests 2 -->
+	<!-- suites 0 -->
+	<!-- pass 1 -->
+	<!-- fail 1 -->
+	<!-- cancelled 0 -->
+	<!-- skipped 0 -->
+	<!-- todo 0 -->
+	<!-- duration_ms * -->
 </testsuites>
 ",
 }

--- a/packages/junit/.snapshots/cfb5c52c79bf4e0fca85f0849af3a80a/0.snap
+++ b/packages/junit/.snapshots/cfb5c52c79bf4e0fca85f0849af3a80a/0.snap
@@ -20,6 +20,7 @@ Error [ERR_TEST_FAILURE]: this is an error
 			</failure>
 		</testcase>
 		<testcase name=\"is a diagnostic\" time=\"*\" classname=\"test\"/>
+		<!-- this is a diagnostic -->
 		<testcase name=\"should fail\" time=\"*\" classname=\"test\" failure=\"The expression evaluated to a falsy value:  assert(false)\">
 			<failure type=\"testCodeFailure\" message=\"The expression evaluated to a falsy value:  assert(false)\">
 [Error [ERR_TEST_FAILURE]: The expression evaluated to a falsy value:
@@ -80,6 +81,15 @@ Error [ERR_TEST_FAILURE]: this is an error
 		</failure>
 	</testcase>
 	<testcase name=\"top level diagnostic\" time=\"*\" classname=\"test\"/>
+	<!-- top level diagnostic -->
+	<!-- tests 9 -->
+	<!-- suites 2 -->
+	<!-- pass 4 -->
+	<!-- fail 2 -->
+	<!-- cancelled 0 -->
+	<!-- skipped 1 -->
+	<!-- todo 2 -->
+	<!-- duration_ms * -->
 </testsuites>
 ",
 }

--- a/packages/junit/.snapshots/cfb5c52c79bf4e0fca85f0849af3a80a/1.snap
+++ b/packages/junit/.snapshots/cfb5c52c79bf4e0fca85f0849af3a80a/1.snap
@@ -28,6 +28,14 @@ Object {
 		</failure>
 	</testcase>
 	<testcase name=\"should pass\" time=\"*\" classname=\"test\"/>
+	<!-- tests 2 -->
+	<!-- suites 0 -->
+	<!-- pass 1 -->
+	<!-- fail 1 -->
+	<!-- cancelled 0 -->
+	<!-- skipped 0 -->
+	<!-- todo 0 -->
+	<!-- duration_ms * -->
 </testsuites>
 ",
 }

--- a/packages/junit/index.js
+++ b/packages/junit/index.js
@@ -11,17 +11,24 @@ function escapeContent(s = '') {
   return s.replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
+function escapeComment(s = '') {
+  return s.replace(/--/g, '&#45;&#45;');
+}
+
 function treeToXML(tree) {
   if (typeof tree === 'string') {
     return `${escapeContent(tree)}\n`;
   }
   const {
-    tag, props, nesting, children,
+    tag, props, nesting, children, comment,
   } = tree;
+  const indent = '\t'.repeat(nesting + 1);
+  if (comment) {
+    return `${indent}<!-- ${escapeComment(comment)} -->\n`;
+  }
   const propsString = Object.entries(props)
     .map(([key, value]) => `${key}="${escapeProperty(String(value))}"`)
     .join(' ');
-  const indent = '\t'.repeat(nesting + 1);
   if (!children?.length) {
     return `${indent}<${tag} ${propsString}/>\n`;
   }
@@ -30,11 +37,11 @@ function treeToXML(tree) {
 }
 
 function isFailure(node) {
-  return node?.children.some((c) => c.tag === 'failure') || node?.props?.failures;
+  return (node?.children && node.children.some((c) => c.tag === 'failure')) || node?.props?.failures;
 }
 
 function isSkipped(node) {
-  return node?.children.some((c) => c.tag === 'skipped') || node?.props?.skipped;
+  return (node?.children && node.children.some((c) => c.tag === 'skipped')) || node?.props?.skipped;
 }
 
 export default async function* junitReporter(source) {
@@ -77,11 +84,12 @@ export default async function* junitReporter(source) {
           currentSuite = currentSuite.parent;
         }
         currentTest.props.time = (event.data.details.duration_ms / 1000).toFixed(6);
-        if (currentTest.children.length > 0) {
+        const nonCommentChildren = currentTest.children.filter((c) => c.comment == null);
+        if (nonCommentChildren.length > 0) {
           currentTest.tag = 'testsuite';
           currentTest.props.disabled = 0;
           currentTest.props.errors = 0;
-          currentTest.props.tests = currentTest.children.length;
+          currentTest.props.tests = nonCommentChildren.length;
           currentTest.props.failures = currentTest.children.filter(isFailure).length;
           currentTest.props.skipped = currentTest.children.filter(isSkipped).length;
           currentTest.props.hostname = HOSTNAME;
@@ -112,7 +120,11 @@ export default async function* junitReporter(source) {
         break;
       }
       case 'test:diagnostic':
+      case 'test:log': {
+        const parent = currentSuite?.children ?? roots;
+        parent.push({ nesting: event.data.nesting, comment: event.data.message });
         break;
+      }
       default:
         break;
     }

--- a/packages/junit/tests/index.test.js
+++ b/packages/junit/tests/index.test.js
@@ -40,3 +40,56 @@ test('single test', async () => {
     await snapshot.snap(snapshot.snap.serialize(lines)),
   );
 });
+
+test('logs and diagnostics both render as XML comments, like the native reporter', async () => {
+  const lines = [];
+  const events = [
+    { type: 'test:start', data: { name: 'suite', nesting: 0 } },
+    { type: 'test:log', data: { name: 'suite', nesting: 1, message: 'a log line' } },
+    { type: 'test:diagnostic', data: { nesting: 1, message: 'a diagnostic' } },
+    { type: 'test:pass', data: { name: 'suite', nesting: 0, details: { duration_ms: 1 } } },
+  ];
+  for await (const line of reporter(events)) {
+    lines.push(line);
+  }
+  const xml = lines.join('');
+  assert.match(xml, /<!-- a log line -->/);
+  assert.match(xml, /<!-- a diagnostic -->/);
+});
+
+test('a comment-only test stays a testcase and is not counted as a suite', async () => {
+  const lines = [];
+  const events = [
+    { type: 'test:start', data: { name: 'leaf', nesting: 0 } },
+    { type: 'test:log', data: { name: 'leaf', nesting: 1, message: 'note' } },
+    { type: 'test:pass', data: { name: 'leaf', nesting: 0, details: { duration_ms: 1 } } },
+  ];
+  for await (const line of reporter(events)) {
+    lines.push(line);
+  }
+  const xml = lines.join('');
+  assert.match(xml, /<testcase /, 'a test whose only children are comments is still a testcase');
+  assert.doesNotMatch(xml, /<testsuite /);
+  assert.match(xml, /<!-- note -->/);
+});
+
+test('a comment escapes the double hyphen that would close it early', async () => {
+  const lines = [];
+  const events = [
+    { type: 'test:start', data: { name: 'leaf', nesting: 0 } },
+    { type: 'test:log', data: { name: 'leaf', nesting: 1, message: 'before -- after' } },
+    { type: 'test:pass', data: { name: 'leaf', nesting: 0, details: { duration_ms: 1 } } },
+  ];
+  for await (const line of reporter(events)) {
+    lines.push(line);
+  }
+  assert.match(lines.join(''), /<!-- before &#45;&#45; after -->/);
+});
+
+test('a log outside any test becomes a root-level comment', async () => {
+  const lines = [];
+  for await (const line of reporter([{ type: 'test:log', data: { nesting: 0, message: 'orphan' } }])) {
+    lines.push(line);
+  }
+  assert.match(lines.join(''), /<!-- orphan -->/);
+});

--- a/packages/live/README.md
+++ b/packages/live/README.md
@@ -34,7 +34,11 @@ node --test-reporter=@reporters/live --test
 
 - **Live** — tests appear as they start and complete in real execution order.
 - **Full tree, always expanded** — you always see every test; only per-test
-  diagnostics (errors, stdout/stderr, `diagnostic()` messages) collapse.
+  detail (errors, stdout/stderr, `diagnostic()` and `log()` messages) collapses.
+- **Live logs** — `t.log()` messages (Node ≥ v26.6.0) appear the moment they are
+  emitted, even under process isolation, where everything else is buffered until
+  the file reports. A `{ level: 'warn' | 'error' }` in the payload colors the
+  line; the payload itself renders after the message.
 - **Interactive review** — when stdin is a TTY it stays open after the run so
   you can browse:
   - `↑`/`↓` (or `k`/`j`) — move between tests that have diagnostics

--- a/packages/live/src/TreeNode.tsx
+++ b/packages/live/src/TreeNode.tsx
@@ -11,7 +11,7 @@ function basename(file: string | undefined): string {
 }
 
 export function nodeHasDiagnostics(node: TestNode): boolean {
-  return Boolean(node.error) || node.diagnostics.length > 0
+  return Boolean(node.error) || node.messages.length > 0
     || node.stdout.length > 0 || node.stderr.length > 0;
 }
 
@@ -33,7 +33,7 @@ function Diagnostics({ node, indent }: { node: TestNode; indent: string }) {
     ));
   };
   if (node.error) push('error', node.error.stack || node.error.message, 'red');
-  if (node.diagnostics.length) push('diagnostics', node.diagnostics.map((d) => d.message).join('\n'));
+  if (node.messages.length) push('diagnostics', node.messages.map((d) => d.message).join('\n'));
   if (node.stdout.length) push('stdout', node.stdout.join('').replace(/\n$/, ''));
   if (node.stderr.length) push('stderr', node.stderr.join('').replace(/\n$/, ''));
   return <Box flexDirection="column">{lines}</Box>;

--- a/packages/live/src/TreeNode.tsx
+++ b/packages/live/src/TreeNode.tsx
@@ -3,6 +3,7 @@ import { Text, Box } from 'ink';
 import {
   formatDuration, INK_COLOR, SPINNER_FRAMES, SYMBOLS, todoLabel, type TestNode,
 } from '@reporters/tree-core';
+import { diagnosticSections } from './sections.ts';
 
 function basename(file: string | undefined): string {
   if (!file) return '<unknown>';
@@ -21,22 +22,17 @@ export function diagnosticsOpen(node: TestNode, overrides: Map<string, boolean>)
 }
 
 function Diagnostics({ node, indent }: { node: TestNode; indent: string }) {
-  const lines: React.ReactNode[] = [];
-  const push = (label: string, text: string, color?: string) => {
-    lines.push(
-      // eslint-disable-next-line react/no-array-index-key
-      <Text key={`${label}-l`} dimColor>{indent}{label}</Text>,
-    );
-    text.split('\n').forEach((line, i) => lines.push(
-      // eslint-disable-next-line react/no-array-index-key
-      <Text key={`${label}-${i}`} color={color}>{indent}{line}</Text>,
-    ));
-  };
-  if (node.error) push('error', node.error.stack || node.error.message, 'red');
-  if (node.messages.length) push('diagnostics', node.messages.map((d) => d.message).join('\n'));
-  if (node.stdout.length) push('stdout', node.stdout.join('').replace(/\n$/, ''));
-  if (node.stderr.length) push('stderr', node.stderr.join('').replace(/\n$/, ''));
-  return <Box flexDirection="column">{lines}</Box>;
+  return (
+    <Box flexDirection="column">
+      {diagnosticSections(node).flatMap((section) => [
+        <Text key={`${section.label}-l`} dimColor>{indent}{section.label}</Text>,
+        ...section.lines.map((line, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <Text key={`${section.label}-${i}`} color={line.color}>{indent}{line.text}</Text>
+        )),
+      ])}
+    </Box>
+  );
 }
 
 interface TreeNodeProps {

--- a/packages/live/src/index.tsx
+++ b/packages/live/src/index.tsx
@@ -19,7 +19,9 @@ import { renderTreeText } from './text.ts';
  *
  * Note: under the default process isolation Node buffers each file's events
  * until that file's turn to report, so files fill in as they complete. For true
- * real-time per-test streaming, run with `--test-isolation=none`.
+ * real-time per-test streaming, run with `--test-isolation=none`. The exception
+ * is `t.log()` (Node >= v26.6.0), whose `test:log` events bypass that buffer and
+ * land on the tree as they happen.
  */
 export default async function* live(source: AsyncIterable<TestEvent>): AsyncGenerator<string> {
   const store = createTreeStore();

--- a/packages/live/src/sections.ts
+++ b/packages/live/src/sections.ts
@@ -1,0 +1,37 @@
+import { formatLogPayload, INK_LEVEL_COLOR, type TestNode } from '@reporters/tree-core';
+
+export interface SectionLine {
+  text: string;
+  color?: string;
+}
+
+export interface Section {
+  label: string;
+  lines: SectionLine[];
+}
+
+function split(text: string, color?: string): SectionLine[] {
+  return text.split('\n').map((line) => ({ text: line, color }));
+}
+
+/**
+ * The expandable body of a row, as flat labelled line groups the renderer maps
+ * straight to `<Text>`. Diagnostics and logs share one `messages` group in
+ * arrival order — which is execution order, since logs arrive live and
+ * diagnostics arrive buffered — each line colored by its own level.
+ */
+export function diagnosticSections(node: TestNode): Section[] {
+  const sections: Section[] = [];
+  const add = (label: string, lines: SectionLine[]): void => {
+    if (lines.length > 0) sections.push({ label, lines });
+  };
+
+  if (node.error) add('error', split(node.error.stack || node.error.message, 'red'));
+  add('messages', node.messages.flatMap((message) => {
+    const payload = formatLogPayload(message.data);
+    return split(payload === '' ? message.message : `${message.message} ${payload}`, INK_LEVEL_COLOR[message.level]);
+  }));
+  if (node.stdout.length > 0) add('stdout', split(node.stdout.join('').replace(/\n$/, '')));
+  if (node.stderr.length > 0) add('stderr', split(node.stderr.join('').replace(/\n$/, '')));
+  return sections;
+}

--- a/packages/live/tests/sections.test.ts
+++ b/packages/live/tests/sections.test.ts
@@ -1,0 +1,110 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import type { TestMessage, TestNode } from '@reporters/tree-core';
+import { diagnosticSections } from '../src/sections.ts';
+
+const COUNTS = {
+  passed: 1, failed: 0, skipped: 0, todo: 0, running: 0, queued: 0, carried: 0, total: 1,
+};
+
+function node(over: Partial<TestNode> = {}): TestNode {
+  return {
+    key: 'k',
+    testId: 1,
+    parentKey: null,
+    file: '/a.test.js',
+    name: 't',
+    nesting: 0,
+    type: 'test',
+    status: 'passed',
+    messages: [],
+    stdout: [],
+    stderr: [],
+    children: [],
+    counts: COUNTS,
+    ...over,
+  };
+}
+
+const log = (message: string, over: Partial<TestMessage> = {}): TestMessage => ({
+  kind: 'log', message, level: 'info', ...over,
+});
+
+const diagnostic = (message: string, level: TestMessage['level'] = 'info'): TestMessage => ({
+  kind: 'diagnostic', message, level,
+});
+
+function labels(target: TestNode): string[] {
+  return diagnosticSections(target).map((section) => section.label);
+}
+
+test('a node with nothing to show has no sections', () => {
+  assert.deepStrictEqual(diagnosticSections(node()), []);
+});
+
+test('logs and diagnostics share one section, in arrival order', () => {
+  const sections = diagnosticSections(node({
+    messages: [log('live one'), diagnostic('buffered'), log('live two')],
+  }));
+  assert.deepStrictEqual(labels(node({ messages: [log('x')] })), ['messages']);
+  assert.strictEqual(sections.length, 1);
+  assert.deepStrictEqual(sections[0].lines.map((l) => l.text), ['live one', 'buffered', 'live two']);
+});
+
+test('a log payload renders as a compact suffix', () => {
+  const sections = diagnosticSections(node({
+    messages: [log('fetched user', { data: { userId: 42 } })],
+  }));
+  assert.deepStrictEqual(sections[0].lines.map((l) => l.text), ['fetched user {"userId":42}']);
+});
+
+test('a payloadless log gets no trailing space', () => {
+  const sections = diagnosticSections(node({ messages: [log('plain')] }));
+  assert.strictEqual(sections[0].lines[0].text, 'plain');
+});
+
+test('each line is colored by its own level', () => {
+  const sections = diagnosticSections(node({
+    messages: [log('i'), log('w', { level: 'warn' }), diagnostic('e', 'error')],
+  }));
+  assert.deepStrictEqual(sections[0].lines.map((l) => l.color), [undefined, 'yellow', 'red']);
+});
+
+test('a multi-line message becomes one line per row, keeping its color', () => {
+  const sections = diagnosticSections(node({
+    messages: [log('first\nsecond', { level: 'warn' })],
+  }));
+  assert.deepStrictEqual(sections[0].lines, [
+    { text: 'first', color: 'yellow' },
+    { text: 'second', color: 'yellow' },
+  ]);
+});
+
+test('error, messages, stdout and stderr appear in that order', () => {
+  const target = node({
+    error: { message: 'boom', stack: 'boom\n  at x' },
+    messages: [log('m')],
+    stdout: ['out\n'],
+    stderr: ['err\n'],
+  });
+  assert.deepStrictEqual(labels(target), ['error', 'messages', 'stdout', 'stderr']);
+});
+
+test('the error section prefers the stack and is red', () => {
+  const sections = diagnosticSections(node({ error: { message: 'boom', stack: 'boom\n  at x' } }));
+  assert.deepStrictEqual(sections[0].lines, [
+    { text: 'boom', color: 'red' },
+    { text: '  at x', color: 'red' },
+  ]);
+});
+
+test('an error without a stack falls back to its message', () => {
+  const sections = diagnosticSections(node({ error: { message: 'no stack' } }));
+  assert.deepStrictEqual(sections[0].lines.map((l) => l.text), ['no stack']);
+});
+
+test('a trailing newline is trimmed from stdout and stderr', () => {
+  const sections = diagnosticSections(node({ stdout: ['a\nb\n'], stderr: ['c\n'] }));
+  assert.deepStrictEqual(sections[0].lines.map((l) => l.text), ['a', 'b']);
+  assert.deepStrictEqual(sections[1].lines.map((l) => l.text), ['c']);
+});

--- a/packages/tree-core/README.md
+++ b/packages/tree-core/README.md
@@ -29,8 +29,8 @@ npm i @reporters/tree-core
 
 - **`createTreeStore()`** — feed it `node:test` events, get a subscribable tree
   of suites and tests with statuses (queued → running → passed/failed/skipped),
-  durations, counts, and per-test diagnostics (errors, stdout/stderr,
-  `diagnostic()` messages).
+  durations, counts, and per-test detail (errors, stdout/stderr, and a
+  `messages` stream carrying both `diagnostic()` and `log()` output).
 - **Wire format** — `toWireEvent` / `serializeWireLine` / `parseWireLines`
   convert runner events to and from the JSON-safe NDJSON lines that
   `@reporters/web` streams, so a run can be replayed anywhere.

--- a/packages/tree-core/src/format.ts
+++ b/packages/tree-core/src/format.ts
@@ -1,3 +1,14 @@
+/** A log's structured payload as a compact one-line string, empty when absent.
+ *  Wire-sanitized payloads always stringify; a store fed raw events might not. */
+export function formatLogPayload(data: unknown): string {
+  if (data === undefined) return '';
+  try {
+    return JSON.stringify(data) ?? '';
+  } catch {
+    return String(data);
+  }
+}
+
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
 const HOUR = 60 * MINUTE;

--- a/packages/tree-core/src/index.ts
+++ b/packages/tree-core/src/index.ts
@@ -8,7 +8,7 @@ export type {
   TestStatus,
   NodeType,
   DiagnosticLevel,
-  Diagnostic,
+  TestMessage,
   SerializedError,
   Counts,
   TestNode,

--- a/packages/tree-core/src/index.ts
+++ b/packages/tree-core/src/index.ts
@@ -1,6 +1,6 @@
 export { createTreeStore } from './store.ts';
 export { toWireEvent, serializeWireLine, parseWireLines } from './wire.ts';
-export { formatDuration } from './format.ts';
+export { formatDuration, formatLogPayload } from './format.ts';
 export { defaultExpanded, isPassingTodo, todoLabel } from './expand.ts';
 export { isCarried, carriedAttempt } from './carried.ts';
 export * from './theme.ts';

--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -30,7 +30,7 @@ interface InternalNode {
   durationMs?: number;
   startedAt?: number;
   error?: SerializedError;
-  diagnostics: TestNode['diagnostics'];
+  messages: TestNode['messages'];
   stdout: string[];
   stderr: string[];
   line?: number;
@@ -159,7 +159,7 @@ export function createTreeStore(): TreeStore {
       nesting: type === 'root' || type === 'file' ? -1 : 0,
       type,
       status: type === 'root' || type === 'file' ? 'running' : 'queued',
-      diagnostics: [],
+      messages: [],
       stdout: [],
       stderr: [],
       childKeys: [],
@@ -634,7 +634,7 @@ export function createTreeStore(): TreeStore {
         const targetKey = lastStartedByGroupNesting.get(gk)?.get(data.nesting ?? 0);
         const target = (declKey && nodes.get(declKey))
           || (targetKey && nodes.get(targetKey)) || nodes.get(gk);
-        if (target) target.diagnostics.push({ message: data.message, level: data.level ?? 'info' });
+        if (target) target.messages.push({ kind: 'diagnostic', message: data.message, level: data.level ?? 'info' });
         break;
       }
       case 'test:stdout':
@@ -694,12 +694,12 @@ export function createTreeStore(): TreeStore {
   // re-linked away: it never got an event of its own, so it has no name.
   function isEmptyFileNode(node: TestNode): boolean {
     return node.type === 'file' && node.children.length === 0
-      && node.stdout.length === 0 && node.stderr.length === 0 && node.diagnostics.length === 0;
+      && node.stdout.length === 0 && node.stderr.length === 0 && node.messages.length === 0;
   }
 
   function isEmptyPlaceholder(node: TestNode): boolean {
     return node.type === 'test' && node.name === '' && node.children.length === 0
-      && node.diagnostics.length === 0;
+      && node.messages.length === 0;
   }
 
   function build(key: string): TestNode {
@@ -754,7 +754,7 @@ export function createTreeStore(): TreeStore {
       durationMs: internal.durationMs,
       startedAt: internal.startedAt,
       error,
-      diagnostics: internal.diagnostics,
+      messages: internal.messages,
       stdout: internal.stdout,
       stderr: internal.stderr,
       children,

--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -1,10 +1,12 @@
 import type {
   Counts,
+  DiagnosticLevel,
   NodeType,
   SerializedError,
   SummaryData,
   TestEvent,
   TestEventData,
+  TestMessage,
   TestNode,
   TestStatus,
   TreeSnapshot,
@@ -66,6 +68,15 @@ function statusFromComplete(data: TestEventData): TestStatus {
   if (data.skip != null && data.skip !== false) return 'skipped';
   if (data.todo != null && data.todo !== false) return data.details?.passed ? 'passed' : 'todo';
   return data.details?.passed ? 'passed' : 'failed';
+}
+
+const LEVELS: ReadonlySet<string> = new Set(['info', 'warn', 'error']);
+
+// `test:log` carries no level of its own — the runner passes the payload through
+// untouched — so a level is a reporter-side convention read out of it.
+function logLevel(data: TestEventData): DiagnosticLevel {
+  const level = (data.data as { level?: unknown } | null | undefined)?.level;
+  return typeof level === 'string' && LEVELS.has(level) ? level as DiagnosticLevel : 'info';
 }
 
 function serializeError(raw: unknown): SerializedError | undefined {
@@ -623,6 +634,22 @@ export function createTreeStore(): TreeStore {
         } else {
           stackFinalize(status, data);
         }
+        break;
+      }
+      case 'test:log': {
+        // Unlike a diagnostic, a log names its own test (testId/parentId), so it
+        // routes exactly. It is also execution-ordered and bypasses the per-file
+        // declaration buffer, so it can be the first sight of a test — the eager
+        // upsert below creates the node when that happens.
+        if (data.message == null) break;
+        const message: TestMessage = { kind: 'log', message: data.message, level: logLevel(data) };
+        if (data.data !== undefined) message.data = data.data;
+        if (currentT != null) message.t = currentT;
+        if (data.testId == null) {
+          ensureGroupNode(groupKey(data), data.file).messages.push(message);
+          break;
+        }
+        upsertFromTestEvent(data, (node) => { node.messages.push(message); });
         break;
       }
       case 'test:diagnostic': {

--- a/packages/tree-core/src/theme.ts
+++ b/packages/tree-core/src/theme.ts
@@ -1,4 +1,4 @@
-import type { TestStatus } from './types.ts';
+import type { DiagnosticLevel, TestStatus } from './types.ts';
 
 export const SYMBOLS: Record<TestStatus, string> = {
   passed: '✔',
@@ -19,6 +19,13 @@ export const INK_COLOR: Record<TestStatus, string> = {
   todo: 'cyan',
   running: 'blue',
   queued: 'gray',
+};
+
+/** Ink color names per message level; `info` keeps the surrounding default. */
+export const INK_LEVEL_COLOR: Record<DiagnosticLevel, string | undefined> = {
+  info: undefined,
+  warn: 'yellow',
+  error: 'red',
 };
 
 /** CSS color tokens per status, for the web renderers. */

--- a/packages/tree-core/src/types.ts
+++ b/packages/tree-core/src/types.ts
@@ -10,9 +10,17 @@ export type NodeType = 'root' | 'file' | 'suite' | 'test';
 
 export type DiagnosticLevel = 'info' | 'warn' | 'error';
 
-export interface Diagnostic {
+/** A message a test reported about itself. `diagnostic` comes from
+ *  `t.diagnostic()`, buffered by the runner into declaration order; `log` comes
+ *  from `t.log()` and arrives immediately, in execution order. */
+export interface TestMessage {
+  kind: 'diagnostic' | 'log';
   message: string;
   level: DiagnosticLevel;
+  /** Logs only: the opaque payload from `t.log(message, data)`, JSON-sanitized. */
+  data?: unknown;
+  /** Logs only: writer wall-clock when the log was emitted. */
+  t?: number;
 }
 
 export interface SerializedError {
@@ -46,7 +54,7 @@ export interface TestNode {
    *  stamps against each other, never against their own clock. */
   startedAt?: number;
   error?: SerializedError;
-  diagnostics: Diagnostic[];
+  messages: TestMessage[];
   stdout: string[];
   stderr: string[];
   children: TestNode[];
@@ -96,6 +104,8 @@ export interface TestEventData {
   skip?: boolean | string;
   message?: string;
   level?: DiagnosticLevel;
+  /** `test:log` only: the opaque payload from `t.log(message, data)`. */
+  data?: unknown;
   count?: number;
   type?: 'suite' | 'test';
   details?: {

--- a/packages/tree-core/src/wire.ts
+++ b/packages/tree-core/src/wire.ts
@@ -32,6 +32,77 @@ function flattenError(raw: unknown): unknown {
   };
 }
 
+const MAX_DEPTH = 8;
+const MAX_NODES = 1000;
+
+/**
+ * Make a `t.log()` payload safe to JSON-serialize. The payload is arbitrary
+ * user data that reaches us untouched — under `--test-isolation=none` a
+ * circular object arrives with its cycle intact, and an unguarded
+ * `JSON.stringify` would throw and take down the whole run. Cycles are tracked
+ * along the current path only, so a value referenced twice is kept twice rather
+ * than being mistaken for a cycle.
+ */
+function sanitizeLogData(root: unknown): unknown {
+  let budget = MAX_NODES;
+  const path = new Set<object>();
+
+  const walkList = (items: unknown[], depth: number): unknown[] => {
+    const out: unknown[] = [];
+    for (const item of items) {
+      if (budget <= 0) {
+        out.push('[Truncated]');
+        break;
+      }
+      budget -= 1;
+      // Positions carry meaning in a list, so an omitted value becomes null
+      // rather than shifting everything after it.
+      const value = walk(item, depth + 1);
+      out.push(value === undefined ? null : value);
+    }
+    return out;
+  };
+
+  const walkObject = (obj: object, depth: number): Record<string, unknown> => {
+    const out: Record<string, unknown> = {};
+    for (const [key, raw] of Object.entries(obj)) {
+      if (budget <= 0) {
+        out['[Truncated]'] = true;
+        break;
+      }
+      budget -= 1;
+      const value = walk(raw, depth + 1);
+      if (value !== undefined) out[key] = value;
+    }
+    return out;
+  };
+
+  function walk(value: unknown, depth: number): unknown {
+    if (value === null) return null;
+    const type = typeof value;
+    if (type === 'string' || type === 'boolean') return value;
+    // JSON turns NaN/Infinity into null, losing which one it was.
+    if (type === 'number') return Number.isFinite(value) ? value : String(value);
+    if (type === 'bigint') return `${value as bigint}n`;
+    if (type === 'undefined' || type === 'function' || type === 'symbol') return undefined;
+    if (depth >= MAX_DEPTH) return '[Truncated]';
+    const obj = value as object;
+    if (path.has(obj)) return '[Circular]';
+    if (obj instanceof Date) return obj.toISOString();
+    if (obj instanceof Error) return flattenError(obj);
+    path.add(obj);
+    try {
+      if (obj instanceof Map || obj instanceof Set) return walkList([...obj], depth);
+      if (Array.isArray(obj)) return walkList(obj, depth);
+      return walkObject(obj, depth);
+    } finally {
+      path.delete(obj);
+    }
+  }
+
+  return walk(root, 0);
+}
+
 /**
  * Normalize a `node:test` event into a small, JSON-safe object containing only
  * the fields the store consumes. This is the canonical NDJSON wire shape shared
@@ -53,6 +124,7 @@ export function toWireEvent(event: TestEvent): TestEvent {
   if (d.skip != null) data.skip = d.skip;
   if (d.message != null) data.message = d.message;
   if (d.level != null) data.level = d.level;
+  if (d.data !== undefined) data.data = sanitizeLogData(d.data);
   if (d.count != null) data.count = d.count;
   if (d.type != null) data.type = d.type;
   if (d.counts != null) data.counts = d.counts;

--- a/packages/tree-core/tests/carried.test.ts
+++ b/packages/tree-core/tests/carried.test.ts
@@ -16,7 +16,7 @@ const zero = (): Counts => ({
 function leaf(over: Partial<TestNode> = {}): TestNode {
   return {
     key: 'k', testId: undefined, parentKey: null, file: undefined, name: '',
-    nesting: 0, type: 'test', status: 'passed', diagnostics: [], stdout: [], stderr: [],
+    nesting: 0, type: 'test', status: 'passed', messages: [], stdout: [], stderr: [],
     children: [], counts: { ...zero(), passed: 1, total: 1 }, ...over,
   };
 }

--- a/packages/tree-core/tests/corpus.test.ts
+++ b/packages/tree-core/tests/corpus.test.ts
@@ -4,7 +4,7 @@ import { spawnSync } from 'node:child_process';
 import { createTreeStore } from '../src/store.ts';
 import { parseWireLines, serializeWireLine } from '../src/wire.ts';
 import type { TestEvent, TestNode } from '../src/types.ts';
-import { build, captureEvents } from './util.ts';
+import { build, captureEvents, findOne } from './util.ts';
 
 // `--test-isolation` was not available on older Node (e.g. v22), where it errors
 // with "bad option". Feature-detect so we can skip the isolation=none case there.
@@ -153,4 +153,57 @@ test('replaying the captured real stream into a fresh store is deterministic', (
     a.root.children.map((f) => [f.name, f.children.length]),
     b.root.children.map((f) => [f.name, f.children.length]),
   );
+});
+
+// `test:log` landed in Node v26.6.0; v22/v24 emit nothing for `t.log()`.
+const logStream = captureEvents(['fixtures/log-events.mjs']);
+const supportsLog = logStream.some((e) => e.type === 'test:log');
+const skipLog = supportsLog ? false : 'this Node build lacks test:log';
+
+test('real test:log events attach to the test that emitted them', { skip: skipLog }, () => {
+  const { root } = build(logStream);
+
+  assert.deepStrictEqual(
+    findOne(root, 'logging suite').node.messages.map((m) => [m.kind, m.message]),
+    [['log', 'from the suite']],
+  );
+
+  const leaf = findOne(root, 'logging leaf').node;
+  assert.deepStrictEqual(leaf.messages.map((m) => [m.kind, m.message, m.level]), [
+    ['log', 'plain', 'info'],
+    ['log', 'elevated', 'warn'],
+    ['log', 'structured', 'info'],
+  ]);
+  assert.deepStrictEqual(leaf.messages[1].data, { level: 'warn', attempt: 2 });
+  assert.deepStrictEqual(leaf.messages[2].data, { userId: 42 });
+});
+
+test('a log from a helper-defined subtest lands on that subtest', { skip: skipLog }, () => {
+  const { node, path } = findOne(build(logStream).root, 'helper-defined subtest');
+  assert.ok(path.includes('logging parent'), `expected it under its parent, got ${JSON.stringify(path)}`);
+  assert.deepStrictEqual(node.messages.map((m) => m.message), ['from a helper file']);
+});
+
+test('a log reaches the tree before its test\'s declaration-ordered start', { skip: skipLog }, () => {
+  // This is the whole point of the event: under process isolation test:start is
+  // buffered until the file's turn to report, while test:log is not. Replay only
+  // up to the first log and the message must already be on the tree.
+  const idx = logStream.findIndex((e) => e.type === 'test:log' && e.data.message === 'plain');
+  assert.ok(idx >= 0, 'expected a test:log for "plain"');
+  const startIdx = logStream.findIndex((e) => e.type === 'test:start' && e.data.name === 'logging leaf');
+  assert.ok(startIdx > idx, `test:log must precede test:start, got ${idx} and ${startIdx}`);
+
+  const store = createTreeStore();
+  for (const event of logStream.slice(0, idx + 1)) store.apply(event);
+  assert.deepStrictEqual(
+    findOne(store.getSnapshot().root, 'logging leaf').node.messages.map((m) => m.message),
+    ['plain'],
+  );
+});
+
+test('logs survive a wire round-trip (web/embedded path)', { skip: skipLog }, () => {
+  const roundTripped = parseWireLines(logStream.map(serializeWireLine).join(''));
+  const leaf = findOne(build(roundTripped).root, 'logging leaf').node;
+  assert.deepStrictEqual(leaf.messages.map((m) => m.message), ['plain', 'elevated', 'structured']);
+  assert.deepStrictEqual(leaf.messages[2].data, { userId: 42 });
 });

--- a/packages/tree-core/tests/fixtures/log-events.mjs
+++ b/packages/tree-core/tests/fixtures/log-events.mjs
@@ -1,0 +1,15 @@
+import { suite, test } from 'node:test';
+import { defineLoggingSubtest } from './log-helper.mjs';
+
+suite('logging suite', (s) => {
+  s.log('from the suite');
+  test('logging leaf', (t) => {
+    t.log('plain');
+    t.log('elevated', { level: 'warn', attempt: 2 });
+    t.log('structured', { userId: 42 });
+  });
+});
+
+test('logging parent', async (t) => {
+  await defineLoggingSubtest(t);
+});

--- a/packages/tree-core/tests/fixtures/log-helper.mjs
+++ b/packages/tree-core/tests/fixtures/log-helper.mjs
@@ -1,0 +1,5 @@
+export function defineLoggingSubtest(t) {
+  return t.test('helper-defined subtest', (sub) => {
+    sub.log('from a helper file');
+  });
+}

--- a/packages/tree-core/tests/helpers.test.ts
+++ b/packages/tree-core/tests/helpers.test.ts
@@ -4,7 +4,7 @@ import { inspect } from 'node:util';
 
 // eslint-disable-next-line no-control-regex
 const stripAnsi = (text: string) => text.replace(/\[[0-9;]*m/g, '');
-import { formatDuration } from '../src/format.ts';
+import { formatDuration, formatLogPayload } from '../src/format.ts';
 import { toWireEvent, serializeWireLine, parseWireLines } from '../src/wire.ts';
 import { defaultExpanded } from '../src/expand.ts';
 import * as api from '../src/index.ts';
@@ -331,4 +331,20 @@ test('defaultExpanded keeps every container expanded and leaves collapsed', () =
   assert.strictEqual(defaultExpanded(node({ type: 'suite', status: 'failed', children: kids })), true);
   // a childless leaf has nothing to expand
   assert.strictEqual(defaultExpanded(node({ type: 'test', status: 'failed' })), false);
+});
+
+test('formatLogPayload renders a compact payload and nothing for none', () => {
+  assert.strictEqual(formatLogPayload(undefined), '');
+  assert.strictEqual(formatLogPayload({ userId: 42 }), '{"userId":42}');
+  assert.strictEqual(formatLogPayload([1, 2]), '[1,2]');
+  assert.strictEqual(formatLogPayload('plain'), '"plain"');
+  assert.strictEqual(formatLogPayload(null), 'null');
+});
+
+test('formatLogPayload survives a value JSON cannot render', () => {
+  // Wire-sanitized payloads always stringify; a store fed raw events might not.
+  const circular: Record<string, unknown> = {};
+  circular.self = circular;
+  assert.strictEqual(formatLogPayload(circular), '[object Object]');
+  assert.strictEqual(formatLogPayload(() => {}), '');
 });

--- a/packages/tree-core/tests/helpers.test.ts
+++ b/packages/tree-core/tests/helpers.test.ts
@@ -296,7 +296,7 @@ function node(partial: Partial<TestNode>): TestNode {
     nesting: 0,
     type: 'suite',
     status: 'passed',
-    diagnostics: [],
+    messages: [],
     stdout: [],
     stderr: [],
     children: [],

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -122,7 +122,7 @@ test('diagnostics attach to the last started test at that file+nesting', () => {
     { type: 'test:pass', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1 } },
   ]);
   const node = store.getSnapshot().root.children[0].children[0];
-  assert.deepStrictEqual(node.diagnostics, [{ message: 'hello', level: 'info' }]);
+  assert.deepStrictEqual(node.messages, [{ kind: 'diagnostic', message: 'hello', level: 'info' }]);
 });
 
 test('stdout and stderr attach to the file node', () => {

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -443,3 +443,109 @@ test('unstamped events leave startedAt and the stream clock unset', () => {
   assert.strictEqual(snapshot.clock, undefined);
   assert.strictEqual(snapshot.root.children[0].children[0].startedAt, undefined);
 });
+
+// test:log is execution-ordered and bypasses the per-file declaration buffer, so
+// it can be the very first sight of a test. Measured on a real v26.6.0 stream, a
+// suite's `s.log()` precedes that suite's own test:enqueue.
+test('a log arriving before its test is enqueued still attaches to it', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:log', t: 10, data: { name: 'suite a', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, message: 'suite log' } },
+    { type: 'test:enqueue', t: 11, data: { name: 'suite a', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, type: 'suite' } },
+  ]);
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(node.name, 'suite a');
+  assert.deepStrictEqual(node.messages, [{ kind: 'log', message: 'suite log', level: 'info', t: 10 }]);
+});
+
+test('a log resolves under its parent test, not the file', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:dequeue', data: { name: 'parent', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0 } },
+    { type: 'test:log', data: { name: 'child', nesting: 1, file: '/a.test.js', testId: 2, parentId: 1, message: 'from the child' } },
+  ]);
+  const parent = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(parent.name, 'parent');
+  assert.strictEqual(parent.children[0].name, 'child');
+  assert.strictEqual(parent.children[0].messages[0].message, 'from the child');
+});
+
+test('a log never moves a test out of its current status', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:dequeue', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0 } },
+    { type: 'test:log', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, message: 'mid-flight' } },
+  ]);
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(node.status, 'running');
+});
+
+test('a log after a test settled leaves its result alone', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:complete', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, details: { passed: true, duration_ms: 1 } } },
+    { type: 'test:log', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, message: 'late' } },
+  ]);
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(node.status, 'passed');
+  assert.strictEqual(node.messages[0].message, 'late');
+});
+
+// The runner never interprets the payload, so a level is a reporter-side
+// convention read out of it.
+test('a log level comes from the payload when it names a known level', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:log', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, message: 'w', data: { level: 'warn', attempt: 2 } } },
+    { type: 'test:log', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, message: 'e', data: { level: 'error' } } },
+    { type: 'test:log', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, message: 'u', data: { level: 'nope' } } },
+    { type: 'test:log', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, message: 'n', data: { attempt: 2 } } },
+    { type: 'test:log', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, message: 'p', data: 'just a string' } },
+  ]);
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.deepStrictEqual(node.messages.map((m) => [m.message, m.level]), [
+    ['w', 'warn'], ['e', 'error'], ['u', 'info'], ['n', 'info'], ['p', 'info'],
+  ]);
+});
+
+test('the payload is kept on the message', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:log', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, message: 'm', data: { userId: 42 } } },
+  ]);
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.deepStrictEqual(node.messages[0].data, { userId: 42 });
+});
+
+test('logs and diagnostics share one array, in arrival order', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0 } },
+    { type: 'test:log', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0, message: 'live' } },
+    { type: 'test:diagnostic', data: { message: 'buffered', nesting: 0, file: '/a.test.js', level: 'warn' } },
+  ]);
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.deepStrictEqual(node.messages.map((m) => [m.kind, m.message, m.level]), [
+    ['log', 'live', 'info'], ['diagnostic', 'buffered', 'warn'],
+  ]);
+});
+
+test('a log without a testId attaches to its file node', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0 } },
+    { type: 'test:log', data: { nesting: 0, file: '/a.test.js', message: 'orphan' } },
+  ]);
+  const fileNode = store.getSnapshot().root.children[0];
+  assert.deepStrictEqual(fileNode.messages.map((m) => m.message), ['orphan']);
+});
+
+test('a log with no message is ignored', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:dequeue', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0 } },
+    { type: 'test:log', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, parentId: 0 } },
+  ]);
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.deepStrictEqual(node.messages, []);
+});

--- a/packages/tree-core/tests/wire.test.ts
+++ b/packages/tree-core/tests/wire.test.ts
@@ -1,0 +1,89 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { serializeWireLine, toWireEvent } from '../src/wire.ts';
+import type { TestEvent } from '../src/types.ts';
+
+const logEvent = (data: unknown): TestEvent => ({
+  type: 'test:log',
+  data: { message: 'm', data },
+});
+
+function wirePayload(data: unknown): unknown {
+  return (JSON.parse(serializeWireLine(logEvent(data))) as TestEvent).data.data;
+}
+
+// A user's `t.log()` payload reaches reporters raw. Under --test-isolation=none
+// a circular payload arrives with the cycle intact, and an unguarded
+// JSON.stringify throws — taking down the whole run.
+test('a circular log payload serializes instead of throwing', () => {
+  const circ: Record<string, unknown> = { name: 'c' };
+  circ.self = circ;
+  assert.deepStrictEqual(wirePayload(circ), { name: 'c', self: '[Circular]' });
+});
+
+test('a payload repeated without a cycle is not mistaken for one', () => {
+  const shared = { id: 1 };
+  assert.deepStrictEqual(wirePayload({ a: shared, b: shared }), { a: { id: 1 }, b: { id: 1 } });
+});
+
+test('BigInt, Map, Set and Date payloads become JSON-safe', () => {
+  assert.deepStrictEqual(wirePayload({
+    n: 10n,
+    m: new Map<string, unknown>([['a', 1]]),
+    s: new Set([1, 2]),
+    d: new Date(0),
+  }), {
+    n: '10n', m: [['a', 1]], s: [1, 2], d: '1970-01-01T00:00:00.000Z',
+  });
+});
+
+test('an Error payload keeps its message, name and stack', () => {
+  const payload = wirePayload({ e: new Error('boom') }) as { e: Record<string, unknown> };
+  assert.strictEqual(payload.e.message, 'boom');
+  assert.strictEqual(payload.e.name, 'Error');
+  assert.strictEqual(typeof payload.e.stack, 'string');
+});
+
+test('functions and symbols drop out rather than serializing as null', () => {
+  const payload = wirePayload({ keep: 1, f() {}, [Symbol('s')]: 2, sym: Symbol('t') }) as Record<string, unknown>;
+  assert.deepStrictEqual(payload, { keep: 1 });
+});
+
+test('functions and symbols in an array become null, keeping positions', () => {
+  assert.deepStrictEqual(wirePayload([1, () => {}, 3]), [1, null, 3]);
+});
+
+test('runaway depth is capped', () => {
+  let deep: unknown = 'leaf';
+  for (let i = 0; i < 40; i += 1) deep = { deep };
+  const line = serializeWireLine(logEvent(deep));
+  assert.ok(line.length < 400, `expected a capped payload, got ${line.length} chars`);
+  assert.ok(line.includes('[Truncated]'));
+});
+
+test('a runaway node count is capped', () => {
+  const wide = Array.from({ length: 5000 }, (_, i) => i);
+  const payload = wirePayload(wide) as unknown[];
+  assert.ok(payload.length < 5000, `expected truncation, got ${payload.length} entries`);
+});
+
+test('a primitive payload passes through unchanged', () => {
+  assert.strictEqual(wirePayload('hello'), 'hello');
+  assert.strictEqual(wirePayload(42), 42);
+  assert.strictEqual(wirePayload(true), true);
+  assert.strictEqual(wirePayload(null), null);
+});
+
+test('non-finite numbers survive as strings rather than JSON null', () => {
+  assert.deepStrictEqual(wirePayload({ a: NaN, b: Infinity, c: -Infinity }), { a: 'NaN', b: 'Infinity', c: '-Infinity' });
+});
+
+test('an absent payload adds no data field', () => {
+  const wire = toWireEvent({ type: 'test:log', data: { message: 'm' } });
+  assert.ok(!('data' in wire.data), 'no data key for a payloadless log');
+});
+
+test('an explicitly undefined payload adds no data field', () => {
+  const wire = toWireEvent({ type: 'test:log', data: { message: 'm', data: undefined } });
+  assert.ok(!('data' in wire.data), 'no data key for an undefined payload');
+});

--- a/packages/tree-core/tests/wire.test.ts
+++ b/packages/tree-core/tests/wire.test.ts
@@ -87,3 +87,11 @@ test('an explicitly undefined payload adds no data field', () => {
   const wire = toWireEvent({ type: 'test:log', data: { message: 'm', data: undefined } });
   assert.ok(!('data' in wire.data), 'no data key for an undefined payload');
 });
+
+test('a runaway object key count is capped', () => {
+  const wide: Record<string, number> = {};
+  for (let i = 0; i < 5000; i += 1) wide[`k${i}`] = i;
+  const payload = wirePayload(wide) as Record<string, unknown>;
+  assert.strictEqual(payload['[Truncated]'], true);
+  assert.ok(Object.keys(payload).length < 5000, 'expected truncation');
+});

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -2,7 +2,7 @@ import React, {
   useEffect, useMemo, useRef, useState,
 } from 'react';
 import {
-  carriedAttempt, formatDuration, isCarried, todoLabel, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
+  carriedAttempt, formatDuration, formatLogPayload, isCarried, todoLabel, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
 } from '@reporters/tree-core';
 import {
   buildRows, collectContainerKeys, computeMatches, displayName, isContainer, isSectionOpen, liveNodeDuration, reasonOf, realError, type FlatRow, type LiveClock,
@@ -68,7 +68,7 @@ interface DiagBlock {
   stack?: string;
   text?: string;
   lines?: OutLine[];
-  items?: { level: string; sev: TestStatus; text: string }[];
+  items?: { level: string; sev: TestStatus; text: string; payload?: string }[];
 }
 
 /** stdout + stderr merged into one line list, stream-tagged (ANSI kept — the
@@ -176,15 +176,20 @@ function computeDiagBlocks(node: TestNode): DiagBlock[] {
     });
   }
   if (node.messages.length > 0) {
-    const items = node.messages.map((d) => {
-      const level = extractLevel(d.message) ?? d.level;
-      return { level, sev: levelSeverity(level), text: d.message };
+    // Diagnostics and logs share one block in arrival order — which is execution
+    // order, since logs arrive live while diagnostics arrive buffered.
+    const items = node.messages.map((m) => {
+      const level = extractLevel(m.message) ?? m.level;
+      const payload = formatLogPayload(m.data);
+      return {
+        level, sev: levelSeverity(level), text: m.message, ...(payload === '' ? {} : { payload }),
+      };
     });
     const sev: TestStatus = items.some((i) => i.sev === 'failed') ? 'failed'
       : items.some((i) => i.sev === 'running') ? 'running' : 'skipped';
     blocks.push({
-      key: 'diag', title: 'Diagnostics', icon: '◇', sev, kind: 'list', items,
-      copyText: stripAnsi(node.messages.map((d) => d.message).join('\n')),
+      key: 'diag', title: 'Messages', icon: '◇', sev, kind: 'list', items,
+      copyText: stripAnsi(items.map((i) => (i.payload == null ? i.text : `${i.text} ${i.payload}`)).join('\n')),
     });
   }
   const reason = reasonOf(node);
@@ -297,7 +302,10 @@ function BlockContent({ block }: { block: DiagBlock }) {
             // eslint-disable-next-line react/no-array-index-key
             <div className="diag-item" key={i}>
               <span className="diag-level" data-soft={item.sev}>{item.level}</span>
-              <span className="txt"><Ansi text={item.text} /></span>
+              <span className="txt">
+                <Ansi text={item.text} />
+                {item.payload != null ? <span className="diag-payload">{item.payload}</span> : null}
+              </span>
             </div>
           ))}
         </div>

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -175,8 +175,8 @@ function computeDiagBlocks(node: TestNode): DiagBlock[] {
       copyText: stripAnsi(lines.map((l) => l.text).join('\n')),
     });
   }
-  if (node.diagnostics.length > 0) {
-    const items = node.diagnostics.map((d) => {
+  if (node.messages.length > 0) {
+    const items = node.messages.map((d) => {
       const level = extractLevel(d.message) ?? d.level;
       return { level, sev: levelSeverity(level), text: d.message };
     });
@@ -184,7 +184,7 @@ function computeDiagBlocks(node: TestNode): DiagBlock[] {
       : items.some((i) => i.sev === 'running') ? 'running' : 'skipped';
     blocks.push({
       key: 'diag', title: 'Diagnostics', icon: '◇', sev, kind: 'list', items,
-      copyText: stripAnsi(node.diagnostics.map((d) => d.message).join('\n')),
+      copyText: stripAnsi(node.messages.map((d) => d.message).join('\n')),
     });
   }
   const reason = reasonOf(node);

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -144,7 +144,7 @@ export function realError(node: TestNode): { message: string; stack?: string } |
 
 export function hasDiagnostics(node: TestNode): boolean {
   return Boolean(realError(node))
-    || node.diagnostics.length > 0
+    || node.messages.length > 0
     || node.stdout.length > 0
     || node.stderr.length > 0
     || Boolean(reasonOf(node));

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -213,6 +213,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 .out-line, .diag-item { content-visibility: auto; contain-intrinsic-size: auto 19px; }
 .diag-level { font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; flex: none; border-radius: 5px; padding: 1px 6px; }
 .diag-item .txt { font-family: var(--mono); font-size: 12px; white-space: pre-wrap; word-break: break-word; }
+.diag-payload { margin-left: 7px; opacity: .68; word-break: break-all; }
 .diag a { color: var(--st-todo); text-decoration: underline; text-underline-offset: 2px; word-break: break-all; }
 .diag a:hover { filter: brightness(1.15); }
 

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -14,7 +14,7 @@ const zeroCounts = (): Counts => ({
 function node(over: Partial<TestNode> = {}): TestNode {
   return {
     key: 'k', testId: undefined, parentKey: null, file: undefined, name: '',
-    nesting: 0, type: 'test', status: 'passed', diagnostics: [], stdout: [], stderr: [],
+    nesting: 0, type: 'test', status: 'passed', messages: [], stdout: [], stderr: [],
     children: [], counts: zeroCounts(), ...over,
   };
 }

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -8,6 +8,8 @@ const dom = new JSDOM('<div id="root"></div>', { url: 'http://localhost/' });
 (globalThis as any).window = dom.window;
 (globalThis as any).document = dom.window.document;
 Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
+// linkifyDom walks rendered message/log text with a TreeWalker.
+(globalThis as any).NodeFilter = dom.window.NodeFilter;
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
 
 // Everything below is imported dynamically, after the DOM globals exist:
@@ -151,5 +153,70 @@ test('memoryFilterState keeps the page URL untouched', async () => {
   await tick(30);
   await typeQuery(el, 'adds');
   assert.strictEqual(dom.window.location.search, '', 'memory store must not write query params');
+  await act(async () => root.unmount());
+});
+
+// The real v26.6.0 shape: logs stream out eagerly, then the buffered
+// declaration block (start/pass) and finally the diagnostics.
+const MESSAGE_LOG = [
+  '{"type":"test:enqueue","data":{"name":"uploads","nesting":0,"file":"s3.test.js","testId":1,"parentId":0,"type":"test"}}',
+  '{"type":"test:dequeue","data":{"name":"uploads","nesting":0,"file":"s3.test.js","testId":1,"parentId":0,"type":"test"}}',
+  '{"type":"test:log","data":{"name":"uploads","nesting":0,"file":"s3.test.js","testId":1,"parentId":0,"message":"fetched user","data":{"userId":42}}}',
+  '{"type":"test:log","data":{"name":"uploads","nesting":0,"file":"s3.test.js","testId":1,"parentId":0,"message":"retrying endpoint","data":{"level":"warn","attempt":3}}}',
+  '{"type":"test:complete","data":{"name":"uploads","nesting":0,"file":"s3.test.js","testId":1,"parentId":0,"details":{"passed":true,"duration_ms":1}}}',
+  '{"type":"test:start","data":{"name":"uploads","nesting":0,"file":"s3.test.js","testId":1,"parentId":0}}',
+  '{"type":"test:pass","data":{"name":"uploads","nesting":0,"file":"s3.test.js","testId":1,"parentId":0,"details":{"duration_ms":1}}}',
+  '{"type":"test:diagnostic","data":{"nesting":0,"file":"s3.test.js","message":"buffered note","level":"info"}}',
+].join('\n');
+
+/** Mount the log, then open the "uploads" row and its Messages section — a
+ *  passing test collapses both by default. */
+async function openMessages(): Promise<{ root: Root; el: HTMLElement; list: Element }> {
+  const { fetchImpl } = fakeSource(`${MESSAGE_LOG}\n${SUMMARY}\n`);
+  const { root, el } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10 }));
+  });
+  await tick(30);
+
+  const row = [...el.querySelectorAll('[role="treeitem"]')]
+    .find((n) => n.getAttribute('aria-label')!.startsWith('uploads,')) as HTMLElement;
+  assert.ok(row, 'the uploads row should render');
+  await act(async () => { row.click(); });
+
+  const head = [...el.querySelectorAll('.diag-head')]
+    .find((n) => n.textContent!.includes('Messages')) as HTMLElement;
+  assert.ok(head, 'a Messages section should render');
+  await act(async () => { head.click(); });
+
+  const list = el.querySelector('.diag-list');
+  assert.ok(list, 'the Messages list body should mount once opened');
+  return { root, el, list: list! };
+}
+
+test('logs and diagnostics render in one Messages block, in arrival order', async () => {
+  const { root, list } = await openMessages();
+  assert.deepStrictEqual(
+    [...list.querySelectorAll('.diag-item .txt')].map((n) => n.textContent),
+    ['fetched user{"userId":42}', 'retrying endpoint{"level":"warn","attempt":3}', 'buffered note'],
+  );
+  await act(async () => root.unmount());
+});
+
+test('a log payload renders in its own dimmed span', async () => {
+  const { root, list } = await openMessages();
+  assert.deepStrictEqual(
+    [...list.querySelectorAll('.diag-payload')].map((n) => n.textContent),
+    ['{"userId":42}', '{"level":"warn","attempt":3}'],
+  );
+  await act(async () => root.unmount());
+});
+
+test('a warn payload level drives the item severity', async () => {
+  const { root, list } = await openMessages();
+  assert.deepStrictEqual(
+    [...list.querySelectorAll('.diag-item .diag-level')].map((n) => [n.textContent, n.getAttribute('data-soft')]),
+    [['info', 'skipped'], ['warn', 'running'], ['info', 'skipped']],
+  );
   await act(async () => root.unmount());
 });

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -18,6 +18,7 @@ function sanitize(str) {
     .replaceAll(/[0-9.]+(ms| millisecond)s?/g, '*$1')
     .replaceAll(hostname(), 'HOSTNAME')
     .replaceAll(/time="[0-9.]+"/g, 'time="*"')
+    .replaceAll(/duration_ms [0-9.]+/g, 'duration_ms *')
     .replaceAll(/test_runner\/harness:[0-9.]+\n/g, 'test_runner/harness:*\n')
     // eslint-disable-next-line no-control-regex
     .replaceAll(/\u001b\[[0-9;]*m/g, '')


### PR DESCRIPTION
Adopts [`test:log`](https://github.com/nodejs/node/pull/64389) (node v26.6.0) across every reporter.

`test:log` is the live counterpart of `test:diagnostic`: it names its own test via `testId`/`parentId`, so attribution is exact with no heuristics, and it is execution-ordered — it bypasses the per-file declaration buffer, making it the first genuinely real-time per-test channel under process isolation.

## Model

`TestNode.diagnostics` becomes `TestNode.messages`, a single stream carrying both kinds:

```ts
interface TestMessage {
  kind: 'diagnostic' | 'log';
  message: string;
  level: DiagnosticLevel;
  data?: unknown;  // logs: the sanitized opaque payload
  t?: number;      // logs: writer wall-clock
}
```

One array keeps arrival order, which is execution order — logs arrive live, diagnostics arrive buffered. The runner never interprets the payload, so a `{ level: 'info' | 'warn' | 'error' }` in it is honored as a reporter-side convention (upstream's own test hints at this); anything else is `info`.

## Payload sanitizing is required, not defensive

Measured on real streams:

| payload | `--test-isolation=none` | default (process) |
|---|---|---|
| circular object | `JSON.stringify` **throws, killing the run** | test passes, file fails: `Unable to deserialize cloned data.` |
| `{ n: 10n }` | `JSON.stringify` **throws** | fine |
| `{ f() {} }` | fine | test fails with a bare `'test failed'` |

So `toWireEvent` now sanitizes: cycles → `[Circular]`, BigInt → string, `Map`/`Set` → entries/values, `Error` → flattened, `Date` → ISO, functions/symbols dropped, depth and node-count caps. Every reporter and both browser clients funnel through that one chokepoint.

The two process-isolation rows above look like upstream bugs in the new event and are **not** addressed here — circular objects are structured-clone-legal, and a non-cloneable payload should surface as a `DataCloneError`.

## Reporters

| Package | Behavior |
|---|---|
| `live` | Logs and diagnostics render in one `messages` section, per-line level color, payload as a suffix |
| `web` | One `Messages` block, per-item level badge, payload in a dimmed span |
| `gh` | Inline at its nesting, colored by payload level, payload appended. Not filtered by `isTopLevelDiagnostic` — that rule suppresses run-level counts lines, and a log always names a real test |
| `github` | `notice` annotation behind the existing `GITHUB_ACTIONS_REPORTER_VERBOSE` opt-in, since annotations are rate-limited |
| `junit` | **Now matches the native reporter**: diagnostics *and* logs become `<!-- … -->` comments. It previously dropped diagnostics entirely |
| `mocha`, `live/text.ts` | Unchanged — neither renders diagnostics today either |

junit's alignment brings native's `--` escaping, comment children excluded from the suite/case decision and the `tests` count, and native's `children` guards. Snapshots regenerated on v22/v24/v26.

## Compatibility

`test:log` exists only on v26.6.0+, so every new assertion feature-detects and skips on v22/v24, following the existing `isolationFlagSupported` / `liveComplete` patterns. Verified green on all three majors.

## Testing

- tree-core: attribution (including a log arriving **before** its test is enqueued — measured real ordering), level precedence, payload retention, wire round-trip, and sanitizer edge cases
- A real captured v26.6.0 stream asserts logs reach the tree before the buffered `test:start`
- `live`: section building extracted to `sections.ts` so it is unit-testable — node's type stripping cannot import a `.tsx`, which is why `TreeNode` had no tests. Rendering also verified against the real Ink component
- `web`: DOM assertions through the built bundle in JSDOM. The harness gained the `NodeFilter` global — no existing test rendered message text, so `linkifyDom`'s TreeWalker had never run
- Verified end-to-end in the browser viewer (light + dark) and in a real terminal render

The shared snapshot sanitizer now masks `duration_ms <n>`: junit's new run-level counts comments carry a raw timing that would otherwise make every snapshot run differ.

> Note: 8 gh/github snapshot tests fail locally on node 24.16/26.6 from node-internal stack line drift. They fail identically on `main` — pre-existing, handled by the nightly update-snapshots workflow.

## BREAKING CHANGE

`TestNode.diagnostics: Diagnostic[]` → `TestNode.messages: TestMessage[]`. The `Diagnostic` type is removed; `TestMessage.kind === 'diagnostic'` identifies the old contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)