### PR TITLE
feat(web): compact rows, dot leaves, and a fail chip that replaces the rollup card

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -5,7 +5,7 @@ import {
   carriedAttempt, formatDuration, formatLogPayload, isCarried, todoLabel, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
 } from '@reporters/tree-core';
 import {
-  buildRows, collectContainerKeys, computeMatches, displayName, isCancelled, isContainer, isSectionOpen, isSubtestsRollup, liveNodeDuration, reasonOf, realError, type FlatRow, type LiveClock,
+  buildRows, collectContainerKeys, computeMatches, displayName, hasFailChip, isCancelled, isContainer, isSectionOpen, liveNodeDuration, reasonOf, realError, type FlatRow, type LiveClock,
 } from './rowModel.ts';
 
 // node:test captures colored output verbatim; render the ANSI SGR codes as real
@@ -22,6 +22,7 @@ const GLYPH: Record<TestStatus, string> = {
 /** Shown in place of ✕ for a failure the runner recorded because the test never
  *  ran (see `isCancelled`). Not a status of its own — such a node stays failed. */
 const CANCEL_GLYPH = '⊗';
+export type Density = 'compact' | 'cozy';
 const STATUS_ORDER: TestStatus[] = ['passed', 'failed', 'skipped', 'todo', 'running', 'queued'];
 const STATUS_LABEL: Record<TestStatus, string> = {
   passed: 'passed', failed: 'failed', skipped: 'skipped', todo: 'todo', running: 'running', queued: 'queued',
@@ -60,8 +61,7 @@ interface DiagBlock {
   title: string;
   icon: string;
   sev: TestStatus;
-  /** `chip` renders as a bare labelled line — no disclosure, no toolbar. */
-  kind: 'error' | 'output' | 'list' | 'text' | 'chip';
+  kind: 'error' | 'output' | 'list' | 'text';
   /** Header count (`Output · 1.9k lines`), also surfaced on the row chip. */
   count?: { n: number; unit: string };
   /** Row-chip text when it should differ from the title (e.g. the trimmed skip reason). */
@@ -164,14 +164,7 @@ function Stack({ stack }: { stack: string }) {
 function computeDiagBlocks(node: TestNode): DiagBlock[] {
   const blocks: DiagBlock[] = [];
   const error = realError(node);
-  if (error && isSubtestsRollup(node)) {
-    // "N subtests failed" says nothing a stack could add — the failing children
-    // are the rows right below — so it stays a bare label.
-    blocks.push({
-      key: 'rollup', title: 'Error', chip: error.message, icon: '✕', sev: 'failed',
-      kind: 'chip', copyText: '',
-    });
-  } else if (error) {
+  if (error) {
     const stack = error.stack ?? error.message;
     blocks.push({
       key: 'error', title: 'Error', icon: '✕', sev: 'failed', kind: 'error',
@@ -502,13 +495,7 @@ function OutputPanel({
       aria-label={`Output of ${displayName(node)}`}
       style={style}
     >
-      {blocks.map((block) => (block.kind === 'chip' ? (
-        // Nothing to disclose and nothing worth copying — a label, not a section.
-        <div className="diag-chip" key={block.key}>
-          <span className="diag-icon" data-stc={block.sev}>{block.icon}</span>
-          <span className="diag-chip-text">{block.chip}</span>
-        </div>
-      ) : (
+      {blocks.map((block) => (
         <DiagSection
           block={block}
           node={node}
@@ -516,7 +503,7 @@ function OutputPanel({
           onToggle={() => toggle(`${node.key}::diag:${block.key}`, isSectionOpen(node, block.key, overrides))}
           key={block.key}
         />
-      )))}
+      ))}
     </div>
   );
 }
@@ -647,14 +634,22 @@ function RowView({
         {Array.from({ length: depth }, (_, i) => <span className="guide" key={i} />)}
       </span>
       <span className="caret" data-open={expandable && expanded ? 'true' : undefined}>{expandable ? '▸' : ''}</span>
-      {isTest && status === 'running' ? (
-        <span className="spinner indicator" />
+      {/* Two status marks, split on leaf vs container rather than node type: a
+          leaf is one result, so a dot; anything with children carries a verdict
+          over everything beneath it, so it keeps the glyph — including a
+          `test()` that nests subtests. A cancellation always takes the glyph,
+          since ⊗ is the whole point. */}
+      {!container && !cancelled ? (
+        <span className="tdot indicator" data-stf={status} data-pulse={status === 'running' ? 'true' : undefined} data-tip={!container ? statusTip(node, status, ms) : undefined} />
       ) : (
-        // One visual language for pass/fail at every level: containers and leaf
-        // tests both use the status glyph (design mobile-review ruling).
-        <span className="cglyph indicator" data-stc={cancelled ? 'cancelled' : status} data-spin={!isTest && status === 'running' ? 'true' : undefined} data-tip={!container ? statusTip(node, status, ms) : undefined}>{cancelled ? CANCEL_GLYPH : GLYPH[status]}</span>
+        <span className="cglyph indicator" data-stc={cancelled ? 'cancelled' : status} data-spin={container && status === 'running' ? 'true' : undefined} data-tip={!container ? statusTip(node, status, ms) : undefined}>{cancelled ? CANCEL_GLYPH : GLYPH[status]}</span>
       )}
       <span className="name" data-kind={node.type} data-tip-clipped={node.type === 'file' ? node.file ?? displayName(node) : displayName(node)} style={{ color: nameColor }}>{displayName(node)}</span>
+      {hasFailChip(node) ? (
+        // The rolled-up count, on the row and always visible — it replaces the
+        // runner's "N subtests failed" card that used to restate it below.
+        <span className="failchip" data-soft="failed" data-tip={`${counts.failed} failing ${counts.failed === 1 ? 'test' : 'tests'} inside`}>{counts.failed} failed</span>
+      ) : null}
       {hasDiag ? (
         // Passive badge (never a control): output exists inside this node.
         <span className="outbadge" data-stc={hasError ? 'failed' : undefined} data-tip={hasError ? 'Has error output — expand the row to view' : 'Has output — expand the row to view'}>
@@ -666,6 +661,9 @@ function RowView({
       ) : typeof node.skip === 'string' && node.skip ? (
         <span className="todotag" data-soft="skipped">⊘ {trimTag(node.skip)}</span>
       ) : null}
+      {node.tags?.map((tag) => (
+        <span className="todotag" data-soft="todo" key={tag}>{trimTag(tag)}</span>
+      ))}
       <span className="spacer" />
       {renderNodeActions ? (
         // Custom content is interactive on its own terms: clicks and keys
@@ -681,7 +679,9 @@ function RowView({
       ) : null}
       {container && !expanded ? (
         <span className="pills">
-          {STATUS_ORDER.filter((s) => (s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]) > 0).map((s) => (
+          {/* `failed` is omitted: the fail chip beside the name already carries
+              it, at every expansion state rather than only when collapsed. */}
+          {STATUS_ORDER.filter((s) => s !== 'failed' && (s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]) > 0).map((s) => (
             <span className="pill" data-soft={s} data-tip={`${s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]} ${STATUS_LABEL[s]}`} key={s}>{s === 'passed' && onlyRerun ? counts.passed - counts.carried : counts[s]}</span>
           ))}
         </span>
@@ -754,10 +754,14 @@ export interface TreeViewProps {
    *  ?status, ?rerun). Pass memoryFilterState() (or your own store) when the
    *  host app owns the address bar. Must be stable across renders. */
   filters?: FilterStore;
+  /** Row density. `compact` (the default) is built for scanning a long run;
+   *  `cozy` trades rows-per-screen for a roomier hit area. Under 640px both
+   *  give way to 40px touch rows. */
+  dense?: Density;
 }
 
 export function TreeView({
-  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions, renderHeaderActions, filters,
+  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions, renderHeaderActions, filters, dense = 'compact',
 }: TreeViewProps) {
   const [theme, toggleTheme] = useTheme();
   // The default store is per-mount so its debounce timer dies with the view.
@@ -869,7 +873,7 @@ export function TreeView({
 
   if (loadError) {
     return (
-      <div className="app">
+      <div className="app" data-dense={dense}>
         <CenteredState icon="⚠" iconStatus="failed" title="Couldn’t load the live log">
           <div className="state-sub">
             The viewer needs a <code style={{ fontFamily: 'var(--mono)', color: 'var(--st-todo)' }}>?src=</code>
@@ -890,7 +894,7 @@ export function TreeView({
   const barSegments = STATUS_ORDER.filter((s) => counts[s] > 0);
 
   return (
-    <div className="app">
+    <div className="app" data-dense={dense}>
       <header className="hdr">
         <div className="hdr-row">
           <Verdict counts={counts} inProgress={inProgress} duration={duration} />

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -148,20 +148,32 @@ export function isSubtestsRollup(node: TestNode): boolean {
   return node.error?.failureType === 'subtestsFailed';
 }
 
+/** The row carries a rolled-up `N failed` chip. Containers only: a failed leaf
+ *  counts itself, and "1 failed" beside a red test row says nothing. */
+export function hasFailChip(node: TestNode): boolean {
+  return isContainer(node) && node.counts.failed > 0;
+}
+
 /**
  * Any error the node reported is shown — containers included. A container's
  * error can be the only place the real cause lives (a suite whose before hook
  * failed cancels its children with a generic message), so nothing is filtered
  * on message text.
  *
- * The one exception is a cancellation, which the runner writes in place of an
- * error the test never got to produce. It is identified structurally, by the
- * runner's own `failureType`, so a real cause is never at risk: a failed hook
- * reports `hookFailed` and stays fully visible, and a log written before the
- * wire carried `failureType` keeps every error it has.
+ * The exceptions are the two errors the runner writes itself, both identified
+ * structurally by its own `failureType` so a real cause is never at risk:
+ *
+ *  - a cancellation, written in place of an error the test never produced;
+ *  - the "N subtests failed" rollup, but only while the row's fail chip is
+ *    there to say the same thing. No count, no chip, no suppression.
+ *
+ * A failed hook reports `hookFailed` and stays fully visible, and a log written
+ * before the wire carried `failureType` keeps every error it has.
  */
 export function realError(node: TestNode): { message: string; stack?: string } | undefined {
-  return isCancelled(node) ? undefined : node.error;
+  if (isCancelled(node)) return undefined;
+  if (isSubtestsRollup(node) && hasFailChip(node)) return undefined;
+  return node.error;
 }
 
 export function hasDiagnostics(node: TestNode): boolean {

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -6,13 +6,13 @@ import { createTreeStore, type TreeSnapshot } from '@reporters/tree-core';
 import { createNdjsonReader, DEFAULT_POLL_MS, type FetchLike } from '../poll.ts';
 import { resolveReportSource, type ViewerOptions as SourceOptions } from '../source.ts';
 import { STYLES } from '../template.ts';
-import { TreeView, type RenderHeaderActions, type RenderNodeActions } from './TreeView.tsx';
+import { TreeView, type Density, type RenderHeaderActions, type RenderNodeActions } from './TreeView.tsx';
 import { initTooltips } from './tooltip.ts';
 import type { FilterStore } from './urlState.ts';
 
 export type { ReportSource } from '../source.ts';
 export type { FetchLike } from '../poll.ts';
-export type { RenderHeaderActions, RenderNodeActions } from './TreeView.tsx';
+export type { Density, RenderHeaderActions, RenderNodeActions } from './TreeView.tsx';
 export type { TestNode } from '@reporters/tree-core';
 export { memoryFilterState, urlFilterState, type FilterState, type FilterStore } from './urlState.ts';
 
@@ -128,13 +128,15 @@ export interface TestReportViewerProps {
    *  e.g. re-run the host's own source resolution. With no `src` there is no
    *  stream to restart, so without this the retry button is hidden. */
   onRetry?: () => void;
+  /** Row density: `compact` (default) or `cozy`. */
+  dense?: Density;
 }
 
 /** The report viewer as a React component: render it anywhere in a host app.
  *  Polls `src`, live-updates until the run's summary, and stops polling on
  *  unmount. Injects its stylesheet into document.head before first paint. */
 export function TestReportViewer({
-  src, fetch: fetchImpl, pollMs = DEFAULT_POLL_MS, renderNodeActions, renderHeaderActions, filters, onRetry,
+  src, fetch: fetchImpl, pollMs = DEFAULT_POLL_MS, renderNodeActions, renderHeaderActions, filters, onRetry, dense,
 }: TestReportViewerProps) {
   useInsertionEffect(() => { injectStyles(); }, []);
   useEffect(() => { initTooltips(); }, []);
@@ -151,6 +153,7 @@ export function TestReportViewer({
       renderNodeActions={renderNodeActions}
       renderHeaderActions={renderHeaderActions}
       filters={filters}
+      dense={dense}
     />
   );
 }

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -109,7 +109,11 @@ button { font-family: inherit; } input { font-family: inherit; }
 }
 
 /* app shell */
-.app { height: 100%; display: flex; flex-direction: column; --rh: 34px; --fs: 13.5px; --ind: 20px; --diag-mr: 12px; --diag-gap: 18px; }
+.app { height: 100%; display: flex; flex-direction: column; --diag-mr: 12px; --diag-gap: 18px; }
+/* Row density. Compact is the shipping default — a real run is hundreds of
+   rows, and the tree is for scanning them. */
+.app, .app[data-dense="compact"] { --rh: 26px; --fs: 12.5px; --ind: 15px; }
+.app[data-dense="cozy"] { --rh: 34px; --fs: 13.5px; --ind: 20px; }
 .loading { flex: 1; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 13px; }
 
 /* header */
@@ -144,15 +148,17 @@ button { font-family: inherit; } input { font-family: inherit; }
 
 /* tree */
 .tree { flex: 1; overflow: auto; min-height: 0; padding: 8px 10px 28px; }
-.row { display: flex; align-items: center; gap: 8px; min-height: var(--rh); padding: 0 12px; border-radius: 9px; }
+.row { display: flex; align-items: center; gap: 8px; min-height: var(--rh); padding: 0 10px 0 12px; border-radius: 9px; }
 .row[data-clickable="true"] { cursor: pointer; }
 .row:hover { background: var(--row-hover); }
 .row[data-fail="true"] { background: var(--fail-tint); }
 .guides { display: flex; flex: none; align-self: stretch; }
 .guide { width: var(--ind); align-self: stretch; border-left: 1px solid var(--line); }
-.caret { width: 16px; flex: none; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 10px; transition: transform 160ms var(--ease-out); }
+.caret { width: 14px; flex: none; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 10px; transition: transform 160ms var(--ease-out); }
 .caret[data-open="true"] { transform: rotate(90deg); }
 .cglyph { font-size: 13px; font-weight: 700; width: 14px; flex: none; text-align: center; }
+/* A test's status mark: one result, so a dot rather than a verdict glyph. */
+.tdot { width: 9px; height: 9px; border-radius: 50%; flex: none; margin: 0 2.5px; }
 .name { font-size: var(--fs); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .name[data-kind="file"] { font-family: var(--mono); font-weight: 700; }
 .name[data-kind="suite"] { font-weight: 600; }
@@ -160,7 +166,8 @@ button { font-family: inherit; } input { font-family: inherit; }
 /* passive badge on a node row (right after the name): output exists inside
    this node — never a control */
 .outbadge { flex: none; color: var(--faint); font-size: 11px; font-weight: 700; margin-left: 2px; }
-.todotag { flex: none; font-size: 10px; font-weight: 600; border-radius: 6px; padding: 1px 6px; }
+.failchip { flex: none; font-size: 10.5px; font-weight: 700; border-radius: 6px; padding: 1px 7px; }
+.todotag { flex: none; font-size: 10.5px; font-weight: 600; border-radius: 6px; padding: 1px 7px; }
 .spacer { flex: 1; min-width: 10px; }
 .pills { display: inline-flex; gap: 5px; flex: none; margin-right: 9px; }
 .pill { font-size: 11px; font-weight: 700; border-radius: 999px; padding: 1px 8px; font-variant-numeric: tabular-nums; }
@@ -190,8 +197,6 @@ button { font-family: inherit; } input { font-family: inherit; }
 .diag-head:hover { background: var(--raise); }
 .diag-icon { font-weight: 800; font-size: 12px; }
 .diag-title { font-size: 11px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--dim); }
-.diag-chip { display: flex; align-items: center; gap: 7px; padding: 5px 13px 5px 6px; background: var(--panel-2); }
-.diag-chip-text { font-size: 11.5px; font-weight: 600; color: var(--dim); }
 .diag-count { font-size: 10.5px; font-weight: 600; color: var(--faint); font-variant-numeric: tabular-nums; }
 .diag-tools { margin-left: auto; display: flex; gap: 6px; align-items: center; }
 .hbtn { background: transparent; border: 1px solid var(--line); color: var(--dim); border-radius: 7px; padding: 2px 8px; font-size: 10.5px; font-weight: 600; cursor: pointer; transition: background .13s, color .13s; }
@@ -253,7 +258,9 @@ button { font-family: inherit; } input { font-family: inherit; }
 /* mobile (~phone widths): reclaim the indent budget, let names wrap, keep
    everything on-screen, and pad tap targets */
 @media (max-width: 640px) {
-  .app { --ind: 12px; --rh: 40px; --fs: 13px; --diag-mr: 8px; --diag-gap: 8px; }
+  /* Touch targets win over density: 40px rows at any data-dense setting, so
+     this must out-specify the .app[data-dense=…] rules above. */
+  .app, .app[data-dense] { --ind: 12px; --rh: 40px; --fs: 13px; --diag-mr: 8px; --diag-gap: 8px; }
   .guide { border-left: none; }
   .tree { padding: 6px 4px 24px; }
   .row { padding: 0 8px; gap: 6px; }

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -4,7 +4,7 @@ import { createTreeStore } from '@reporters/tree-core';
 import type { Counts, TestEvent, TestNode } from '@reporters/tree-core';
 import {
   buildRows, collectContainerKeys, computeMatches, displayName, hasDiagnostics,
-  isCancelled, isExpanded, isPassingTodo, isSectionOpen, isSubtestsRollup, liveNodeDuration, nodeDuration, reasonOf, realError, rollup,
+  hasFailChip, isCancelled, isExpanded, isPassingTodo, isSectionOpen, isSubtestsRollup, liveNodeDuration, nodeDuration, reasonOf, realError, rollup,
 } from '../src/client/rowModel.ts';
 
 const zeroCounts = (): Counts => ({
@@ -237,11 +237,21 @@ test('realError drops a cancellation — the runner wrote it, the test never ran
   }
 });
 
+test('the subtests rollup is dropped only while the fail chip replaces it', () => {
+  const error = { message: '3 subtests failed', failureType: 'subtestsFailed' };
+  const suite = node({
+    error, children: [node({ key: 'c' })], counts: { ...zeroCounts(), failed: 3, total: 3 },
+  });
+  assert.ok(isSubtestsRollup(suite) && hasFailChip(suite));
+  assert.strictEqual(realError(suite), undefined, 'the row shows "3 failed" instead');
+  // A leaf counts its own failure, so counts alone would wrongly suppress here —
+  // the chip is containers-only, and so is the suppression.
+  const leaf = node({ error, counts: { ...zeroCounts(), failed: 1, total: 1 } });
+  assert.strictEqual(hasFailChip(leaf), false, '"1 failed" beside a red test row says nothing');
+  assert.strictEqual(realError(leaf), error);
+});
+
 test('realError keeps every failure the test actually produced', () => {
-  // The rollup is kept — the viewer renders it as a chip rather than a panel.
-  const rollup = { message: '3 subtests failed', failureType: 'subtestsFailed' };
-  assert.strictEqual(realError(node({ error: rollup })), rollup);
-  assert.ok(isSubtestsRollup(node({ error: rollup })));
   // A failed before hook is the case that made suppression a bug: it holds the
   // only real cause while its children carry the generic cancellation text.
   const hook = { message: 'HTTP-Code: 401 Unauthorized', failureType: 'hookFailed' };

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -257,22 +257,42 @@ test('a cancelled test renders muted, with no error panel to expand', async () =
   await act(async () => root.unmount());
 });
 
-test('a real failure keeps its glyph, its tint and its full stack', async () => {
+test('a real failure keeps its mark, its tint and its full stack', async () => {
   const { root, el } = await renderCascade();
   const row = rowOf(el, 'discovers pg');
-  assert.strictEqual(row.querySelector('.cglyph')!.textContent, '✕');
+  assert.strictEqual(row.querySelector('.tdot')!.getAttribute('data-stf'), 'failed', 'a test is a dot, not a glyph');
   assert.strictEqual(row.getAttribute('data-fail'), 'true');
   assert.ok(el.querySelector('.stack')!.textContent!.includes('at eks.test.js:12:3'), 'the stack still renders');
   await act(async () => root.unmount());
 });
 
-test('a subtests rollup renders as a bare chip, not a panel', async () => {
+test('a suite keeps the verdict glyph its tests trade for a dot', async () => {
   const { root, el } = await renderCascade();
-  const chip = el.querySelector('.diag-chip') as HTMLElement;
-  assert.ok(chip, 'the rollup gets a chip');
-  assert.strictEqual(chip.querySelector('.diag-chip-text')!.textContent, '2 subtests failed');
-  assert.strictEqual(chip.querySelector('.diag-tools'), null, 'nothing to copy or open full-screen');
-  assert.ok(!el.textContent!.includes('ERROR2 subtests failed'), 'and no ERROR panel header');
-  assert.strictEqual(rowOf(el, 'EKS Namespace').querySelector('.outbadge')!.textContent, '✕');
+  assert.strictEqual(rowOf(el, 'EKS Namespace').querySelector('.cglyph')!.textContent, '✕');
+  assert.strictEqual(rowOf(el, 'EKS Namespace').querySelector('.tdot'), null);
+  await act(async () => root.unmount());
+});
+
+test('the subtests rollup becomes a fail chip on the row, with no panel left', async () => {
+  const { root, el } = await renderCascade();
+  const row = rowOf(el, 'EKS Namespace');
+  assert.strictEqual(row.querySelector('.failchip')!.textContent, '2 failed');
+  assert.ok(!el.textContent!.includes('2 subtests failed'), 'the runner’s wording is gone entirely');
+  assert.strictEqual(row.querySelector('.outbadge'), null, 'and nothing is left to disclose on that row');
+  await act(async () => root.unmount());
+});
+
+test('a rollup with no failing descendant to point at keeps its error', async () => {
+  // The chip is the replacement; with no count there is no chip, so suppressing
+  // would lose the only thing the node said.
+  const orphan = '{"type":"test:fail","data":{"name":"lonely","nesting":0,"file":"x.test.js","testId":9,"details":{"duration_ms":1,"error":{"message":"1 subtest failed","failureType":"subtestsFailed"}}}}';
+  const { fetchImpl } = fakeSource(`${orphan}\n`);
+  const { root, el } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filterState: memoryFilterState() }));
+  });
+  await tick(20);
+  assert.strictEqual(rowOf(el, 'lonely').querySelector('.failchip'), null, 'no chip to stand in for it');
+  assert.ok(el.textContent!.includes('1 subtest failed'), 'so the error still shows');
   await act(async () => root.unmount());
 });


### PR DESCRIPTION
First of three slices implementing the **compact run view** design handoff. This one is density and row anatomy only — nothing about *where* logs live moves yet.

Follows #281, which shrank Node's "N subtests failed" card to a one-line label. The design's answer is better, and this replaces it.

## Row anatomy

| | before | after |
|---|---|---|
| density | 34px / 13.5px / 20px indent | **26px / 12.5px / 15px**, with the old values kept as `cozy` |
| leaf status mark | verdict glyph (`✕`) | **9px dot**, pulsing while running |
| container status mark | verdict glyph | unchanged |
| rolled-up failures | `failed` pill, collapsed containers only | **`N failed` chip** beside the name, always |
| `test()` tags | never rendered | todo-toned chips |

The dot/glyph split is on **leaf vs container**, not node type — a `test()` with subtests is a container and keeps the glyph. Density is a `dense` prop on `TreeView` / `TestReportViewer` (`compact` | `cozy`); under 640px both still yield to 40px touch rows.

## The rollup card is now fully gone

With `N failed` on the row, #281's label is redundant — so it's deleted and `realError` drops the `subtestsFailed` error outright.

**But only while the chip is actually there.** The chip is containers-only: a failed *leaf* counts itself, so `counts.failed > 0` is true for every red test row, and "1 failed" next to one says nothing. The suppression uses the same `hasFailChip()` predicate the chip does, which makes the invariant literal — no chip, no suppression, so a rollup with no failing descendant to point at still shows its error. There's a test for exactly that case; it's what caught the leaf bug during review.

Unchanged from #281: `hookFailed` keeps its full stack, cancellations keep `⊗`, and logs without `failureType` render verbosely.

## Verification

134 web tests pass; lint clean. Driven in a real browser over a served NDJSON — the five-deep RDS rollup chain that was five stacked ERROR panels is now five 26px rows, and the density switch was checked by reading computed `--rh` in both settings.

Deliberately **not** in this PR: the logs popup and message button (slice 2), the inline error preview and header/progress/footer respec (slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)