### PR TITLE
feat(tree-core,web): quiet the runner's own synthetic failures

### DIFF
--- a/packages/tree-core/src/store.ts
+++ b/packages/tree-core/src/store.ts
@@ -45,7 +45,7 @@ function logLevel(data: TestEventData): DiagnosticLevel {
 
 function serializeError(raw: unknown): SerializedError | undefined {
   if (raw == null) return undefined;
-  const err = raw as { message?: string; stack?: string; name?: string; cause?: unknown };
+  const err = raw as { message?: string; stack?: string; name?: string; cause?: unknown; failureType?: unknown };
   const cause = (err.cause ?? err) as { message?: string; stack?: string; name?: string };
   // A cause whose message/name live on prototype getters (e.g. DOMException) loses them
   // when v8-serialized across the test-runner IPC boundary; the stack string keeps the
@@ -54,6 +54,9 @@ function serializeError(raw: unknown): SerializedError | undefined {
     message: cause?.message || cause?.stack?.split('\n', 1)[0] || String(cause),
     stack: cause?.stack,
     name: cause?.name,
+    // Read off the ERR_TEST_FAILURE wrapper, not the cause we unwrap to: for the
+    // runner's own synthetic failures the cause is a bare string carrying nothing.
+    ...(typeof err.failureType === 'string' ? { failureType: err.failureType } : {}),
   };
 }
 

--- a/packages/tree-core/src/types.ts
+++ b/packages/tree-core/src/types.ts
@@ -27,6 +27,11 @@ export interface SerializedError {
   message: string;
   stack?: string;
   name?: string;
+  /** How `node:test` itself classified the failure — `'testCodeFailure'`,
+   *  `'subtestsFailed'`, `'cancelledByParent'`, `'hookFailed'`, … Absent on
+   *  logs written before the wire carried it, and on errors the runner did not
+   *  wrap. */
+  failureType?: string;
 }
 
 export interface Counts {

--- a/packages/tree-core/tests/store.test.ts
+++ b/packages/tree-core/tests/store.test.ts
@@ -67,6 +67,39 @@ test('failed test carries the unwrapped cause error', () => {
   assert.strictEqual(node.error?.message, 'actual failure');
 });
 
+test('failureType comes off the wrapper, which is where the runner puts it', () => {
+  const store = createTreeStore();
+  // node:test's own synthetic failures wrap a bare string, so unwrapping to the
+  // cause first would lose the classification entirely.
+  const rollup = Object.assign(new Error('3 subtests failed'), {
+    code: 'ERR_TEST_FAILURE', failureType: 'subtestsFailed', cause: '3 subtests failed',
+  });
+  const real = Object.assign(new Error('wrapper'), {
+    code: 'ERR_TEST_FAILURE', failureType: 'testCodeFailure', cause: new Error('actual failure'),
+  });
+  apply(store, [
+    { type: 'test:start', data: { name: 'suite', nesting: 0, file: '/a.test.js', testId: 1 } },
+    { type: 'test:start', data: { name: 't', nesting: 1, file: '/a.test.js', testId: 2, parentId: 1 } },
+    { type: 'test:fail', data: { name: 't', nesting: 1, file: '/a.test.js', testId: 2, parentId: 1, details: { error: real } } },
+    { type: 'test:fail', data: { name: 'suite', nesting: 0, file: '/a.test.js', testId: 1, details: { error: rollup } } },
+  ]);
+  const suite = store.getSnapshot().root.children[0].children[0];
+  assert.strictEqual(suite.error?.failureType, 'subtestsFailed');
+  assert.strictEqual(suite.error?.message, '3 subtests failed');
+  assert.strictEqual(suite.children[0].error?.failureType, 'testCodeFailure');
+  assert.strictEqual(suite.children[0].error?.message, 'actual failure', 'unwrapping to the cause still wins for the message');
+});
+
+test('an error with no failureType leaves the field off', () => {
+  const store = createTreeStore();
+  apply(store, [
+    { type: 'test:start', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1 } },
+    { type: 'test:fail', data: { name: 't', nesting: 0, file: '/a.test.js', testId: 1, details: { error: new Error('boom') } } },
+  ]);
+  const node = store.getSnapshot().root.children[0].children[0];
+  assert.ok(!('failureType' in node.error!), 'logs written before the wire carried it stay unannotated');
+});
+
 test('empty-message cause falls back to the stack first line', () => {
   const store = createTreeStore();
   // A DOMException cause (e.g. AbortSignal.timeout's TimeoutError) crossing the

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -5,7 +5,7 @@ import {
   carriedAttempt, formatDuration, formatLogPayload, isCarried, todoLabel, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
 } from '@reporters/tree-core';
 import {
-  buildRows, collectContainerKeys, computeMatches, displayName, isContainer, isSectionOpen, liveNodeDuration, reasonOf, realError, type FlatRow, type LiveClock,
+  buildRows, collectContainerKeys, computeMatches, displayName, isCancelled, isContainer, isSectionOpen, isSubtestsRollup, liveNodeDuration, reasonOf, realError, type FlatRow, type LiveClock,
 } from './rowModel.ts';
 
 // node:test captures colored output verbatim; render the ANSI SGR codes as real
@@ -19,6 +19,9 @@ import { urlFilterState, type FilterState, type FilterStore } from './urlState.t
 const GLYPH: Record<TestStatus, string> = {
   passed: '✓', failed: '✕', skipped: '⊘', todo: '◇', running: '◐', queued: '○',
 };
+/** Shown in place of ✕ for a failure the runner recorded because the test never
+ *  ran (see `isCancelled`). Not a status of its own — such a node stays failed. */
+const CANCEL_GLYPH = '⊗';
 const STATUS_ORDER: TestStatus[] = ['passed', 'failed', 'skipped', 'todo', 'running', 'queued'];
 const STATUS_LABEL: Record<TestStatus, string> = {
   passed: 'passed', failed: 'failed', skipped: 'skipped', todo: 'todo', running: 'running', queued: 'queued',
@@ -42,7 +45,7 @@ function statusTip(node: TestNode, status: TestStatus, ms: number): string | und
   const reason = reasonOf(node);
   switch (status) {
     case 'passed': return `Passed in ${formatDuration(ms) || '—'}`;
-    case 'failed': return 'Failed';
+    case 'failed': return isCancelled(node) ? 'Cancelled — did not run before its parent finished' : 'Failed';
     case 'skipped': return reason ? `Skipped — ${shortReason(reason)}` : 'Skipped';
     case 'todo': return reason ? `Todo — ${shortReason(reason)}` : 'Todo — does not fail the run';
     case 'queued': return 'Queued — waiting to run';
@@ -57,7 +60,8 @@ interface DiagBlock {
   title: string;
   icon: string;
   sev: TestStatus;
-  kind: 'error' | 'output' | 'list' | 'text';
+  /** `chip` renders as a bare labelled line — no disclosure, no toolbar. */
+  kind: 'error' | 'output' | 'list' | 'text' | 'chip';
   /** Header count (`Output · 1.9k lines`), also surfaced on the row chip. */
   count?: { n: number; unit: string };
   /** Row-chip text when it should differ from the title (e.g. the trimmed skip reason). */
@@ -160,7 +164,14 @@ function Stack({ stack }: { stack: string }) {
 function computeDiagBlocks(node: TestNode): DiagBlock[] {
   const blocks: DiagBlock[] = [];
   const error = realError(node);
-  if (error) {
+  if (error && isSubtestsRollup(node)) {
+    // "N subtests failed" says nothing a stack could add — the failing children
+    // are the rows right below — so it stays a bare label.
+    blocks.push({
+      key: 'rollup', title: 'Error', chip: error.message, icon: '✕', sev: 'failed',
+      kind: 'chip', copyText: '',
+    });
+  } else if (error) {
     const stack = error.stack ?? error.message;
     blocks.push({
       key: 'error', title: 'Error', icon: '✕', sev: 'failed', kind: 'error',
@@ -491,7 +502,13 @@ function OutputPanel({
       aria-label={`Output of ${displayName(node)}`}
       style={style}
     >
-      {blocks.map((block) => (
+      {blocks.map((block) => (block.kind === 'chip' ? (
+        // Nothing to disclose and nothing worth copying — a label, not a section.
+        <div className="diag-chip" key={block.key}>
+          <span className="diag-icon" data-stc={block.sev}>{block.icon}</span>
+          <span className="diag-chip-text">{block.chip}</span>
+        </div>
+      ) : (
         <DiagSection
           block={block}
           node={node}
@@ -499,7 +516,7 @@ function OutputPanel({
           onToggle={() => toggle(`${node.key}::diag:${block.key}`, isSectionOpen(node, block.key, overrides))}
           key={block.key}
         />
-      ))}
+      )))}
     </div>
   );
 }
@@ -585,9 +602,14 @@ function RowView({
   const counts = node.counts;
   const isTest = node.type === 'test';
   const container = isContainer(node);
-  const nameColor = isTest && status === 'failed' ? 'var(--st-failed)'
-    : isTest && (status === 'skipped' || status === 'todo' || status === 'queued') ? 'var(--dim)'
-      : 'var(--fg)';
+  // A cancelled node still counts as failed — it just never ran, so it reads
+  // muted and wears its own glyph instead of competing with the real failure
+  // above it for attention.
+  const cancelled = status === 'failed' && isCancelled(node);
+  const nameColor = isTest && cancelled ? 'var(--dim)'
+    : isTest && status === 'failed' ? 'var(--st-failed)'
+      : isTest && (status === 'skipped' || status === 'todo' || status === 'queued') ? 'var(--dim)'
+        : 'var(--fg)';
   const carried = isTest && !container && node.passedOnAttempt != null;
   const rollupMark = container && isCarried(node);
   const markAttempt = carried ? node.passedOnAttempt : rollupMark ? carriedAttempt(node) : undefined;
@@ -599,7 +621,7 @@ function RowView({
 
   const rowClass = `row${enter !== null ? ' row-enter' : ''}${settled ? ` settle-${status}` : ''}`;
   const rowStyle = enter !== null ? { animationDelay: `${Math.min(enter, 8) * 18}ms` } : undefined;
-  const hasError = hasDiag && diagBlocks(node).some((b) => b.key === 'error');
+  const hasError = hasDiag && diagBlocks(node).some((b) => b.key === 'error' || b.key === 'rollup');
   const ms = liveNodeDuration(node, now, since, clock);
   const durTip = carried || rollupMark
     ? `${formatDuration(ms) || '—'} — measured on ${markAttempt != null ? `attempt ${markAttempt + 1}` : 'an earlier attempt'}`
@@ -614,7 +636,7 @@ function RowView({
       aria-label={`${displayName(node)}, ${status}${container ? `, ${counts.total} tests` : ''}`}
       tabIndex={0}
       data-clickable={expandable}
-      data-fail={isTest && status === 'failed'}
+      data-fail={isTest && status === 'failed' && !cancelled}
       data-running={status === 'running' ? 'true' : undefined}
       onClick={expandable ? () => { if (!selectionClick()) activate(); } : undefined}
       onMouseDown={markPointerFocus}
@@ -630,7 +652,7 @@ function RowView({
       ) : (
         // One visual language for pass/fail at every level: containers and leaf
         // tests both use the status glyph (design mobile-review ruling).
-        <span className="cglyph indicator" data-stc={status} data-spin={!isTest && status === 'running' ? 'true' : undefined} data-tip={!container ? statusTip(node, status, ms) : undefined}>{GLYPH[status]}</span>
+        <span className="cglyph indicator" data-stc={cancelled ? 'cancelled' : status} data-spin={!isTest && status === 'running' ? 'true' : undefined} data-tip={!container ? statusTip(node, status, ms) : undefined}>{cancelled ? CANCEL_GLYPH : GLYPH[status]}</span>
       )}
       <span className="name" data-kind={node.type} data-tip-clipped={node.type === 'file' ? node.file ?? displayName(node) : displayName(node)} style={{ color: nameColor }}>{displayName(node)}</span>
       {hasDiag ? (

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -133,13 +133,35 @@ export function reasonOf(node: TestNode): string | undefined {
   return undefined;
 }
 
+// A test the runner cancelled before its body ever ran, per node:test's own
+// classification: the parent settled first, or the test's signal aborted. Its
+// error is a fixed sentence about the cancellation with no cause underneath.
+const CANCELLED: ReadonlySet<string> = new Set(['cancelledByParent', 'testAborted']);
+
+export function isCancelled(node: TestNode): boolean {
+  return node.error?.failureType != null && CANCELLED.has(node.error.failureType);
+}
+
+/** Node's "N subtests failed" rollup — the node's own body was fine, a child
+ *  failed. The child rows say which, so the row shows the count, not a panel. */
+export function isSubtestsRollup(node: TestNode): boolean {
+  return node.error?.failureType === 'subtestsFailed';
+}
+
 /**
  * Any error the node reported is shown — containers included. A container's
  * error can be the only place the real cause lives (a suite whose before hook
- * failed cancels its children with a generic message), so nothing is filtered.
+ * failed cancels its children with a generic message), so nothing is filtered
+ * on message text.
+ *
+ * The one exception is a cancellation, which the runner writes in place of an
+ * error the test never got to produce. It is identified structurally, by the
+ * runner's own `failureType`, so a real cause is never at risk: a failed hook
+ * reports `hookFailed` and stays fully visible, and a log written before the
+ * wire carried `failureType` keeps every error it has.
  */
 export function realError(node: TestNode): { message: string; stack?: string } | undefined {
-  return node.error;
+  return isCancelled(node) ? undefined : node.error;
 }
 
 export function hasDiagnostics(node: TestNode): boolean {

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -5,6 +5,7 @@ const DARK = `
   --row-hover:rgba(255,255,255,.04);
   --accent:#8b7cff; --accent-ink:#0c0a1f;
   --st-passed:#34d27b; --st-failed:#fb5a6a; --st-skipped:#8a93a1; --st-todo:#7c9cff; --st-running:#ffb13d; --st-queued:#5d6573;
+  --st-cancelled:#8a93a1;
   --soft-passed:rgba(52,210,123,.15); --soft-failed:rgba(251,90,106,.16); --soft-skipped:rgba(138,147,161,.16); --soft-todo:rgba(124,156,255,.16); --soft-running:rgba(255,177,61,.17); --soft-queued:rgba(93,101,115,.18);
   --fail-tint:rgba(251,90,106,.07);
   --carry-fg:#a2a9b5; --carry-bg:rgba(255,255,255,.06); --carry-border:rgba(255,255,255,.14);
@@ -21,6 +22,7 @@ const LIGHT = `
   --row-hover:rgba(17,24,33,.035);
   --accent:#6357e6; --accent-ink:#ffffff;
   --st-passed:#16a34a; --st-failed:#e23744; --st-skipped:#697381; --st-todo:#3f63d6; --st-running:#bf7400; --st-queued:#97a0ad;
+  --st-cancelled:#697381;
   --soft-passed:rgba(22,163,74,.12); --soft-failed:rgba(226,55,68,.10); --soft-skipped:rgba(105,115,129,.12); --soft-todo:rgba(63,99,214,.11); --soft-running:rgba(191,116,0,.13); --soft-queued:rgba(151,160,173,.14);
   --fail-tint:rgba(226,55,68,.05);
   --carry-fg:#586170; --carry-bg:rgba(17,24,33,.05); --carry-border:rgba(17,24,33,.14);
@@ -58,7 +60,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 ::-webkit-scrollbar-track { background: transparent; }
 
 /* status color helpers */
-[data-stc="passed"]{color:var(--st-passed)} [data-stc="failed"]{color:var(--st-failed)} [data-stc="skipped"]{color:var(--st-skipped)} [data-stc="todo"]{color:var(--st-todo)} [data-stc="running"]{color:var(--st-running)} [data-stc="queued"]{color:var(--st-queued)}
+[data-stc="passed"]{color:var(--st-passed)} [data-stc="failed"]{color:var(--st-failed)} [data-stc="skipped"]{color:var(--st-skipped)} [data-stc="todo"]{color:var(--st-todo)} [data-stc="running"]{color:var(--st-running)} [data-stc="queued"]{color:var(--st-queued)} [data-stc="cancelled"]{color:var(--st-cancelled)}
 [data-stf="passed"]{background:var(--st-passed)} [data-stf="failed"]{background:var(--st-failed)} [data-stf="skipped"]{background:var(--st-skipped)} [data-stf="todo"]{background:var(--st-todo)} [data-stf="running"]{background:var(--st-running)} [data-stf="queued"]{background:var(--st-queued)}
 [data-soft="passed"]{background:var(--soft-passed);color:var(--st-passed)} [data-soft="failed"]{background:var(--soft-failed);color:var(--st-failed)} [data-soft="skipped"]{background:var(--soft-skipped);color:var(--st-skipped)} [data-soft="todo"]{background:var(--soft-todo);color:var(--st-todo)} [data-soft="running"]{background:var(--soft-running);color:var(--st-running)} [data-soft="queued"]{background:var(--soft-queued);color:var(--st-queued)}
 
@@ -188,6 +190,8 @@ button { font-family: inherit; } input { font-family: inherit; }
 .diag-head:hover { background: var(--raise); }
 .diag-icon { font-weight: 800; font-size: 12px; }
 .diag-title { font-size: 11px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--dim); }
+.diag-chip { display: flex; align-items: center; gap: 7px; padding: 5px 13px 5px 6px; background: var(--panel-2); }
+.diag-chip-text { font-size: 11.5px; font-weight: 600; color: var(--dim); }
 .diag-count { font-size: 10.5px; font-weight: 600; color: var(--faint); font-variant-numeric: tabular-nums; }
 .diag-tools { margin-left: auto; display: flex; gap: 6px; align-items: center; }
 .hbtn { background: transparent; border: 1px solid var(--line); color: var(--dim); border-radius: 7px; padding: 2px 8px; font-size: 10.5px; font-weight: 600; cursor: pointer; transition: background .13s, color .13s; }

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -4,7 +4,7 @@ import { createTreeStore } from '@reporters/tree-core';
 import type { Counts, TestEvent, TestNode } from '@reporters/tree-core';
 import {
   buildRows, collectContainerKeys, computeMatches, displayName, hasDiagnostics,
-  isExpanded, isPassingTodo, isSectionOpen, liveNodeDuration, nodeDuration, reasonOf, realError, rollup,
+  isCancelled, isExpanded, isPassingTodo, isSectionOpen, isSubtestsRollup, liveNodeDuration, nodeDuration, reasonOf, realError, rollup,
 } from '../src/client/rowModel.ts';
 
 const zeroCounts = (): Counts => ({
@@ -224,6 +224,42 @@ test('realError shows every recorded error — leaves, containers, and rollups a
   assert.strictEqual(realError(container), containerError);
   // a leaf with no error has none
   assert.strictEqual(realError(node()), undefined);
+});
+
+test('realError drops a cancellation — the runner wrote it, the test never ran', () => {
+  for (const failureType of ['cancelledByParent', 'testAborted']) {
+    const cancelled = node({
+      error: { message: 'test did not finish before its parent and was cancelled', failureType },
+    });
+    assert.ok(isCancelled(cancelled), `${failureType} reads as cancelled`);
+    assert.strictEqual(realError(cancelled), undefined);
+    assert.strictEqual(hasDiagnostics(cancelled), false, 'nothing left to expand');
+  }
+});
+
+test('realError keeps every failure the test actually produced', () => {
+  // The rollup is kept — the viewer renders it as a chip rather than a panel.
+  const rollup = { message: '3 subtests failed', failureType: 'subtestsFailed' };
+  assert.strictEqual(realError(node({ error: rollup })), rollup);
+  assert.ok(isSubtestsRollup(node({ error: rollup })));
+  // A failed before hook is the case that made suppression a bug: it holds the
+  // only real cause while its children carry the generic cancellation text.
+  const hook = { message: 'HTTP-Code: 401 Unauthorized', failureType: 'hookFailed' };
+  assert.strictEqual(realError(node({ error: hook })), hook);
+  assert.ok(!isCancelled(node({ error: hook })));
+  const code = { message: 'expected 3 to equal 4', failureType: 'testCodeFailure' };
+  assert.strictEqual(realError(node({ error: code })), code);
+});
+
+test('an unannotated error is never dropped — old logs carry no failureType', () => {
+  // Matching the message text instead would suppress these; only the runner's
+  // own classification may hide anything.
+  for (const message of ['3 subtests failed', 'test did not finish before its parent and was cancelled']) {
+    const legacy = node({ error: { message } });
+    assert.strictEqual(isCancelled(legacy), false);
+    assert.strictEqual(isSubtestsRollup(legacy), false);
+    assert.deepStrictEqual(realError(legacy), { message });
+  }
 });
 
 test('hasDiagnostics sees a container error', () => {

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -220,3 +220,59 @@ test('a warn payload level drives the item severity', async () => {
   );
   await act(async () => root.unmount());
 });
+
+/** The shape of your everyday cascade: a suite whose before hook blew up, a
+ *  failing test with a real stack, and children the runner cancelled. */
+const CASCADE = [
+  '{"type":"test:start","data":{"name":"EKS Namespace","nesting":0,"file":"eks.test.js","testId":1}}',
+  '{"type":"test:start","data":{"name":"with S3 vault","nesting":1,"file":"eks.test.js","testId":2,"parentId":1}}',
+  '{"type":"test:fail","data":{"name":"with S3 vault","nesting":1,"file":"eks.test.js","testId":2,"parentId":1,"details":{"duration_ms":0,"error":{"message":"test did not finish before its parent and was cancelled","failureType":"cancelledByParent","code":"ERR_TEST_FAILURE"}}}}',
+  '{"type":"test:start","data":{"name":"discovers pg","nesting":1,"file":"eks.test.js","testId":3,"parentId":1}}',
+  '{"type":"test:fail","data":{"name":"discovers pg","nesting":1,"file":"eks.test.js","testId":3,"parentId":1,"details":{"duration_ms":4,"error":{"message":"expected 3 to equal 4","stack":"AssertionError: expected 3 to equal 4\\n    at eks.test.js:12:3","failureType":"testCodeFailure","code":"ERR_TEST_FAILURE"}}}}',
+  '{"type":"test:fail","data":{"name":"EKS Namespace","nesting":0,"file":"eks.test.js","testId":1,"details":{"duration_ms":9,"error":{"message":"2 subtests failed","failureType":"subtestsFailed","code":"ERR_TEST_FAILURE"}}}}',
+].join('\n');
+
+async function renderCascade() {
+  const { fetchImpl } = fakeSource(`${CASCADE}\n`);
+  const { root, el } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filterState: memoryFilterState() }));
+  });
+  await tick(20);
+  return { root, el };
+}
+
+const rowOf = (el: HTMLElement, name: string) => [...el.querySelectorAll('.row')]
+  .find((n) => n.getAttribute('aria-label')!.startsWith(`${name},`)) as HTMLElement;
+
+test('a cancelled test renders muted, with no error panel to expand', async () => {
+  const { root, el } = await renderCascade();
+  const row = rowOf(el, 'with S3 vault');
+  const glyph = row.querySelector('.cglyph')!;
+  assert.strictEqual(glyph.textContent, '⊗', 'cancelled wears its own glyph, not ✕');
+  assert.strictEqual(glyph.getAttribute('data-stc'), 'cancelled', 'and its own muted tone');
+  assert.strictEqual(row.getAttribute('data-fail'), 'false', 'no red row tint');
+  assert.strictEqual(row.getAttribute('data-clickable'), 'false', 'nothing left to disclose');
+  assert.ok(!el.textContent!.includes('did not finish before its parent'), 'the runner’s cancellation text is gone');
+  await act(async () => root.unmount());
+});
+
+test('a real failure keeps its glyph, its tint and its full stack', async () => {
+  const { root, el } = await renderCascade();
+  const row = rowOf(el, 'discovers pg');
+  assert.strictEqual(row.querySelector('.cglyph')!.textContent, '✕');
+  assert.strictEqual(row.getAttribute('data-fail'), 'true');
+  assert.ok(el.querySelector('.stack')!.textContent!.includes('at eks.test.js:12:3'), 'the stack still renders');
+  await act(async () => root.unmount());
+});
+
+test('a subtests rollup renders as a bare chip, not a panel', async () => {
+  const { root, el } = await renderCascade();
+  const chip = el.querySelector('.diag-chip') as HTMLElement;
+  assert.ok(chip, 'the rollup gets a chip');
+  assert.strictEqual(chip.querySelector('.diag-chip-text')!.textContent, '2 subtests failed');
+  assert.strictEqual(chip.querySelector('.diag-tools'), null, 'nothing to copy or open full-screen');
+  assert.ok(!el.textContent!.includes('ERROR2 subtests failed'), 'and no ERROR panel header');
+  assert.strictEqual(rowOf(el, 'EKS Namespace').querySelector('.outbadge')!.textContent, '✕');
+  await act(async () => root.unmount());
+});


### PR DESCRIPTION
Two errors `node:test` writes itself dominate a failing report without adding anything the tree isn't already showing:

- **`subtestsFailed`** — the "N subtests failed" rollup, repeated on every ancestor of a real failure. A four-deep suite chain renders four stacked ERROR panels that all say "something below me failed".
- **`cancelledByParent` / `testAborted`** — "test did not finish before its parent and was cancelled", stamped on every child of a suite that died in a hook. These tests never executed, but they render as full red failures competing with the hook error that actually explains the run.

## What changed

`serializeError` was throwing away `failureType` when it unwraps an error to its cause. It's now kept, read **off the `ERR_TEST_FAILURE` wrapper** rather than the cause — for both of these the cause is a bare string that carries nothing. `SerializedError` gains the field; nothing else in tree-core moves.

In the viewer:

| | before | after |
|---|---|---|
| `subtestsFailed` | full ERROR panel, message printed twice (no stack to fall back to) | bare chip — `✕ 2 subtests failed`, no disclosure, no toolbar |
| cancelled | red ✕, pink row tint, ERROR panel | muted `⊗`, no tint, no panel; row isn't even expandable |

Counts are untouched — a cancelled test still fails the run and still appears under the `failed` filter chip.

## On the earlier ruling

This is deliberately narrower than the message-regex suppression removed in `worktree-show-container-errors`. That version matched on error text and swallowed a suite's real cause; this one keys on the runner's own classification, so:

- a failed `before` hook reports `hookFailed` and keeps its full stack — the EKS 401 case that motivated the revert renders unchanged;
- a log written **before** the wire carried `failureType` (#265) renders exactly as it does today, verbosely. No text matching anywhere.

Both guarantees have tests.

## Verification

Full suite green (the 8 `@reporters/github` failures are pre-existing on `main`). Beyond unit and JSDOM component tests, driven in a real browser over a served NDJSON in both themes, including a `legacy.test.ts` block with the same messages and **no** `failureType` to confirm old logs are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)