### PR TITLE
feat(tree-core): give every snapshot node parent and ancestors()

### DIFF
--- a/packages/live/tests/sections.test.ts
+++ b/packages/live/tests/sections.test.ts
@@ -22,6 +22,7 @@ function node(over: Partial<TestNode> = {}): TestNode {
     stderr: [],
     children: [],
     counts: COUNTS,
+    ancestors: () => [],
     ...over,
   };
 }

--- a/packages/tree-core/README.md
+++ b/packages/tree-core/README.md
@@ -31,6 +31,10 @@ npm i @reporters/tree-core
   of suites and tests with statuses (queued → running → passed/failed/skipped),
   durations, counts, and per-test detail (errors, stdout/stderr, and a
   `messages` stream carrying both `diagnostic()` and `log()` output).
+- **Upward traversal** — every node in a snapshot carries `parent` and
+  `ancestors()` (root-first, the node itself excluded), so you can walk back up
+  from a test without threading a path down through your own recursion. Both
+  are non-enumerable, so a snapshot still serializes as plain, acyclic data.
 - **Wire format** — `toWireEvent` / `serializeWireLine` / `parseWireLines`
   convert runner events to and from the JSON-safe NDJSON lines that
   `@reporters/web` streams, so a run can be replayed anywhere.

--- a/packages/tree-core/src/lineage.ts
+++ b/packages/tree-core/src/lineage.ts
@@ -1,0 +1,26 @@
+import type { TestNode } from './types.ts';
+
+// Shared by every node — the walk needs nothing but `this.parent`, so there is
+// no per-node closure to allocate.
+function ancestors(this: TestNode): TestNode[] {
+  const path: TestNode[] = [];
+  for (let node = this.parent; node != null; node = node.parent) path.unshift(node);
+  return path;
+}
+
+/**
+ * Installs a node's lineage: `ancestors()` on the node, and `parent` on each of
+ * the children it was built from. The tree is built bottom-up, so a child
+ * object always exists by the time its parent is assembled.
+ *
+ * Both are non-enumerable, which is what keeps the upward reference from making
+ * the tree cyclic: `Object.keys`, spreads, `JSON.stringify`, `structuredClone`
+ * and `assert.deepStrictEqual` all walk own enumerable properties, so a
+ * snapshot serializes and compares exactly as it did without them.
+ */
+export function withLineage(data: Omit<TestNode, 'parent' | 'ancestors'>): TestNode {
+  const node = data as TestNode;
+  Object.defineProperty(node, 'ancestors', { value: ancestors });
+  for (const child of node.children) Object.defineProperty(child, 'parent', { value: node });
+  return node;
+}

--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -17,6 +17,7 @@ import {
 import {
   createExactResolver, createLegacyResolver, type Resolver, type ResolverContext,
 } from './resolve.ts';
+import { withLineage } from './lineage.ts';
 
 // A todo test that actually passes reports as passed (its `todo` marker is
 // kept on the node); `todo` status is reserved for todos that are failing
@@ -652,7 +653,7 @@ export function createTreeStore(): TreeStore {
       else if (counts.queued > 0 && counts.passed + counts.skipped + counts.todo === 0) status = 'queued';
       else status = 'passed';
     }
-    return {
+    return withLineage({
       key: internal.key,
       testId: internal.testId,
       parentKey: internal.parentKey,
@@ -676,7 +677,7 @@ export function createTreeStore(): TreeStore {
       skip: internal.skip,
       passedOnAttempt: internal.passedOnAttempt,
       counts,
-    };
+    });
   }
 
   function getSnapshot(): TreeSnapshot {

--- a/packages/tree-core/src/types.ts
+++ b/packages/tree-core/src/types.ts
@@ -71,6 +71,12 @@ export interface TestNode {
    *  was carried — reported passed without executing this attempt. */
   passedOnAttempt?: number;
   counts: Counts;
+  /** The node above this one in the snapshot it was built from; absent on the
+   *  root. Non-enumerable, so it stays out of serialization. */
+  parent?: TestNode;
+  /** The path from the root down to this node's parent — outermost first, this
+   *  node excluded. Empty on the root. */
+  ancestors(): TestNode[];
 }
 
 export interface SummaryData {

--- a/packages/tree-core/tests/carried.test.ts
+++ b/packages/tree-core/tests/carried.test.ts
@@ -17,7 +17,7 @@ function leaf(over: Partial<TestNode> = {}): TestNode {
   return {
     key: 'k', testId: undefined, parentKey: null, file: undefined, name: '',
     nesting: 0, type: 'test', status: 'passed', messages: [], stdout: [], stderr: [],
-    children: [], counts: { ...zero(), passed: 1, total: 1 }, ...over,
+    children: [], counts: { ...zero(), passed: 1, total: 1 }, ancestors: () => [], ...over,
   };
 }
 

--- a/packages/tree-core/tests/lineage.test.ts
+++ b/packages/tree-core/tests/lineage.test.ts
@@ -1,0 +1,99 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { createTreeStore } from '../src/store.ts';
+import type { TestEvent } from '../src/types.ts';
+
+function apply(store: ReturnType<typeof createTreeStore>, events: TestEvent[]) {
+  for (const event of events) store.apply(event);
+}
+
+const FILE = '/a.test.js';
+
+function nested() {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', data: { name: 'math', nesting: 0, file: FILE, testId: 1 } },
+    { type: 'test:start', data: { name: 'adds', nesting: 1, file: FILE, testId: 2, parentId: 1 } },
+    { type: 'test:pass', data: { name: 'adds', nesting: 1, file: FILE, testId: 2, parentId: 1, details: { duration_ms: 1 } } },
+    { type: 'test:pass', data: { name: 'math', nesting: 0, file: FILE, testId: 1, details: { duration_ms: 3, type: 'suite' } } },
+  ]);
+  const { root } = store.getSnapshot();
+  const fileNode = root.children[0];
+  const suite = fileNode.children[0];
+  return { root, fileNode, suite, leaf: suite.children[0] };
+}
+
+test('parent links every node to the one above it, and is absent on the root', () => {
+  const { root, fileNode, suite, leaf } = nested();
+
+  assert.strictEqual(leaf.parent, suite);
+  assert.strictEqual(suite.parent, fileNode);
+  assert.strictEqual(fileNode.parent, root);
+  assert.strictEqual(root.parent, undefined);
+});
+
+test('parent agrees with the parentKey the node already carried', () => {
+  const { fileNode, suite, leaf } = nested();
+
+  for (const node of [fileNode, suite, leaf]) {
+    assert.strictEqual(node.parent!.key, node.parentKey);
+  }
+});
+
+test('ancestors walks root-first and excludes the node itself', () => {
+  const { root, fileNode, suite, leaf } = nested();
+
+  assert.deepStrictEqual(leaf.ancestors(), [root, fileNode, suite]);
+  assert.deepStrictEqual(suite.ancestors(), [root, fileNode]);
+  assert.deepStrictEqual(fileNode.ancestors(), [root]);
+  assert.deepStrictEqual(root.ancestors(), []);
+});
+
+test('ancestors of a node in a second file stay within that file', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', data: { name: 'a', nesting: 0, file: '/a.test.js', testId: 1 } },
+    { type: 'test:pass', data: { name: 'a', nesting: 0, file: '/a.test.js', testId: 1, details: { duration_ms: 1 } } },
+    { type: 'test:start', data: { name: 'b', nesting: 0, file: '/b.test.js', testId: 1 } },
+    { type: 'test:pass', data: { name: 'b', nesting: 0, file: '/b.test.js', testId: 1, details: { duration_ms: 1 } } },
+  ]);
+
+  const { root } = store.getSnapshot();
+  const [fileA, fileB] = root.children;
+
+  assert.deepStrictEqual(fileB.children[0].ancestors(), [root, fileB]);
+  assert.deepStrictEqual(fileA.children[0].ancestors(), [root, fileA]);
+});
+
+// The tree is rebuilt on every dirty snapshot, so lineage must point inside the
+// snapshot the node came from — the same rule `children` already follows.
+test('each snapshot links its own nodes, not the previous snapshot\'s', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', data: { name: 'adds', nesting: 0, file: FILE, testId: 1 } },
+  ]);
+  const first = store.getSnapshot();
+  apply(store, [
+    { type: 'test:pass', data: { name: 'adds', nesting: 0, file: FILE, testId: 1, details: { duration_ms: 5 } } },
+  ]);
+  const second = store.getSnapshot();
+
+  assert.notStrictEqual(second.root, first.root);
+  assert.strictEqual(second.root.children[0].children[0].parent, second.root.children[0]);
+  assert.strictEqual(first.root.children[0].children[0].parent, first.root.children[0]);
+});
+
+// The back-reference would make the tree cyclic to anything that walks own
+// enumerable properties, so both members must be invisible to them.
+test('lineage members are non-enumerable and leave serialization untouched', () => {
+  const { root, leaf } = nested();
+
+  assert.ok(!Object.keys(leaf).includes('parent'));
+  assert.ok(!Object.keys(leaf).includes('ancestors'));
+  assert.ok(!('parent' in JSON.parse(JSON.stringify(root))));
+  assert.strictEqual(structuredClone(root).children[0].children[0].name, 'math');
+});
+
+test('two structurally identical trees still deep-equal each other', () => {
+  assert.deepStrictEqual(nested().root, nested().root);
+});

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -15,7 +15,7 @@ function node(over: Partial<TestNode> = {}): TestNode {
   return {
     key: 'k', testId: undefined, parentKey: null, file: undefined, name: '',
     nesting: 0, type: 'test', status: 'passed', messages: [], stdout: [], stderr: [],
-    children: [], counts: zeroCounts(), ...over,
+    children: [], counts: zeroCounts(), ancestors: () => [], ...over,
   };
 }
 


### PR DESCRIPTION
## What

Snapshot trees could only be walked downward. A node carried `parentKey`, but the snapshot exposes no key→node index to resolve it against — so every consumer that needed a node's path threaded one down through its own recursion (`rowModel`'s `walk`, `tests/util.ts`'s `findOne`).

Every node built by `getSnapshot()` now carries:

```ts
/** The node above this one in the snapshot it was built from; absent on the root. */
parent?: TestNode;
/** The path from the root down to this node's parent — outermost first, this node excluded. */
ancestors(): TestNode[];
```

```js
leaf.parent.parent          // the file node
leaf.ancestors()            // [root, fileNode, suiteNode]
root.ancestors()            // []
root.parent                 // undefined
```

## How

New `src/lineage.ts`, one call from `build()`. The tree is assembled bottom-up, so a parent installs `parent` on its already-built children; `ancestors()` is a single shared function walking `this.parent`, not a per-node closure.

Both go on with `Object.defineProperty` and so are **non-enumerable**. That is the load-bearing detail: `Object.keys`, spreads, `JSON.stringify`, `structuredClone` and `assert.deepStrictEqual` all walk own enumerable properties, so the upward reference cannot make the tree cyclic and a snapshot serializes and compares exactly as it did before. Nodes stay plain objects on `Object.prototype`.

Lifetime matches `children`: nodes are rebuilt per dirty snapshot, so `parent` points inside the snapshot the node came from. `build()` drops empty file nodes and placeholders only when they're childless, so an ancestor of a surviving node is never one of them — `ancestors()` always terminates at the root and never yields a node absent from the tree.

## Note on the test-only changes in web/live

`ancestors()` is required on `TestNode`, so the three test factories that hand-build node literals each gain `ancestors: () => []`. That's why `packages/web` and `packages/live` appear in the diff — no source change in either. Heads up that release-please attributes by path, so the squashed `feat` may bump those two as well.

## Verification

- 7 new tests in `packages/tree-core/tests/lineage.test.ts` covering the parent chain, `parent.key === parentKey`, root-first order, per-snapshot identity, non-enumerability (`Object.keys` / `JSON.stringify` / `structuredClone`), and that two structurally identical trees still `deepStrictEqual`.
- `yarn test`: 440 passed, 8 failed. Those 8 are the `gh`/`github` `index.test.js` failures already failing on a clean tree at this base (433 passed / same 8 failed before the change).
- `yarn lint` clean (5 pre-existing warnings, 0 errors); `tsc --noEmit` clean for tree-core, web and live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)