### PR TITLE
feat(tree-core): resolve the test tree exactly using entryFile

### DIFF
--- a/packages/tree-core/src/internal.ts
+++ b/packages/tree-core/src/internal.ts
@@ -1,0 +1,68 @@
+import type {
+  NodeType, SerializedError, TestNode, TestStatus,
+} from './types.ts';
+
+export const ROOT_KEY = '<root>';
+export const REPL = '<repl>';
+export const SEP = '\0';
+
+export const TERMINAL: ReadonlySet<TestStatus> = new Set(['passed', 'failed', 'skipped', 'todo']);
+
+export interface InternalNode {
+  key: string;
+  testId: number | undefined;
+  // Placed by a declaration-ordered test:start — the authoritative position.
+  // Execution-ordered events must never re-link such a node.
+  declPlaced?: boolean;
+  parentKey: string | null;
+  file: string | undefined;
+  entryFile?: string;
+  name: string;
+  nesting: number;
+  type: NodeType;
+  status: TestStatus;
+  durationMs?: number;
+  startedAt?: number;
+  error?: SerializedError;
+  messages: TestNode['messages'];
+  stdout: string[];
+  stderr: string[];
+  line?: number;
+  column?: number;
+  tags?: string[];
+  todo?: boolean | string;
+  skip?: boolean | string;
+  passedOnAttempt?: number;
+  // File groups only: the file-level wrapper has started but not yet
+  // completed — the file is alive even when every test in it has settled
+  // (hooks, teardown, or subtests still to come).
+  wrapperOpen?: boolean;
+  // File groups only: the wrapper closed with its own failure — a hook threw
+  // or the child process died — which node reports only on the wrapper, so it
+  // must survive here or a file whose tests all passed renders green.
+  wrapperFailed?: boolean;
+  wrapperError?: SerializedError;
+  childKeys: string[];
+}
+
+export function makeNode(key: string, type: NodeType): InternalNode {
+  return {
+    key,
+    testId: undefined,
+    parentKey: null,
+    file: undefined,
+    name: '',
+    nesting: type === 'root' || type === 'file' ? -1 : 0,
+    type,
+    status: type === 'root' || type === 'file' ? 'running' : 'queued',
+    messages: [],
+    stdout: [],
+    stderr: [],
+    childKeys: [],
+  };
+}
+
+export function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] || path;
+}

--- a/packages/tree-core/src/resolve.ts
+++ b/packages/tree-core/src/resolve.ts
@@ -1,0 +1,217 @@
+import type { TestEventData } from './types.ts';
+import {
+  basename, REPL, SEP, TERMINAL, type InternalNode,
+} from './internal.ts';
+
+/** The node-graph primitives a resolver needs; all owned by the store. */
+export interface ResolverContext {
+  nodes: Map<string, InternalNode>;
+  /** The absolute spelling of a path the runner reported CLI-relative. */
+  aliasFile(file: string | undefined): string | undefined;
+  /** The file-group node this event belongs to, created if new. */
+  group(data: TestEventData): InternalNode;
+  instancesFor(gk: string, testId: number): InternalNode[];
+  createInstance(gk: string, testId: number, data: TestEventData): InternalNode;
+  /** Most recent node seen at (group, nesting). */
+  lastAtGroupNesting(gk: string, nesting: number): string | undefined;
+  /** Most recent still-open node at a nesting, in any group. */
+  lastOpenAtNesting(nesting: number): string | undefined;
+}
+
+/**
+ * Every decision about which node an event belongs to and where it hangs.
+ *
+ * Two implementations, deliberately kept side by side so they can be read
+ * against each other: the exact one, used once a stream is seen to carry
+ * `entryFile`, and the heuristic one for every stream that does not.
+ */
+export interface Resolver {
+  /** The file a group is named for — the entry file when the stream says so. */
+  groupFile(data: TestEventData): string | undefined;
+  /** The file-group key an event belongs to. */
+  groupKey(data: TestEventData): string;
+  /** A parent-emitted file wrapper: marks isolation, but is not a real test. */
+  isFileLevel(data: TestEventData): boolean;
+  /** Which declaration stack this event's report order belongs to. */
+  declBucket(data: TestEventData): string;
+  /** The instance an execution-ordered event refers to, creating it if new. */
+  instance(data: TestEventData, gk: string): InternalNode;
+  /** Where an execution-ordered event's node hangs. Provisional. */
+  parentKey(data: TestEventData, gk: string): string;
+  /** Where a declaration-ordered start's node hangs. Authoritative. */
+  declParentKey(data: TestEventData, gk: string, enclosing: InternalNode | undefined): string;
+}
+
+const ONE_STACK = `${SEP}decl`;
+
+export function groupKeyFor(file: string | undefined): string {
+  return `${SEP}file${SEP}${file ?? REPL}`;
+}
+
+/**
+ * For streams without `entryFile` — Node < v26.6.0, or any run without process
+ * isolation. Groups by the reported file, which for a test defined in a shared
+ * imported helper is that helper rather than the entry file; so under process
+ * isolation the same helper run from two files merges and their per-process
+ * testIds collide. Everything heuristic lives here.
+ */
+export function createLegacyResolver(ctx: ResolverContext): Resolver {
+  // A subtest defined in a shared helper reports the helper as its `file`, so
+  // its parentId points at a test in ANOTHER group. Candidates are the
+  // still-open (non-terminal) nodes with that testId: under process isolation
+  // testIds collide across files, and only a still-open candidate can be the
+  // real parent — a collided one from a file that already finished cannot. A
+  // real parent always sits one nesting level above its child, so when any
+  // candidate matches that, the ones that don't are ruled out.
+  function findOpenParents(parentId: number, childNesting: number | undefined): InternalNode[] {
+    const open: InternalNode[] = [];
+    for (const node of ctx.nodes.values()) {
+      if (node.testId !== parentId || TERMINAL.has(node.status)) continue;
+      if (node.type !== 'test' && node.type !== 'suite') continue;
+      open.push(node);
+    }
+    if (childNesting != null) {
+      const exact = open.filter((n) => n.nesting === childNesting - 1);
+      if (exact.length > 0) return exact;
+    }
+    return open;
+  }
+
+  return {
+    groupFile(data) {
+      return ctx.aliasFile(data.file);
+    },
+
+    groupKey(data) {
+      return groupKeyFor(this.groupFile(data));
+    },
+
+    // Matched on basename because the wrapper's relative `name` and absolute
+    // `file` only reliably agree on the last segment, and paths can't be
+    // resolved in the browser (the store runs there too).
+    isFileLevel(data) {
+      if (data.nesting !== 0 || data.name == null || data.file == null) return false;
+      return basename(data.name) === basename(data.file);
+    },
+
+    // The declaration-ordered events are one depth-first traversal of the real
+    // tree serialized across the whole run, so a single stack resolves every
+    // parent — including helper-file subtests whose parentId is ambiguous.
+    declBucket() {
+      return ONE_STACK;
+    },
+
+    // Route to the instance the event belongs to: same name (or a still-unnamed
+    // placeholder), preferring one still open. Identically named twins from
+    // colliding processes may share an instance here — their declaration-ordered
+    // starts split them later.
+    instance(data, gk) {
+      const named = ctx.instancesFor(gk, data.testId!)
+        .filter((n) => data.name == null || n.name === '' || n.name === data.name);
+      const open = named.filter((n) => !TERMINAL.has(n.status));
+      const node = open[open.length - 1] ?? named[named.length - 1];
+      return node ?? ctx.createInstance(gk, data.testId!, data);
+    },
+
+    parentKey(data, gk) {
+      const group = ctx.group(data);
+      // parentId is the in-process testId of the enclosing test; 0 is the root.
+      if (data.parentId != null) {
+        if (data.parentId === 0) return group.key;
+        const local = ctx.instancesFor(gk, data.parentId).filter((n) => !TERMINAL.has(n.status)).pop();
+        if (local) return local.key;
+        const candidates = findOpenParents(data.parentId, data.nesting);
+        if (candidates.length === 1) return candidates[0].key;
+        // Several concurrent processes have an open test with this id — the
+        // event doesn't say which one is the parent, so don't guess: park under
+        // the helper group. A later event re-resolves once the collision clears,
+        // and the declaration-ordered block settles it for good.
+        if (candidates.length > 1) return group.key;
+        return ctx.createInstance(gk, data.parentId, data).key;
+      }
+      // Fallback for Node builds that don't emit parentId: use the nesting stack.
+      const nesting = data.nesting ?? 0;
+      if (nesting > 0) {
+        const ancestor = ctx.lastAtGroupNesting(gk, nesting - 1);
+        if (ancestor) return ancestor;
+        const crossGroup = ctx.lastOpenAtNesting(nesting - 1);
+        if (crossGroup) return crossGroup;
+      }
+      return group.key;
+    },
+
+    // A same-group parent that was itself declaration-placed is exact (and
+    // tolerates decl streams that interleave across files); otherwise the
+    // enclosing open declaration node one level up is the parent — that is what
+    // report order means.
+    declParentKey(data, gk, enclosing) {
+      if (data.parentId != null && data.parentId !== 0) {
+        const local = ctx.instancesFor(gk, data.parentId)
+          .filter((n) => n.declPlaced && !TERMINAL.has(n.status)).pop();
+        if (local) return local.key;
+      }
+      if (enclosing && (data.parentId == null || enclosing.testId === data.parentId)) return enclosing.key;
+      return this.parentKey(data, gk);
+    },
+  };
+}
+
+/**
+ * For streams whose events carry `entryFile` (process isolation on Node >=
+ * v26.6.0). `entryFile` names the child process that produced the event, and
+ * testIds are unique within one process, so `(entryFile, testId)` identifies a
+ * test exactly. Nothing here searches, guesses or parks.
+ */
+export function createExactResolver(ctx: ResolverContext): Resolver {
+  return {
+    // Child-forwarded events carry the entry file directly; the parent's own
+    // file-wrapper events report it as `file`.
+    groupFile(data) {
+      return data.entryFile ?? ctx.aliasFile(data.file);
+    },
+
+    // Grouping by the entry file puts a helper-defined test under the file that
+    // ran it, and makes the CLI-relative/absolute mismatch on test:stdout moot.
+    groupKey(data) {
+      return groupKeyFor(this.groupFile(data));
+    },
+
+    // A wrapper is emitted by the parent runner, which never stamps entryFile,
+    // so its absence is what identifies one. That is exact, where the basename
+    // match alone would misread a test named after its own file.
+    isFileLevel(data) {
+      if (data.entryFile != null) return false;
+      if (data.nesting !== 0 || data.name == null || data.file == null) return false;
+      return basename(data.name) === basename(data.file);
+    },
+
+    // Each process reports its own declaration order, so each entry file gets
+    // its own stack and interleaving across files cannot confuse them.
+    declBucket(data) {
+      return this.groupFile(data) ?? REPL;
+    },
+
+    // testIds are unique per process and the group IS the process, so there is
+    // exactly one instance per (group, testId) — no splitting, no name matching.
+    instance(data, gk) {
+      return ctx.instancesFor(gk, data.testId!)[0] ?? ctx.createInstance(gk, data.testId!, data);
+    },
+
+    parentKey(data, gk) {
+      if (data.parentId == null || data.parentId === 0) return ctx.group(data).key;
+      const local = ctx.instancesFor(gk, data.parentId)[0];
+      if (local) return local.key;
+      // The parent's own events have not arrived yet; a placeholder under the
+      // same (entryFile, parentId) is exactly what they will land on.
+      return ctx.createInstance(gk, data.parentId, data).key;
+    },
+
+    // parentId is unambiguous here, so it decides. The enclosing declaration
+    // node only matters for a top-level test in a build that omits parentId.
+    declParentKey(data, gk, enclosing) {
+      if (data.parentId != null && data.parentId !== 0) return this.parentKey(data, gk);
+      if (data.parentId == null && enclosing) return enclosing.key;
+      return ctx.group(data).key;
+    },
+  };
+}

--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -25,6 +25,7 @@ interface InternalNode {
   declPlaced?: boolean;
   parentKey: string | null;
   file: string | undefined;
+  entryFile?: string;
   name: string;
   nesting: number;
   type: NodeType;
@@ -302,6 +303,7 @@ export function createTreeStore(): TreeStore {
   }
 
   function assignFields(node: InternalNode, data: TestEventData): void {
+    if (data.entryFile != null) node.entryFile = data.entryFile;
     if (data.name != null) node.name = data.name;
     if (data.nesting != null) node.nesting = data.nesting;
     if (data.line != null) node.line = data.line;
@@ -774,6 +776,7 @@ export function createTreeStore(): TreeStore {
       testId: internal.testId,
       parentKey: internal.parentKey,
       file: internal.file,
+      entryFile: internal.entryFile,
       name: internal.name,
       nesting: internal.nesting,
       type: internal.type,

--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -1,7 +1,6 @@
 import type {
   Counts,
   DiagnosticLevel,
-  NodeType,
   SerializedError,
   SummaryData,
   TestEvent,
@@ -12,49 +11,12 @@ import type {
   TreeSnapshot,
   TreeStore,
 } from './types.ts';
-
-const ROOT_KEY = '<root>';
-const REPL = '<repl>';
-const SEP = '\0';
-
-interface InternalNode {
-  key: string;
-  testId: number | undefined;
-  // Placed by a declaration-ordered test:start — the authoritative position.
-  // Execution-ordered events must never re-link such a node.
-  declPlaced?: boolean;
-  parentKey: string | null;
-  file: string | undefined;
-  entryFile?: string;
-  name: string;
-  nesting: number;
-  type: NodeType;
-  status: TestStatus;
-  durationMs?: number;
-  startedAt?: number;
-  error?: SerializedError;
-  messages: TestNode['messages'];
-  stdout: string[];
-  stderr: string[];
-  line?: number;
-  column?: number;
-  tags?: string[];
-  todo?: boolean | string;
-  skip?: boolean | string;
-  passedOnAttempt?: number;
-  // File groups only: the file-level wrapper has started but not yet
-  // completed — the file is alive even when every test in it has settled
-  // (hooks, teardown, or subtests still to come).
-  wrapperOpen?: boolean;
-  // File groups only: the wrapper closed with its own failure — a hook threw
-  // or the child process died — which node reports only on the wrapper, so it
-  // must survive here or a file whose tests all passed renders green.
-  wrapperFailed?: boolean;
-  wrapperError?: SerializedError;
-  childKeys: string[];
-}
-
-const TERMINAL: ReadonlySet<TestStatus> = new Set(['passed', 'failed', 'skipped', 'todo']);
+import {
+  makeNode, REPL, ROOT_KEY, SEP, TERMINAL, type InternalNode,
+} from './internal.ts';
+import {
+  createExactResolver, createLegacyResolver, type Resolver, type ResolverContext,
+} from './resolve.ts';
 
 // A todo test that actually passes reports as passed (its `todo` marker is
 // kept on the node); `todo` status is reserved for todos that are failing
@@ -94,24 +56,6 @@ function serializeError(raw: unknown): SerializedError | undefined {
   };
 }
 
-function basename(path: string): string {
-  const parts = path.replace(/\\/g, '/').split('/');
-  return parts[parts.length - 1] || path;
-}
-
-/**
- * A file-level wrapper test is emitted by the parent runner under process
- * isolation: its `name` is the test file path (often CLI-relative, e.g.
- * `../../tests/example.js`) and its `file` is the resolved absolute path. They
- * mark the run as isolated but are not real tests. We match on basename because
- * the relative `name` and absolute `file` only reliably agree on the last
- * segment, and we can't resolve paths in the browser (the store runs there too).
- */
-function isFileLevel(data: TestEventData): boolean {
-  if (data.nesting !== 0 || data.name == null || data.file == null) return false;
-  return basename(data.name) === basename(data.file);
-}
-
 export function createTreeStore(): TreeStore {
   const nodes = new Map<string, InternalNode>();
   const listeners = new Set<() => void>();
@@ -120,12 +64,11 @@ export function createTreeStore(): TreeStore {
   // helper file is exercised by concurrent processes. Each such test is its own
   // instance under the (group, testId) base key.
   const instancesByBase = new Map<string, string[]>();
-  // The declaration-ordered events (test:start/pass/fail) are a depth-first
-  // traversal of the real tree, serialized across the whole run — so a single
-  // stack of the currently-open declaration nodes, keyed by nesting, resolves
-  // every parent exactly, including helper-file subtests whose parentId would
-  // otherwise be ambiguous across processes.
-  const declOpen = new Map<number, string>();
+  // Currently-open declaration nodes by nesting, per declaration stack. The
+  // resolver decides how many stacks there are: one shared stack when the
+  // stream gives no way to tell processes apart, one per entry file when it
+  // does.
+  const declOpenByBucket = new Map<string, Map<number, string>>();
   const lastStartedByGroupNesting = new Map<string, Map<number, string>>();
   const lastByGroupNesting = new Map<string, Map<number, string>>();
   // State for the testId-free path (Node builds that don't emit testId, e.g. v22):
@@ -161,23 +104,6 @@ export function createTreeStore(): TreeStore {
   root.status = 'running';
   nodes.set(ROOT_KEY, root);
 
-  function makeNode(key: string, type: NodeType): InternalNode {
-    return {
-      key,
-      testId: undefined,
-      parentKey: null,
-      file: undefined,
-      name: '',
-      nesting: type === 'root' || type === 'file' ? -1 : 0,
-      type,
-      status: type === 'root' || type === 'file' ? 'running' : 'queued',
-      messages: [],
-      stdout: [],
-      stderr: [],
-      childKeys: [],
-    };
-  }
-
   function link(child: InternalNode, parentKey: string): void {
     if (child.parentKey === parentKey) return;
     if (child.parentKey != null) {
@@ -187,15 +113,6 @@ export function createTreeStore(): TreeStore {
     const parent = nodes.get(parentKey);
     if (parent && !parent.childKeys.includes(child.key)) parent.childKeys.push(child.key);
     child.parentKey = parentKey;
-  }
-
-  // Group by the reported file. For tests defined in their own file this is the
-  // entry file; for tests defined in a shared imported helper it is that helper
-  // (so, under process isolation, the same helper run from two files can merge —
-  // a rare case; see docs/node-issue-entry-file-attribution.md).
-  function groupKey(data: TestEventData): string {
-    const file = data.file != null ? (fileAlias.get(data.file) ?? data.file) : undefined;
-    return `${SEP}file${SEP}${file ?? REPL}`;
   }
 
   function ensureGroupNode(key: string, file: string | undefined): InternalNode {
@@ -214,92 +131,63 @@ export function createTreeStore(): TreeStore {
     return `${gk}${SEP}#${testId}`;
   }
 
-  function instancesOf(gk: string, testId: number): InternalNode[] {
-    return (instancesByBase.get(baseKey(gk, testId)) ?? []).map((key) => nodes.get(key)!);
-  }
-
-  function newInstance(gk: string, testId: number, file: string | undefined): InternalNode {
-    const base = baseKey(gk, testId);
-    const list = instancesByBase.get(base) ?? [];
-    const key = list.length === 0 ? base : `${base}${SEP}~${list.length}`;
-    const node = makeNode(key, 'test');
-    node.testId = testId;
-    node.file = file;
-    nodes.set(key, node);
-    list.push(key);
-    instancesByBase.set(base, list);
-    link(node, ensureGroupNode(gk, file).key);
-    return node;
-  }
-
-  // Route an execution-ordered event to the instance it belongs to: same name
-  // (or a still-unnamed placeholder), preferring one still open. Identically
-  // named twins from colliding processes may share an instance here — their
-  // declaration-ordered starts split them later.
-  function eagerInstance(gk: string, testId: number, data: TestEventData): InternalNode {
-    const named = instancesOf(gk, testId)
-      .filter((n) => data.name == null || n.name === '' || n.name === data.name);
-    const open = named.filter((n) => !TERMINAL.has(n.status));
-    const node = open[open.length - 1] ?? named[named.length - 1];
-    return node ?? newInstance(gk, testId, data.file);
-  }
-
-  // A subtest defined in a shared helper reports the helper as its `file`, so
-  // its parentId points at a test in ANOTHER group. Candidates are the
-  // still-open (non-terminal) nodes with that testId: under process isolation
-  // testIds collide across files, and only a still-open candidate can be the
-  // real parent — a collided one from a file that already finished cannot. A
-  // real parent always sits one nesting level above its child, so when any
-  // candidate matches that, the ones that don't are ruled out.
-  // TODO(nodejs/node#64309): once events carry `entryFile`, (entryFile,
-  // parentId) resolves the parent exactly — no candidate search needed (and
-  // instances can be keyed by (entryFile, testId), retiring instancesByBase
-  // splitting). Requires passing entryFile through toWireEvent in wire.ts.
-  function findOpenParents(parentId: number, childNesting: number | undefined): InternalNode[] {
-    const open: InternalNode[] = [];
-    for (const node of nodes.values()) {
-      if (node.testId !== parentId || TERMINAL.has(node.status)) continue;
-      if (node.type !== 'test' && node.type !== 'suite') continue;
-      open.push(node);
-    }
-    if (childNesting != null) {
-      const exact = open.filter((n) => n.nesting === childNesting - 1);
-      if (exact.length > 0) return exact;
-    }
-    return open;
-  }
-
-  function resolveParentKey(data: TestEventData, gk: string): string {
-    const group = ensureGroupNode(gk, data.file);
-    // parentId is the in-process testId of the enclosing test; 0 is the root.
-    if (data.parentId != null) {
-      if (data.parentId === 0) return group.key;
-      const local = instancesOf(gk, data.parentId).filter((n) => !TERMINAL.has(n.status)).pop();
-      if (local) return local.key;
-      const candidates = findOpenParents(data.parentId, data.nesting);
-      if (candidates.length === 1) return candidates[0].key;
-      // Several concurrent processes have an open test with this id — the
-      // event doesn't say which one is the parent, so don't guess: park under
-      // the helper group. A later event re-resolves once the collision clears,
-      // and the declaration-ordered block settles it for good.
-      if (candidates.length > 1) return group.key;
-      return newInstance(gk, data.parentId, data.file).key;
-    }
-    // Fallback for Node builds that don't emit parentId: use the nesting stack.
-    const nesting = data.nesting ?? 0;
-    if (nesting > 0) {
-      const ancestor = lastByGroupNesting.get(gk)?.get(nesting - 1);
-      if (ancestor) return ancestor;
-      const crossGroup = findOpenAtNesting(nesting - 1);
-      if (crossGroup) return crossGroup;
-    }
-    return group.key;
-  }
-
   function findOpenAtNesting(nesting: number): string | undefined {
     const key = lastByNesting.get(nesting);
     const node = key ? nodes.get(key) : undefined;
     return node && !TERMINAL.has(node.status) ? node.key : undefined;
+  }
+
+  const ctx: ResolverContext = {
+    nodes,
+    aliasFile(file) {
+      return file != null ? (fileAlias.get(file) ?? file) : undefined;
+    },
+    group(data) {
+      return ensureGroupNode(resolver.groupKey(data), resolver.groupFile(data));
+    },
+    instancesFor(gk, testId) {
+      return (instancesByBase.get(baseKey(gk, testId)) ?? []).map((key) => nodes.get(key)!);
+    },
+    createInstance(gk, testId, data) {
+      const base = baseKey(gk, testId);
+      const list = instancesByBase.get(base) ?? [];
+      const key = list.length === 0 ? base : `${base}${SEP}~${list.length}`;
+      const node = makeNode(key, 'test');
+      node.testId = testId;
+      // The definition site, which for a helper-defined test is not the file
+      // its group is named for.
+      node.file = data.file;
+      nodes.set(key, node);
+      list.push(key);
+      instancesByBase.set(base, list);
+      link(node, ctx.group(data).key);
+      return node;
+    },
+    lastAtGroupNesting(gk, nesting) {
+      return lastByGroupNesting.get(gk)?.get(nesting);
+    },
+    lastOpenAtNesting: findOpenAtNesting,
+  };
+
+  const legacyResolver = createLegacyResolver(ctx);
+  const exactResolver = createExactResolver(ctx);
+  // Latched, not per-event: the only events preceding the first `entryFile` are
+  // the parent's own file wrappers, which both resolvers key off `data.file`
+  // identically — so switching mid-stream cannot invalidate what came before.
+  let resolver: Resolver = legacyResolver;
+
+  function selectResolver(data: TestEventData): void {
+    if (data.entryFile != null) resolver = exactResolver;
+  }
+
+  function declOpenOf(data: TestEventData): Map<number, string> {
+    const bucket = resolver.declBucket(data);
+    let open = declOpenByBucket.get(bucket);
+    if (!open) {
+      open = new Map<number, string>();
+      declOpenByBucket.set(bucket, open);
+    }
+    return open;
   }
 
   function assignFields(node: InternalNode, data: TestEventData): void {
@@ -315,13 +203,13 @@ export function createTreeStore(): TreeStore {
   }
 
   function upsertFromTestEvent(data: TestEventData, mutate: (node: InternalNode) => void): void {
-    const gk = groupKey(data);
-    const node = eagerInstance(gk, data.testId!, data);
+    const gk = resolver.groupKey(data);
+    const node = resolver.instance(data, gk);
     // Execution-ordered placement is provisional (parentId is ambiguous across
     // processes); once the declaration-ordered start has placed the node, its
     // position is settled — never re-link it from an eager event.
     if (!node.declPlaced) {
-      const parentKey = resolveParentKey(data, gk);
+      const parentKey = resolver.parentKey(data, gk);
       // A late, buffered event (test:pass after the parent finished) can resolve
       // only as far as the group root; never demote a node that already found
       // its real parent.
@@ -335,23 +223,6 @@ export function createTreeStore(): TreeStore {
     lastByNesting.set(data.nesting ?? 0, node.key);
     assignFields(node, data);
     mutate(node);
-  }
-
-  // Authoritative parent for a declaration-ordered start. A same-group parent
-  // that was itself declaration-placed is exact (and tolerates decl streams
-  // that interleave across files); otherwise the enclosing open declaration
-  // node one nesting level up is the parent — that is what report order means.
-  function resolveDeclParentKey(data: TestEventData, gk: string): string {
-    const nesting = data.nesting ?? 0;
-    if (data.parentId != null && data.parentId !== 0) {
-      const local = instancesOf(gk, data.parentId)
-        .filter((n) => n.declPlaced && !TERMINAL.has(n.status)).pop();
-      if (local) return local.key;
-    }
-    const enclosing = declOpen.get(nesting - 1);
-    const node = enclosing ? nodes.get(enclosing) : undefined;
-    if (node && (data.parentId == null || node.testId === data.parentId)) return node.key;
-    return resolveParentKey(data, gk);
   }
 
   // Declaration starts arrive in declaration order, so a node that decl-starts
@@ -386,17 +257,23 @@ export function createTreeStore(): TreeStore {
   }
 
   function declStart(data: TestEventData): void {
-    const gk = groupKey(data);
+    const gk = resolver.groupKey(data);
     const nesting = data.nesting ?? 0;
-    const parentKey = resolveDeclParentKey(data, gk);
-    const candidates = instancesOf(gk, data.testId!)
+    const declOpen = declOpenOf(data);
+    const enclosingKey = declOpen.get(nesting - 1);
+    const parentKey = resolver.declParentKey(
+      data,
+      gk,
+      enclosingKey ? nodes.get(enclosingKey) : undefined,
+    );
+    const candidates = ctx.instancesFor(gk, data.testId!)
       .filter((n) => n.name === data.name || n.name === '');
     // Same declaration position again is a replay; otherwise claim the eager
     // instance, or split off a new one when a colliding process already did.
     const settled = candidates.find((n) => n.declPlaced && n.parentKey === parentKey);
     const node = settled
       ?? candidates.find((n) => !n.declPlaced)
-      ?? newInstance(gk, data.testId!, data.file);
+      ?? ctx.createInstance(gk, data.testId!, data);
     link(node, parentKey);
     node.declPlaced = true;
     // A replayed start (watch-mode rerun, re-read stream) must not move a
@@ -438,12 +315,13 @@ export function createTreeStore(): TreeStore {
   }
 
   function declFinalize(status: TestStatus, data: TestEventData): void {
-    const gk = groupKey(data);
+    const gk = resolver.groupKey(data);
     const nesting = data.nesting ?? 0;
+    const declOpen = declOpenOf(data);
     const openKey = declOpen.get(nesting);
     const openNode = openKey ? nodes.get(openKey) : undefined;
     const matchesOpen = openNode && openNode.testId === data.testId && openNode.name === data.name;
-    const node = matchesOpen ? openNode : eagerInstance(gk, data.testId!, data);
+    const node = matchesOpen ? openNode : resolver.instance(data, gk);
     backdateStart(node, data);
     noteAttempt(node, data);
     assignFields(node, data);
@@ -463,8 +341,8 @@ export function createTreeStore(): TreeStore {
   // test:start and test:pass/fail are emitted in declaration order, so the
   // k-th start at a nesting pairs with the k-th result at that nesting.
   function stackStart(data: TestEventData): InternalNode {
-    const gk = groupKey(data);
-    const group = ensureGroupNode(gk, data.file);
+    const gk = resolver.groupKey(data);
+    const group = ctx.group(data);
     const nesting = data.nesting ?? 0;
     const open = openByGroupNesting.get(gk) ?? new Map<number, string>();
     openByGroupNesting.set(gk, open);
@@ -497,7 +375,7 @@ export function createTreeStore(): TreeStore {
   }
 
   function stackFinalize(status: TestStatus, data: TestEventData): void {
-    const gk = groupKey(data);
+    const gk = resolver.groupKey(data);
     const nesting = data.nesting ?? 0;
     const key = pendingByGroupNesting.get(gk)?.get(nesting)?.shift();
     let node = key ? nodes.get(key) : undefined;
@@ -522,7 +400,7 @@ export function createTreeStore(): TreeStore {
   }
 
   function recordLastStarted(data: TestEventData, key: string): void {
-    const gk = groupKey(data);
+    const gk = resolver.groupKey(data);
     const map = lastStartedByGroupNesting.get(gk) ?? new Map<number, string>();
     map.set(data.nesting ?? 0, key);
     lastStartedByGroupNesting.set(gk, map);
@@ -535,9 +413,12 @@ export function createTreeStore(): TreeStore {
       firstT = firstT == null ? event.t : Math.min(firstT, event.t);
       lastT = lastT == null ? event.t : Math.max(lastT, event.t);
     }
+    // A stream that stamps entryFile resolves exactly from here on. Latched
+    // before anything reads the resolver, so one event never mixes the two.
+    selectResolver(data);
     // The wrapper's relative `name` is the spelling stdout/stderr events use for
     // `file`; map it to the resolved absolute path so both group together.
-    if (isFileLevel(data) && data.name !== data.file) fileAlias.set(data.name!, data.file!);
+    if (resolver.isFileLevel(data) && data.name !== data.file) fileAlias.set(data.name!, data.file!);
     switch (type) {
       case 'test:enqueue':
       case 'test:dequeue':
@@ -546,7 +427,7 @@ export function createTreeStore(): TreeStore {
         // they start — grouped by file, they don't collide across files. The
         // terminal-status guard in upsert keeps this idempotent and lets the
         // later start/pass/fail settle the final state.
-        if (isFileLevel(data)) {
+        if (resolver.isFileLevel(data)) {
           sawFileWrapper = true;
           // The runner enqueues the file wrappers up front, in the order the
           // files will report. Claim the group slots now so file order doesn't
@@ -554,7 +435,7 @@ export function createTreeStore(): TreeStore {
           // the enqueue is that ordered signal — a dequeue seen without its
           // enqueue (mid-run attach) arrives at wall-clock position, and its
           // group must stay unplaced to settle in decl-stream order instead.
-          const group = ensureGroupNode(groupKey(data), data.file);
+          const group = ctx.group(data);
           if (type === 'test:enqueue') group.declPlaced = true;
           else group.wrapperOpen = true;
           break;
@@ -570,10 +451,10 @@ export function createTreeStore(): TreeStore {
         });
         break;
       case 'test:start':
-        if (isFileLevel(data)) {
+        if (resolver.isFileLevel(data)) {
           sawFileWrapper = true;
-          declOpen.clear();
-          ensureGroupNode(groupKey(data), data.file).wrapperOpen = true;
+          declOpenOf(data).clear();
+          ctx.group(data).wrapperOpen = true;
           break;
         }
         if (data.testId != null) {
@@ -588,9 +469,9 @@ export function createTreeStore(): TreeStore {
         // this is what lets the live tree mark tests done in real time. It
         // carries testId on modern Node; older builds (no testId) fall back to
         // the declaration-ordered pass/fail stack below.
-        if (isFileLevel(data)) {
+        if (resolver.isFileLevel(data)) {
           sawFileWrapper = true;
-          const group = ensureGroupNode(groupKey(data), data.file);
+          const group = ctx.group(data);
           group.wrapperOpen = false;
           // The wrapper measures the file's real wall-clock — the file's
           // concurrent tests sum to much more than the run actually took.
@@ -616,10 +497,10 @@ export function createTreeStore(): TreeStore {
       }
       case 'test:pass':
       case 'test:fail': {
-        if (isFileLevel(data)) {
+        if (resolver.isFileLevel(data)) {
           sawFileWrapper = true;
-          declOpen.clear();
-          const group = ensureGroupNode(groupKey(data), data.file);
+          declOpenOf(data).clear();
+          const group = ctx.group(data);
           group.wrapperOpen = false;
           if (data.details?.duration_ms != null) {
             group.durationMs = group.durationMs ?? data.details.duration_ms;
@@ -648,7 +529,7 @@ export function createTreeStore(): TreeStore {
         if (data.data !== undefined) message.data = data.data;
         if (currentT != null) message.t = currentT;
         if (data.testId == null) {
-          ensureGroupNode(groupKey(data), data.file).messages.push(message);
+          ctx.group(data).messages.push(message);
           break;
         }
         upsertFromTestEvent(data, (node) => { node.messages.push(message); });
@@ -656,10 +537,10 @@ export function createTreeStore(): TreeStore {
       }
       case 'test:diagnostic': {
         if (data.message == null) break;
-        const gk = groupKey(data);
+        const gk = resolver.groupKey(data);
         // Diagnostics are declaration-ordered, so the open declaration node at
         // this nesting is the reporting test; fall back to per-group recency.
-        const declKey = declOpen.get(data.nesting ?? 0);
+        const declKey = declOpenOf(data).get(data.nesting ?? 0);
         const targetKey = lastStartedByGroupNesting.get(gk)?.get(data.nesting ?? 0);
         const target = (declKey && nodes.get(declKey))
           || (targetKey && nodes.get(targetKey)) || nodes.get(gk);
@@ -667,18 +548,18 @@ export function createTreeStore(): TreeStore {
         break;
       }
       case 'test:stdout':
-        if (data.message != null) ensureGroupNode(groupKey(data), data.file).stdout.push(data.message);
+        if (data.message != null) ctx.group(data).stdout.push(data.message);
         break;
       case 'test:stderr':
-        if (data.message != null) ensureGroupNode(groupKey(data), data.file).stderr.push(data.message);
+        if (data.message != null) ctx.group(data).stderr.push(data.message);
         break;
       case 'test:summary':
         // A per-file summary trails its file's declaration block, closing it.
         // It also carries the file's wall-clock, for builds whose wrapper
         // completion lacks duration detail.
         if (data.file !== undefined) {
-          declOpen.clear();
-          const group = ensureGroupNode(groupKey(data), data.file);
+          declOpenOf(data).clear();
+          const group = ctx.group(data);
           group.wrapperOpen = false;
           if (data.duration_ms != null) {
             group.durationMs = group.durationMs ?? data.duration_ms;

--- a/packages/tree-core/src/types.ts
+++ b/packages/tree-core/src/types.ts
@@ -45,6 +45,10 @@ export interface TestNode {
   testId: number | undefined;
   parentKey: string | null;
   file: string | undefined;
+  /** The test file that was the child process's entry point, when the runner
+   *  reported one. Differs from `file` for a test defined in an imported
+   *  helper; absent without process isolation, and on Node < v26.6.0. */
+  entryFile?: string;
   name: string;
   nesting: number;
   type: NodeType;
@@ -95,6 +99,11 @@ export interface TestEventData {
   name?: string;
   nesting?: number;
   file?: string;
+  /** The entry file of the child process that emitted this event. Present on
+   *  every child-forwarded event under process isolation (Node >= v26.6.0);
+   *  absent on the parent's own file-wrapper events, whose `file` IS the
+   *  entry file. */
+  entryFile?: string;
   testId?: number;
   parentId?: number;
   line?: number;

--- a/packages/tree-core/src/wire.ts
+++ b/packages/tree-core/src/wire.ts
@@ -115,6 +115,7 @@ export function toWireEvent(event: TestEvent): TestEvent {
   if (d.name != null) data.name = d.name;
   if (d.nesting != null) data.nesting = d.nesting;
   if (d.file != null) data.file = d.file;
+  if (d.entryFile != null) data.entryFile = d.entryFile;
   if (d.testId != null) data.testId = d.testId;
   if (d.parentId != null) data.parentId = d.parentId;
   if (d.line != null) data.line = d.line;

--- a/packages/tree-core/tests/corpus.test.ts
+++ b/packages/tree-core/tests/corpus.test.ts
@@ -11,6 +11,14 @@ import { build, captureEvents, findOne } from './util.ts';
 const isolationFlagSupported = spawnSync(process.execPath, ['--help'], { encoding: 'utf8' })
   .stdout.includes('--test-isolation');
 
+/** The same stream as a pre-v26.6.0 writer would have produced it. */
+function withoutEntryFile(events: TestEvent[]): TestEvent[] {
+  return events.map((event) => {
+    const { entryFile, ...data } = event.data;
+    return { ...event, data };
+  });
+}
+
 function leaf(node: TestNode, name: string): TestNode | undefined {
   if (node.name === name && node.children.length === 0) return node;
   for (const child of node.children) {
@@ -46,15 +54,46 @@ test('a fast test finalizes before its slower, first-declared sibling (live orde
   assert.strictEqual(status.slow, 'running', 'slow should still be running, not waiting on declaration order');
 });
 
-test('isolation: shared-helper tests from two files group under the definition file', () => {
-  // KNOWN LIMITATION: tests defined in a shared, imported module report the
-  // definition file (not the entry file) and, under process isolation, reset
-  // testId per process. Grouping by file (required for a live tree — see the
-  // model in store.ts) therefore merges the two files' identical tests. The
-  // final, cumulative summary still reports the true totals.
-  // See docs/node-issue-entry-file-attribution.md.
-  const events = captureEvents(['fixtures/entry-a.mjs', 'fixtures/entry-b.mjs']);
-  const { root, summary } = build(events);
+// Two entry files whose tests are both defined in one shared imported helper —
+// the case that used to collapse into a single, wrong file node.
+const sharedHelperStream = captureEvents(['fixtures/entry-a.mjs', 'fixtures/entry-b.mjs']);
+const reportsEntryFile = sharedHelperStream.some((e) => e.data.entryFile != null);
+
+test('isolation: shared-helper tests split by the entry file that ran them', {
+  skip: reportsEntryFile ? false : 'this Node build does not report entryFile',
+}, () => {
+  const { root, summary } = build(sharedHelperStream);
+
+  const fileNodes = root.children.filter((n) => n.type === 'file');
+  assert.deepStrictEqual(
+    fileNodes.map((n) => n.name.replace(/^.*\//, '')).sort(),
+    ['entry-a.mjs', 'entry-b.mjs'],
+    'each entry file gets its own node, named for the entry file',
+  );
+
+  for (const fileNode of fileNodes) {
+    const passing = leaf(fileNode, 'shared passing test');
+    assert.strictEqual(passing?.status, 'passed', `passing test under ${fileNode.name}`);
+    assert.strictEqual(leaf(fileNode, 'shared failing test')?.status, 'failed', `failing test under ${fileNode.name}`);
+    // The node keeps the definition site; only the grouping uses the entry file.
+    assert.ok(passing?.file?.endsWith('shared-helper.mjs'), 'file is the definition site');
+    assert.strictEqual(passing?.entryFile, fileNode.file, 'entryFile is the group it sits in');
+  }
+
+  // The tree now agrees with the run-level summary instead of under-reporting.
+  assert.deepStrictEqual(
+    { passed: root.counts.passed, failed: root.counts.failed, total: root.counts.total },
+    { passed: 2, failed: 2, total: 4 },
+  );
+  assert.strictEqual(summary?.counts.tests, 4);
+});
+
+test('a stream without entryFile still merges them under the definition file', () => {
+  // Backwards compatibility, exercised on every Node version: strip the field
+  // and the heuristic path must produce exactly what it always did — one node
+  // named for the helper, holding one copy of each test, with the true totals
+  // surviving only in the cumulative summary.
+  const { root, summary } = build(withoutEntryFile(sharedHelperStream));
 
   const fileNodes = root.children.filter((n) => n.type === 'file');
   assert.strictEqual(fileNodes.length, 1, 'both files define via the same helper');
@@ -62,7 +101,6 @@ test('isolation: shared-helper tests from two files group under the definition f
   assert.strictEqual(leaf(fileNodes[0], 'shared passing test')?.status, 'passed');
   assert.strictEqual(leaf(fileNodes[0], 'shared failing test')?.status, 'failed');
 
-  // The run-level summary still reflects that 4 tests actually ran.
   assert.strictEqual(summary?.counts.tests, 4);
   assert.strictEqual(summary?.counts.passed, 2);
   assert.strictEqual(summary?.counts.failed, 2);

--- a/packages/tree-core/tests/entry-file.test.ts
+++ b/packages/tree-core/tests/entry-file.test.ts
@@ -1,0 +1,188 @@
+// The exact-resolution path: once events carry `entryFile`, (entryFile, testId)
+// identifies a test exactly, so none of the cross-process guessing in
+// isolation-collisions.test.ts applies. These mirror those scenarios with the
+// field present, and assert the guessing is gone rather than merely unused.
+import { test } from 'node:test';
+import assert from 'node:assert';
+import {
+  allNodes, build, done, ev, findAll, findOne,
+} from './util.ts';
+
+const A = '/x/tests/a.test.ts';
+const B = '/x/tests/b.test.ts';
+const HELPER = '/x/tests/helper.ts';
+
+/** A child-forwarded event: carries the entry file of the process that ran it. */
+const child = (
+  type: string,
+  entryFile: string,
+  data: Record<string, unknown>,
+) => ev(type, { entryFile, ...data });
+
+/** A parent-emitted file wrapper: no entryFile, and `file` IS the entry file. */
+const wrapper = (type: string, file: string, extra: Record<string, unknown> = {}) => ev(type, {
+  name: file, file, nesting: 0, testId: 1, parentId: 0, ...extra,
+});
+
+test('the same testId in two entry files stays two distinct tests', () => {
+  // Both processes number their first test 1 and report the same helper as
+  // `file`. Grouping by entryFile keeps them apart with no instance splitting.
+  const { root } = build([
+    child('test:enqueue', A, { name: 'shared', nesting: 0, file: HELPER, testId: 1, parentId: 0, type: 'test' }),
+    child('test:enqueue', B, { name: 'shared', nesting: 0, file: HELPER, testId: 1, parentId: 0, type: 'test' }),
+    child('test:complete', A, { name: 'shared', nesting: 0, file: HELPER, testId: 1, parentId: 0, details: done }),
+    child('test:complete', B, { name: 'shared', nesting: 0, file: HELPER, testId: 1, parentId: 0, details: done }),
+  ]);
+
+  const matches = findAll(root, 'shared');
+  assert.strictEqual(matches.length, 2, 'one per entry file');
+  assert.deepStrictEqual(
+    root.children.filter((n) => n.type === 'file').map((n) => n.file).sort(),
+    [A, B],
+  );
+  assert.deepStrictEqual(
+    root.children.filter((n) => n.type === 'file').flatMap((n) => n.children.map((c) => c.file)),
+    [HELPER, HELPER],
+    'each keeps the helper as its definition site',
+  );
+});
+
+test('a helper-defined subtest attaches to its parent on the eager event, never parked', () => {
+  // Both processes have an open testId 2 when the subtest arrives. Under the
+  // heuristic path this is the ambiguous case that parks the child under the
+  // helper group; here parentId is scoped by entryFile, so it resolves at once.
+  const { root } = build([
+    child('test:dequeue', A, { name: 'a parent', nesting: 0, file: A, testId: 2, parentId: 0, type: 'test' }),
+    child('test:dequeue', B, { name: 'b parent', nesting: 0, file: B, testId: 2, parentId: 0, type: 'test' }),
+    child('test:dequeue', B, { name: 'b sub', nesting: 1, file: HELPER, testId: 3, parentId: 2, type: 'test' }),
+  ]);
+
+  const { path } = findOne(root, 'b sub');
+  assert.ok(path.includes('b parent'), `expected it under b parent, got ${JSON.stringify(path)}`);
+  assert.ok(!path.includes('a parent'), 'must not attach to the other process');
+  assert.deepStrictEqual(
+    root.children.filter((n) => n.file === HELPER),
+    [],
+    'no helper-file group: nothing was parked',
+  );
+});
+
+test('a subtest whose parent has not reported yet anchors to a placeholder in its own entry file', () => {
+  const { root } = build([
+    child('test:dequeue', A, { name: 'orphan sub', nesting: 1, file: HELPER, testId: 9, parentId: 4, type: 'test' }),
+    child('test:start', A, { name: 'late parent', nesting: 0, file: A, testId: 4, parentId: 0 }),
+    child('test:start', A, { name: 'orphan sub', nesting: 1, file: HELPER, testId: 9, parentId: 4 }),
+    child('test:pass', A, { name: 'orphan sub', nesting: 1, file: HELPER, testId: 9, parentId: 4, details: done }),
+    child('test:pass', A, { name: 'late parent', nesting: 0, file: A, testId: 4, parentId: 0, details: done }),
+  ]);
+
+  const { path } = findOne(root, 'orphan sub');
+  assert.ok(path.includes('late parent'), `expected it under late parent, got ${JSON.stringify(path)}`);
+  const nameless = allNodes(root).filter((n) => (n.type === 'test' || n.type === 'suite') && n.name === '');
+  assert.deepStrictEqual(nameless, [], 'the placeholder was claimed, not left behind');
+});
+
+test('a test named after its own file is not mistaken for a file wrapper', () => {
+  // The heuristic path matches wrappers on basename, so a test literally named
+  // like its file reads as one. entryFile makes the distinction exact: only the
+  // parent runner omits it.
+  const { root } = build([
+    wrapper('test:enqueue', A),
+    child('test:enqueue', A, { name: 'a.test.ts', nesting: 0, file: A, testId: 1, parentId: 0, type: 'test' }),
+    child('test:start', A, { name: 'a.test.ts', nesting: 0, file: A, testId: 1, parentId: 0 }),
+    child('test:pass', A, { name: 'a.test.ts', nesting: 0, file: A, testId: 1, parentId: 0, details: done }),
+  ]);
+
+  const fileNodes = root.children.filter((n) => n.type === 'file');
+  assert.strictEqual(fileNodes.length, 1);
+  assert.strictEqual(fileNodes[0].children.length, 1, 'the test is a child, not swallowed by the wrapper');
+  assert.strictEqual(fileNodes[0].children[0].name, 'a.test.ts');
+  assert.strictEqual(fileNodes[0].children[0].status, 'passed');
+});
+
+test('a wrapper event groups with the child events it forwarded', () => {
+  // The wrapper carries no entryFile, but its `file` is the entry file — so both
+  // must land on one group node, wrapper liveness included.
+  const { root } = build([
+    wrapper('test:enqueue', A),
+    wrapper('test:dequeue', A),
+    child('test:complete', A, { name: 'inner', nesting: 0, file: A, testId: 1, parentId: 0, details: done }),
+    wrapper('test:complete', A, { details: { passed: true, duration_ms: 40 } }),
+  ]);
+
+  const fileNodes = root.children.filter((n) => n.type === 'file');
+  assert.strictEqual(fileNodes.length, 1, 'wrapper and children share one group');
+  assert.strictEqual(fileNodes[0].durationMs, 40, "the wrapper's wall-clock lands on the group");
+  assert.strictEqual(findOne(root, 'inner').node.status, 'passed');
+});
+
+test('test:stdout reported CLI-relative still groups with its tests', () => {
+  // stdout reports `file` relative while entryFile is absolute; grouping by
+  // entryFile makes them agree without the wrapper name/file alias.
+  const { root } = build([
+    ev('test:stdout', { file: 'tests/a.test.ts', entryFile: A, message: 'hello\n' }),
+    child('test:complete', A, { name: 'inner', nesting: 0, file: A, testId: 1, parentId: 0, details: done }),
+  ]);
+
+  const fileNodes = root.children.filter((n) => n.type === 'file');
+  assert.strictEqual(fileNodes.length, 1, 'stdout and tests must share one file node');
+  assert.deepStrictEqual(fileNodes[0].stdout, ['hello\n']);
+  assert.strictEqual(fileNodes[0].children[0].name, 'inner');
+});
+
+test('a child diagnostic attributes to the last started test in its own entry file', () => {
+  // Diagnostics carry entryFile but no testId, so they still need recency —
+  // scoped per entry file, two concurrent files cannot steal each other's.
+  const { root } = build([
+    child('test:start', A, { name: 'a test', nesting: 0, file: A, testId: 1, parentId: 0 }),
+    child('test:start', B, { name: 'b test', nesting: 0, file: B, testId: 1, parentId: 0 }),
+    child('test:diagnostic', A, { nesting: 0, file: HELPER, message: 'from a', level: 'info' }),
+    child('test:diagnostic', B, { nesting: 0, file: HELPER, message: 'from b', level: 'info' }),
+  ]);
+
+  assert.deepStrictEqual(findOne(root, 'a test').node.messages.map((m) => m.message), ['from a']);
+  assert.deepStrictEqual(findOne(root, 'b test').node.messages.map((m) => m.message), ['from b']);
+});
+
+test('declaration blocks interleaved across entry files keep their own nesting stacks', () => {
+  // Each process reports its own declaration order. With one shared stack an
+  // interleaved block would mis-parent; per-entry-file stacks cannot.
+  const { root } = build([
+    child('test:start', A, { name: 'a suite', nesting: 0, file: A, testId: 1, parentId: 0, type: 'suite' }),
+    child('test:start', B, { name: 'b suite', nesting: 0, file: B, testId: 1, parentId: 0, type: 'suite' }),
+    child('test:start', A, { name: 'a child', nesting: 1, file: A, testId: 2, parentId: 1 }),
+    child('test:start', B, { name: 'b child', nesting: 1, file: B, testId: 2, parentId: 1 }),
+    child('test:pass', A, { name: 'a child', nesting: 1, file: A, testId: 2, parentId: 1, details: done }),
+    child('test:pass', B, { name: 'b child', nesting: 1, file: B, testId: 2, parentId: 1, details: done }),
+    child('test:pass', A, { name: 'a suite', nesting: 0, file: A, testId: 1, parentId: 0, details: { ...done, type: 'suite' } }),
+    child('test:pass', B, { name: 'b suite', nesting: 0, file: B, testId: 1, parentId: 0, details: { ...done, type: 'suite' } }),
+  ]);
+
+  assert.ok(findOne(root, 'a child').path.includes('a suite'));
+  assert.ok(findOne(root, 'b child').path.includes('b suite'));
+  assert.strictEqual(root.counts.passed, 2);
+  assert.strictEqual(root.counts.failed, 0);
+});
+
+test('a replayed stream is idempotent on the exact path', () => {
+  const events = [
+    child('test:enqueue', A, { name: 'inner', nesting: 0, file: HELPER, testId: 1, parentId: 0, type: 'test' }),
+    child('test:start', A, { name: 'inner', nesting: 0, file: HELPER, testId: 1, parentId: 0 }),
+    child('test:pass', A, { name: 'inner', nesting: 0, file: HELPER, testId: 1, parentId: 0, details: done }),
+  ];
+  const once = build(events);
+  const twice = build([...events, ...events]);
+
+  assert.deepStrictEqual(twice.counts, once.counts);
+  assert.strictEqual(findAll(twice.root, 'inner').length, 1);
+});
+
+test('a top-level test reports parentId 0 and hangs off its entry file', () => {
+  const { root } = build([
+    child('test:start', A, { name: 'top', nesting: 0, file: A, testId: 1, parentId: 0 }),
+    child('test:pass', A, { name: 'top', nesting: 0, file: A, testId: 1, parentId: 0, details: done }),
+  ]);
+
+  const { path } = findOne(root, 'top');
+  assert.deepStrictEqual(path, ['', A], 'root then the entry-file group');
+});

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -549,3 +549,14 @@ test('a log with no message is ignored', () => {
   const node = store.getSnapshot().root.children[0].children[0];
   assert.deepStrictEqual(node.messages, []);
 });
+
+test('a node exposes the entry file it ran under alongside its definition file', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', data: { name: 't', nesting: 0, file: '/helper.mjs', entryFile: '/a.test.mjs', testId: 1, parentId: 0 } },
+    { type: 'test:pass', data: { name: 't', nesting: 0, file: '/helper.mjs', entryFile: '/a.test.mjs', testId: 1, parentId: 0, details: { duration_ms: 1 } } },
+  ]);
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(node.file, '/helper.mjs', 'file stays the definition site');
+  assert.strictEqual(node.entryFile, '/a.test.mjs');
+});

--- a/packages/tree-core/tests/wire.test.ts
+++ b/packages/tree-core/tests/wire.test.ts
@@ -95,3 +95,19 @@ test('a runaway object key count is capped', () => {
   assert.strictEqual(payload['[Truncated]'], true);
   assert.ok(Object.keys(payload).length < 5000, 'expected truncation');
 });
+
+test('entryFile survives the wire', () => {
+  const wire = toWireEvent({
+    type: 'test:start',
+    data: {
+      name: 't', nesting: 0, testId: 1, parentId: 0, file: '/helper.mjs', entryFile: '/a.test.mjs',
+    },
+  });
+  assert.strictEqual(wire.data.entryFile, '/a.test.mjs');
+  assert.strictEqual(wire.data.file, '/helper.mjs');
+});
+
+test('an absent entryFile adds no field (pre-v26.6 streams)', () => {
+  const wire = toWireEvent({ type: 'test:start', data: { name: 't', nesting: 0, file: '/a.test.mjs' } });
+  assert.ok(!('entryFile' in wire.data));
+});


### PR DESCRIPTION
Adopts [`entryFile`](https://github.com/nodejs/node/pull/64309) (node v26.6.0) to fix the ambiguous-tree problem under process isolation. Closes the `TODO(nodejs/node#64309)` that sat on `findOpenParents`.

## The problem

A test defined in a shared imported helper reports **the helper** as its `file`, and `testId` restarts per child process. Grouping by `file` therefore merged every entry file's copy of that helper's tests into one node with colliding ids. Measured on a real two-file run, the tree showed `shared-helper.mjs` with **2** tests while the run summary said **4** — the tree silently under-reported, and the store carried a pile of heuristics to cope: a cross-process open-parent search, "park it under the helper group and re-resolve later", per-`(group, testId)` instance splitting, and cross-group recency.

## The fix

`entryFile` names the child process that produced an event, and testIds are unique *within* a process, so `(entryFile, testId)` identifies a test exactly. Same run, after:

| | before | after |
|---|---|---|
| file nodes | `shared-helper.mjs` | `entry-a.mjs`, `entry-b.mjs` |
| tree counts | 2 tests | 4 tests (matches the summary) |

Nodes keep `file` as the definition site and gain `entryFile`, so a helper-defined test still points at where it was written.

## Two resolvers, not one path with flags

Resolution moves behind a `Resolver` interface (`resolve.ts`) with two implementations kept **side by side in one file**, so they read against each other rather than drifting apart:

- **`createExactResolver`** — for streams carrying `entryFile`. Retires *all* of the above: no instance splitting, no candidate search, no parking, no cross-group recency, and no `fileAlias` (grouping by the entry file makes `test:stdout`'s CLI-relative `file` agree by construction). Each entry file also gets its own declaration stack, so interleaved blocks can't confuse each other.
- **`createLegacyResolver`** — today's heuristics, moved verbatim. Its declaration stack reduces to the single shared stack it has always been.

`store.ts` keeps the event loop, node mutation and snapshot build, and **latches** to the exact resolver on the first event carrying the field. That's safe because of how the real stream is shaped: the only events that can precede it are the parent's own file wrappers, which carry no `entryFile` but whose `file` *is* the entry file — and both resolvers key those identically. `store.ts` also drops ~180 lines into the new `internal.ts` / `resolve.ts`.

One latent bug fixed as a consequence: a wrapper is now identified by the **absence** of `entryFile` rather than a `basename(name) === basename(file)` match, so a test named after its own file is no longer misread as a file wrapper.

## Compatibility

This is the part I was most careful about.

- `isolation-collisions.test.ts` is **untouched** — it emits no `entryFile`, so it now serves as the legacy-path regression suite, and it passes unchanged.
- The shared-helper corpus test doesn't just flip on version. It asserts the new behavior when the captured stream carries `entryFile`, **and** a second test strips the field from that same real stream and asserts the old behavior exactly — so the heuristic path is exercised on *every* node version, including the newest.
- New `entry-file.test.ts` mirrors the collision scenarios *with* the field, asserting the guessing is gone rather than merely unused (e.g. no helper-file group is ever created, so nothing was parked).
- Verified green on v22 / v24 / v26; 100% statements/functions/lines.

## Browser verification

Served both logs through the real viewer:

- with `entryFile`: two file nodes, header `4 tests · 2 passed · 2 failed`
- same log with `entryFile` stripped: one `shared-helper.mjs` node, `2 tests` — i.e. an **old NDJSON log still renders exactly as it used to**, which matters since the hosted viewer replays archived runs.

> Note: 8 gh/github snapshot tests fail locally on node 24.16/26.6 from node-internal stack line drift. They fail identically on `main` — pre-existing, handled by the nightly update-snapshots workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)