### PR TITLE
fix(tree-core): count only the deepest open node as running

### DIFF
--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -628,7 +628,10 @@ export function createTreeStore(): TreeStore {
       // its subtests so far may all have settled while it awaits more (or runs
       // teardown). Count it, so ancestors and the header can't read done early.
       // Once it settles it leaves the counts again: totals stay leaves-only.
-      if ((internal.type === 'test' || internal.type === 'suite') && !TERMINAL.has(internal.status)) {
+      // Only the deepest such node in a branch counts: an ancestor that is
+      // merely awaiting a running descendant is already represented by it.
+      if ((internal.type === 'test' || internal.type === 'suite') && !TERMINAL.has(internal.status)
+        && counts[internal.status] === 0) {
         counts[internal.status] += 1;
         counts.total += 1;
       }

--- a/packages/tree-core/tests/live-status.test.ts
+++ b/packages/tree-core/tests/live-status.test.ts
@@ -79,6 +79,21 @@ test('a file-level start opens the wrapper too (streams without eager wrapper ev
   assert.strictEqual(file.status, 'running', 'the wrapper started and has not completed');
 });
 
+test('a chain of open ancestors counts as one running test, not one per level', () => {
+  const { counts } = build([
+    ev('test:enqueue', WRAP),
+    ev('test:dequeue', WRAP),
+    ev('test:enqueue', { name: 'RDS On-PR E2E', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'suite' }),
+    ev('test:dequeue', { name: 'RDS On-PR E2E', nesting: 0, file: ENTRY, testId: 1, parentId: 0, type: 'suite' }),
+    ev('test:enqueue', { name: 'backup flow', nesting: 1, file: ENTRY, testId: 2, parentId: 1, type: 'suite' }),
+    ev('test:dequeue', { name: 'backup flow', nesting: 1, file: ENTRY, testId: 2, parentId: 1, type: 'suite' }),
+    ev('test:enqueue', { name: 'db2pq restore', nesting: 2, file: ENTRY, testId: 3, parentId: 2, type: 'test' }),
+    ev('test:dequeue', { name: 'db2pq restore', nesting: 2, file: ENTRY, testId: 3, parentId: 2, type: 'test' }),
+  ]);
+  assert.strictEqual(counts.running, 1, 'only the deepest open node is running; ancestors merely await it');
+  assert.strictEqual(counts.total, 1);
+});
+
 test('settled parents leave the final counts as leaves-only', () => {
   const { counts } = build([
     ev('test:enqueue', WRAP),


### PR DESCRIPTION
## Problem

A running leaf under a chain of open ancestors was counted once per level. In a real run the header read **4 running** where exactly one test was executing — the other 3 were suites/parents merely awaiting it. The same over-count inflated `total`.

## Cause

[`build()`](https://github.com/MoLow/reporters/blob/main/packages/tree-core/src/store.ts#L627-L634) adds a non-terminal container's own status to the counts unconditionally. That block exists for a real case — a parent whose subtests have all settled while it awaits more (or runs teardown) must still count as running, or the tree shows ✓ and flips back to running, and the header reads "Running" with no running row in sight. But it also fires for ancestors that already have a running descendant.

## Fix

Count a container's own status only when nothing in its subtree already holds it — the deepest open node per branch:

```diff
-      if ((internal.type === 'test' || internal.type === 'suite') && !TERMINAL.has(internal.status)) {
+      if ((internal.type === 'test' || internal.type === 'suite') && !TERMINAL.has(internal.status)
+        && counts[internal.status] === 0) {
```

Plain leaves-only counting would reintroduce the "Running with 0 running" bug; this keeps that case and drops only the redundant ancestors.

## Tests

New case in `live-status.test.ts`: two open suites over one running test → `running: 1, total: 1`. Both existing guards (running parent / running suite with settled children) still assert `running: 1` and pass.

Full suite: 441 passed / 8 failed — the 8 are pre-existing `packages/gh` snapshot failures present on a clean `main` (440 passed / same 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)