### PR TITLE
feat(web): move logs out of the tree and into a popup

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -5,7 +5,7 @@ import {
   carriedAttempt, formatDuration, formatLogPayload, isCarried, todoLabel, type Counts, type TestNode, type TestStatus, type TreeSnapshot,
 } from '@reporters/tree-core';
 import {
-  buildRows, collectContainerKeys, computeMatches, displayName, hasFailChip, isCancelled, isContainer, isSectionOpen, liveNodeDuration, reasonOf, realError, type FlatRow, type LiveClock,
+  buildRows, collectContainerKeys, computeMatches, displayName, findNode, hasFailChip, isCancelled, isContainer, liveNodeDuration, logCount, outputLines, reasonOf, realError, rollup, type FlatRow, type LiveClock, type OutLine,
 } from './rowModel.ts';
 
 // node:test captures colored output verbatim; render the ANSI SGR codes as real
@@ -23,6 +23,8 @@ const GLYPH: Record<TestStatus, string> = {
  *  ran (see `isCancelled`). Not a status of its own — such a node stays failed. */
 const CANCEL_GLYPH = '⊗';
 export type Density = 'compact' | 'cozy';
+/** Popup tabs, in fallback order: a node with no error opens on Output. */
+type TabKey = 'error' | 'output' | 'diag';
 const STATUS_ORDER: TestStatus[] = ['passed', 'failed', 'skipped', 'todo', 'running', 'queued'];
 const STATUS_LABEL: Record<TestStatus, string> = {
   passed: 'passed', failed: 'failed', skipped: 'skipped', todo: 'todo', running: 'running', queued: 'queued',
@@ -54,39 +56,18 @@ function statusTip(node: TestNode, status: TestStatus, ms: number): string | und
   }
 }
 
-interface OutLine { stream: 'out' | 'err'; text: string; }
-
-interface DiagBlock {
-  key: string;
-  title: string;
-  icon: string;
-  sev: TestStatus;
-  kind: 'error' | 'output' | 'list' | 'text';
-  /** Header count (`Output · 1.9k lines`), also surfaced on the row chip. */
-  count?: { n: number; unit: string };
-  /** Row-chip text when it should differ from the title (e.g. the trimmed skip reason). */
-  chip?: string;
-  /** ANSI-stripped plain text for the Copy button. */
+/** One tab of the logs popup. `count` is what the tab strip shows, and the
+ *  three of them sum to the row button's count by construction. */
+interface LogTab {
+  key: TabKey;
+  label: string;
+  count: number;
+  /** ANSI-stripped plain text for Copy. */
   copyText: string;
   message?: string;
   stack?: string;
-  text?: string;
   lines?: OutLine[];
   items?: { level: string; sev: TestStatus; text: string; payload?: string }[];
-}
-
-/** stdout + stderr merged into one line list, stream-tagged (ANSI kept — the
- *  renderer colors it). */
-function outputLines(node: TestNode): OutLine[] {
-  const lines: OutLine[] = [];
-  const add = (chunks: string[], stream: 'out' | 'err'): void => {
-    if (chunks.length === 0) return;
-    for (const line of chunks.join('').split('\n')) lines.push({ stream, text: line });
-  };
-  add(node.stdout, 'out');
-  add(node.stderr, 'err');
-  while (lines.length > 0 && lines[lines.length - 1].text === '') lines.pop();
-  return lines;
 }
 
 function linkifyDom(rootEl: HTMLElement): void {
@@ -158,29 +139,53 @@ function Stack({ stack }: { stack: string }) {
   );
 }
 
-// At most three sections per test — Error, Output, Diagnostics (plus a reason
-// for skipped/todo). stdout+stderr collapse into one Output block; text keeps
-// its ANSI (colored at render); synthetic container rollups never render an Error.
-function computeDiagBlocks(node: TestNode): DiagBlock[] {
-  const blocks: DiagBlock[] = [];
+/**
+ * The stack minus its "Name: message" preamble. Node builds `err.stack` by
+ * prefixing the message to the frames, so rendering the headline and the stack
+ * verbatim says the same sentence twice — the duplication that made the old
+ * error card twice as tall as it needed to be. Only the preamble goes, and only
+ * when frames remain to show; anything that isn't recognisably the message is
+ * left exactly as it arrived.
+ */
+function stackBody(stack: string, message: string): string {
+  const lines = stack.split('\n');
+  const firstFrame = lines.findIndex((l) => /^\s+at\s/.test(l));
+  const plain = stripAnsi(message).trim();
+  if (firstFrame > 0 && stripAnsi(lines.slice(0, firstFrame).join('\n')).trim().endsWith(plain)) {
+    return lines.slice(firstFrame).join('\n');
+  }
+  // No frames at all (a synthetic error whose "stack" is just its message):
+  // the headline already said it.
+  return stripAnsi(stack).trim() === plain ? '' : stack;
+}
+
+// Three tabs at most — Error, Output, Messages — in that order, which is also
+// the order the popup falls back through. A tab with nothing in it is not
+// rendered at all. The skip/todo reason is not here: it lives on the row chip.
+function computeLogTabs(node: TestNode): LogTab[] {
+  const tabs: LogTab[] = [];
   const error = realError(node);
   if (error) {
-    const stack = error.stack ?? error.message;
-    blocks.push({
-      key: 'error', title: 'Error', icon: '✕', sev: 'failed', kind: 'error',
-      message: error.message, stack, copyText: stripAnsi(stack),
+    const stack = error.stack ?? '';
+    tabs.push({
+      key: 'error',
+      label: 'Error',
+      count: 1,
+      message: error.message,
+      stack: stack === '' ? '' : stackBody(stack, error.message),
+      // Copy hands over the whole error as the runner wrote it, preamble included.
+      copyText: stripAnsi(stack === '' ? error.message : stack),
     });
   }
   const lines = outputLines(node);
   if (lines.length > 0) {
-    blocks.push({
-      key: 'output', title: 'Output', icon: '›', sev: 'skipped', kind: 'output', lines,
-      count: { n: lines.length, unit: lines.length === 1 ? 'line' : 'lines' },
+    tabs.push({
+      key: 'output', label: 'Output', count: lines.length, lines,
       copyText: stripAnsi(lines.map((l) => l.text).join('\n')),
     });
   }
   if (node.messages.length > 0) {
-    // Diagnostics and logs share one block in arrival order — which is execution
+    // Diagnostics and logs share one tab in arrival order — which is execution
     // order, since logs arrive live while diagnostics arrive buffered.
     const items = node.messages.map((m) => {
       const level = extractLevel(m.message) ?? m.level;
@@ -189,33 +194,21 @@ function computeDiagBlocks(node: TestNode): DiagBlock[] {
         level, sev: levelSeverity(level), text: m.message, ...(payload === '' ? {} : { payload }),
       };
     });
-    const sev: TestStatus = items.some((i) => i.sev === 'failed') ? 'failed'
-      : items.some((i) => i.sev === 'running') ? 'running' : 'skipped';
-    blocks.push({
-      key: 'diag', title: 'Messages', icon: '◇', sev, kind: 'list', items,
+    tabs.push({
+      key: 'diag', label: 'Messages', count: items.length, items,
       copyText: stripAnsi(items.map((i) => (i.payload == null ? i.text : `${i.text} ${i.payload}`)).join('\n')),
     });
   }
-  const reason = reasonOf(node);
-  if (reason) {
-    const plain = stripAnsi(reason).replace(/\s+/g, ' ').trim();
-    const label = `${node.status === 'skipped' ? 'Skipped' : 'Todo'}: ${plain}`;
-    blocks.push({
-      key: 'reason', title: node.status === 'skipped' ? 'why skipped' : 'why todo',
-      chip: label.length > 40 ? `${label.slice(0, 39)}…` : label,
-      icon: '⊘', sev: 'skipped', kind: 'text', text: reason, copyText: stripAnsi(reason),
-    });
-  }
-  return blocks;
+  return tabs;
 }
 
-// Blocks are needed by both the row chips and the open panel; splitting a huge
-// log into lines twice per render would hurt, so cache per snapshot node.
-const blocksCache = new WeakMap<TestNode, DiagBlock[]>();
-function diagBlocks(node: TestNode): DiagBlock[] {
-  let blocks = blocksCache.get(node);
-  if (!blocks) { blocks = computeDiagBlocks(node); blocksCache.set(node, blocks); }
-  return blocks;
+// Both the row button and the popup ask for these on every render, and a live
+// run re-renders 4×/s — splitting a 2k-line log that often would hurt.
+const tabsCache = new WeakMap<TestNode, LogTab[]>();
+function logTabs(node: TestNode): LogTab[] {
+  let tabs = tabsCache.get(node);
+  if (!tabs) { tabs = computeLogTabs(node); tabsCache.set(node, tabs); }
+  return tabs;
 }
 
 function computeTheme(): 'dark' | 'light' {
@@ -264,6 +257,12 @@ const ThemeIcon = ({ theme }: { theme: 'dark' | 'light' }) => (theme === 'dark' 
   </svg>
 ));
 
+const MessageIcon = () => (
+  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round">
+    <path d="M21 15a2 2 0 0 1-2 2H8l-4 4V5a2 2 0 0 1 2-2h13a2 2 0 0 1 2 2z" />
+  </svg>
+);
+
 const SearchIcon = () => (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2">
     <circle cx="11" cy="11" r="7" />
@@ -278,233 +277,148 @@ const CarryIcon = () => (
   </svg>
 );
 
-function BlockContent({ block }: { block: DiagBlock }) {
-  return (
-    <>
-      {block.kind === 'error' ? (
-        <>
-          <div className="diag-msg" data-stc="failed"><Ansi text={block.message!} /></div>
-          <Stack stack={block.stack!} />
-        </>
-      ) : null}
-      {block.kind === 'output' ? (
-        <div className="out">
-          {block.lines!.map((line, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <div className="out-line" data-err={line.stream === 'err' ? 'true' : undefined} key={i}>
-              <Ansi text={line.text === '' ? ' ' : line.text} />
-            </div>
-          ))}
-        </div>
-      ) : null}
-      {block.kind === 'text' ? (
-        <pre className="text"><Ansi text={block.text!} /></pre>
-      ) : null}
-      {block.kind === 'list' ? (
-        <div className="diag-list">
-          {block.items!.map((item, i) => (
-            // eslint-disable-next-line react/no-array-index-key
-            <div className="diag-item" key={i}>
-              <span className="diag-level" data-soft={item.sev}>{item.level}</span>
-              <span className="txt">
-                <Ansi text={item.text} />
-                {item.payload != null ? <span className="diag-payload">{item.payload}</span> : null}
-              </span>
-            </div>
-          ))}
-        </div>
-      ) : null}
-    </>
-  );
-}
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  const copy = () => {
-    void navigator.clipboard?.writeText(text).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1200);
-    });
-  };
-  return (
-    <button type="button" className="hbtn" onClick={copy} data-tip="Copy to clipboard" aria-label="Copy to clipboard">
-      {copied ? '✓' : '⧉'}
-      <span className="hbtn-label">{copied ? ' Copied' : ' Copy'}</span>
-    </button>
-  );
-}
-
-/** One section: sticky header with controls above the capped scroll region
- *  (§10a). A settled log opens at the top — logs read top-to-bottom; only a
- *  still-running log tail-follows, and stops the moment the reader scrolls up
- *  or the test settles (§11a). */
-/** One boxed panel section (design demo): its header is the disclosure for
- *  just this section — caret + name on the left, the toolbar on the right —
- *  and the capped log body collapses beneath it. */
-function DiagSection({
-  block, node, open, onToggle,
-}: {
-  block: DiagBlock; node: TestNode; open: boolean; onToggle: () => void;
-}) {
-  const [modal, setModal] = useState(false);
-  const bodyRef = useRef<HTMLDivElement>(null);
-  const pinned = useRef(false);
-  // Lazy-mount the body, but keep it once opened so collapse animates and
-  // scroll survives.
-  const everOpen = useRef(open);
-  if (open) everOpen.current = true;
-  const running = node.status === 'running';
-  useEffect(() => {
-    const el = bodyRef.current;
-    if (!el || !running || !open) return;
-    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
-    if (!pinned.current || nearBottom) { el.scrollTop = el.scrollHeight; pinned.current = true; }
-  });
-  const jump = (toEnd: boolean) => {
-    const el = bodyRef.current;
-    if (el) el.scrollTop = toEnd ? el.scrollHeight : 0;
-  };
-  const long = (block.lines?.length ?? block.items?.length ?? 0) > 20;
-  return (
-    <div className="diag-sec" data-open={open ? 'true' : undefined}>
-      <span className="diag-bar" data-stf={block.sev} />
-      <div className="diag-body">
-        <div
-          className="diag-head"
-          role="button"
-          tabIndex={0}
-          aria-expanded={open}
-          aria-label={`${open ? 'Hide' : 'Show'} ${block.title.toLowerCase()} of ${displayName(node)}`}
-          onClick={() => { if (!selectionClick()) onToggle(); }}
-          onMouseDown={markPointerFocus}
-          onBlur={clearPointerFocus}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onToggle(); }
-            else if (e.key === 'ArrowRight' && !open) { e.preventDefault(); onToggle(); }
-            else if (e.key === 'ArrowLeft' && open) { e.preventDefault(); onToggle(); }
-          }}
-        >
-          <span className="caret" data-open={open ? 'true' : undefined}>▸</span>
-          <span className="diag-icon" data-stc={block.sev}>{block.icon}</span>
-          <span className="diag-title">{block.chip ?? block.title}</span>
-          {block.count ? <span className="diag-count">· {formatCount(block.count.n)} {block.count.unit}</span> : null}
-          <div
-            className="diag-tools"
-            // Toolbar clicks act on the section, never toggle it.
-            // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-            onClick={(e) => e.stopPropagation()}
-          >
-            {open && long ? (
-              <>
-                <button type="button" className="hbtn" onClick={() => jump(false)} data-tip="Jump to top" aria-label="Jump to top">⤒</button>
-                <button type="button" className="hbtn" onClick={() => jump(true)} data-tip="Jump to end" aria-label="Jump to end">⤓</button>
-              </>
-            ) : null}
-            <CopyButton text={block.copyText} />
-            <button type="button" className="hbtn" onClick={() => setModal(true)} data-tip="Open full log" aria-label="Open full log">⤢<span className="hbtn-label"> Full log</span></button>
-            {open ? (
-              <button type="button" className="hbtn hbtn-collapse" onClick={onToggle} data-tip="Collapse this section">Collapse</button>
-            ) : null}
+function TabBody({ tab, wrap }: { tab: LogTab; wrap: boolean }) {
+  if (tab.key === 'error') {
+    return (
+      <>
+        {/* The message appears once — the headline. The stack below is the
+            stack, not a re-print of the message. */}
+        <div className="pop-msg" data-stc="failed"><Ansi text={tab.message!} /></div>
+        {tab.stack !== '' ? (
+          <pre className="stack" data-wrap={wrap ? 'true' : undefined}><Ansi text={tab.stack!} /></pre>
+        ) : null}
+      </>
+    );
+  }
+  if (tab.key === 'output') {
+    return (
+      <div className="out" data-wrap={wrap ? 'true' : undefined}>
+        {tab.lines!.map((line, i) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <div className="out-line" data-err={line.stream === 'err' ? 'true' : undefined} key={i}>
+            <Ansi text={line.text === '' ? ' ' : line.text} />
           </div>
-        </div>
-        <div className={`collapsible${open ? ' open' : ''}`}>
-          <div className="inner">
-            {everOpen.current ? (
-              <div className="log-body" ref={bodyRef}><BlockContent block={block} /></div>
-            ) : null}
-          </div>
-        </div>
+        ))}
       </div>
-      {modal ? (
-        <LogModal title={`${block.title} — ${displayName(node)}`} block={block} onClose={() => setModal(false)} />
-      ) : null}
+    );
+  }
+  return (
+    <div className="diag-list" data-wrap={wrap ? 'true' : undefined}>
+      {tab.items!.map((item, i) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <div className="diag-item" key={i}>
+          <span className="diag-level" data-soft={item.sev}>{item.level}</span>
+          <span className="txt">
+            <Ansi text={item.text} />
+            {item.payload != null ? <span className="diag-payload">{item.payload}</span> : null}
+          </span>
+        </div>
+      ))}
     </div>
   );
 }
 
-function LogModal({ title, block, onClose }: { title: string; block: DiagBlock; onClose: () => void }) {
-  // Lines stay whole by default — the modal exists for room; wrapping is opt-in
-  // (§11b) — except on a phone, where horizontal-scrolling a stack trace is
-  // worse than wrapped lines, so Wrap starts on.
+/** The breadcrumb under the popup title: every ancestor that names something,
+ *  outermost first. The root carries no name of its own. */
+function nodePath(node: TestNode): string[] {
+  return [...node.ancestors(), node].filter((n) => n.type !== 'root').map(displayName);
+}
+
+/**
+ * One node's logs, over the tree. Modal by design: a scrim, Escape, a focus
+ * trap, and focus returned to the button that opened it. It holds no copy of
+ * the node — the caller re-reads it from the newest snapshot every poll, so a
+ * running test's output streams into the open dialog.
+ */
+function LogsPopup({
+  node, tabs, tab, onTab, onClose, running,
+}: {
+  node: TestNode;
+  tabs: LogTab[];
+  tab: TabKey;
+  onTab: (key: TabKey) => void;
+  onClose: () => void;
+  running: boolean;
+}) {
   const [wrap, setWrap] = useState(() => window.matchMedia?.('(max-width: 640px)').matches ?? false);
+  const [copied, setCopied] = useState(false);
   const boxRef = useRef<HTMLDivElement>(null);
+  const bodyRef = useRef<HTMLDivElement>(null);
+  const pinned = useRef(false);
+  const active = tabs.find((t) => t.key === tab) ?? tabs[0];
+
+  useEffect(() => { boxRef.current?.focus(); }, []);
+  // Copy's label belongs to what is on screen; a tab or node change stales it.
+  useEffect(() => { setCopied(false); pinned.current = false; }, [tab, node.key]);
+  // A still-running log tail-follows, and stops the moment the reader scrolls up.
   useEffect(() => {
-    const prev = document.activeElement as HTMLElement | null;
-    boxRef.current?.focus();
-    return () => prev?.focus?.();
-  }, []);
+    const el = bodyRef.current;
+    if (!el || !running) return;
+    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+    if (!pinned.current || nearBottom) { el.scrollTop = el.scrollHeight; pinned.current = true; }
+  });
+
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Escape') { e.stopPropagation(); onClose(); return; }
     if (e.key !== 'Tab') return;
-    const focusables = boxRef.current?.querySelectorAll<HTMLElement>('button, a[href], input');
+    const focusables = boxRef.current?.querySelectorAll<HTMLElement>('button, a[href]');
     if (!focusables || focusables.length === 0) return;
     const first = focusables[0];
     const last = focusables[focusables.length - 1];
     if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
     else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
   };
+
+  const copy = () => {
+    void navigator.clipboard?.writeText(active.copyText).then(() => setCopied(true));
+  };
+
+  const status = rollup(node);
+  const path = nodePath(node);
   return (
-    // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-    <div className="modal-backdrop" onClick={onClose}>
+    <>
+      {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
+      <div className="scrim" onClick={onClose} />
       <div
-        className={`modal${wrap ? ' wrap' : ''}`}
+        className="pop"
         role="dialog"
         aria-modal="true"
-        aria-label={title}
+        aria-label={`Logs for ${displayName(node)}`}
         ref={boxRef}
         tabIndex={-1}
-        onClick={(e) => e.stopPropagation()}
         onKeyDown={onKeyDown}
       >
-        <div className="modal-head">
-          <span className="diag-icon" data-stc={block.sev}>{block.icon}</span>
-          <span className="modal-title">{title}</span>
-          {block.count ? <span className="diag-count">{formatCount(block.count.n)} {block.count.unit}</span> : null}
-          <div className="diag-tools">
-            <CopyButton text={block.copyText} />
-            <button type="button" className="hbtn" data-on={wrap ? 'true' : undefined} onClick={() => setWrap(!wrap)} data-tip="Toggle line wrapping">Wrap</button>
-            <button type="button" className="hbtn" onClick={onClose} aria-label="Close">✕</button>
+        <div className="pop-head">
+          <span className="pop-badge" data-soft={status}>{GLYPH[status]}</span>
+          <div className="pop-heading">
+            <div className="pop-title">{displayName(node)}</div>
+            <div className="pop-path">{path.join(' › ')}</div>
+          </div>
+          <div className="pop-tools">
+            <button type="button" className="pbtn" onClick={copy}>{copied ? 'Copied' : 'Copy'}</button>
+            <button type="button" className="pbtn" data-on={wrap ? 'true' : undefined} onClick={() => setWrap(!wrap)}>Wrap</button>
+            <button type="button" className="pbtn pbtn-x" onClick={onClose} aria-label="Close">✕</button>
           </div>
         </div>
-        <div className="modal-body"><BlockContent block={block} /></div>
+        <div className="pop-tabs" role="tablist">
+          {tabs.map((t) => (
+            <button
+              type="button"
+              className="pop-tab"
+              role="tab"
+              aria-selected={t.key === active.key}
+              data-on={t.key === active.key ? 'true' : undefined}
+              onClick={() => onTab(t.key)}
+              key={t.key}
+            >
+              {t.label}
+              <span className="pop-tab-n">{formatCount(t.count)}</span>
+            </button>
+          ))}
+        </div>
+        <div className="pop-body" ref={bodyRef}><TabBody tab={active} wrap={wrap} /></div>
       </div>
-    </div>
-  );
-}
-
-/** A node's own-output region (design demo): a stack of boxed, independently
- *  collapsible panel sections — a panel, never a tree node. */
-function OutputPanel({
-  row, overrides, toggle, enter,
-}: {
-  row: FlatRow;
-  overrides: Map<string, boolean>;
-  toggle: (key: string, current: boolean) => void;
-  enter: number | null;
-}) {
-  const { node, depth } = row;
-  const blocks = diagBlocks(node);
-  const style: React.CSSProperties = {
-    margin: `4px var(--diag-mr) 7px calc(${depth} * var(--ind) + var(--diag-gap))`,
-    ...(enter !== null ? { animationDelay: `${Math.min(enter, 8) * 18}ms` } : {}),
-  };
-  return (
-    <div
-      className={`diag${enter !== null ? ' row-enter' : ''}`}
-      role="group"
-      aria-label={`Output of ${displayName(node)}`}
-      style={style}
-    >
-      {blocks.map((block) => (
-        <DiagSection
-          block={block}
-          node={node}
-          open={isSectionOpen(node, block.key, overrides)}
-          onToggle={() => toggle(`${node.key}::diag:${block.key}`, isSectionOpen(node, block.key, overrides))}
-          key={block.key}
-        />
-      ))}
-    </div>
+    </>
   );
 }
 
@@ -542,8 +456,6 @@ const selectionClick = (): boolean => {
 
 /** Stable identity for enter-animation bookkeeping and React keys — a node row
  *  and its nested output row share a node but are distinct rows. */
-const rowKey = (row: FlatRow): string => (row.kind === 'output' ? `${row.node.key}::out` : row.node.key);
-
 /** Embedder hook: render custom trailing content (e.g. action buttons) for a
  *  tree row. Called for every node — containers and tests alike — on every
  *  render, so it must be cheap; return null to render nothing for a node. */
@@ -568,18 +480,25 @@ interface RowViewProps {
   /** The only-re-run filter is active (collapsed pills show re-run counts). */
   onlyRerun: boolean;
   renderNodeActions?: RenderNodeActions;
+  /** Open this node's logs popup, on its first available tab. */
+  openLogs: (node: TestNode) => void;
+  /** This row's logs are the ones currently open. */
+  selected: boolean;
 }
 
 function RowView({
-  row, toggle, enter, now, since, clock, carriedRun, onlyRerun, renderNodeActions,
+  row, toggle, enter, now, since, clock, carriedRun, onlyRerun, renderNodeActions, openLogs, selected,
 }: RowViewProps) {
   const {
     node, depth, status, expandable, expanded, hasDiag,
   } = row;
   const settled = useSettle(status);
-  // One disclosure per row: expanding reveals the node's region (its own
-  // output header first, then children). Same gesture for every node type.
-  const activate = () => { if (expandable) toggle(node.key, expanded); };
+  // A container's row is its disclosure; a leaf has nothing to disclose, so its
+  // row opens its logs instead. Either way one gesture, one meaning per row.
+  const activate = () => {
+    if (expandable) toggle(node.key, expanded);
+    else if (hasDiag) openLogs(node);
+  };
   const onKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); activate(); }
     else if (e.key === 'ArrowRight' && expandable && !expanded) { e.preventDefault(); activate(); }
@@ -608,7 +527,7 @@ function RowView({
 
   const rowClass = `row${enter !== null ? ' row-enter' : ''}${settled ? ` settle-${status}` : ''}`;
   const rowStyle = enter !== null ? { animationDelay: `${Math.min(enter, 8) * 18}ms` } : undefined;
-  const hasError = hasDiag && diagBlocks(node).some((b) => b.key === 'error' || b.key === 'rollup');
+  const logs = hasDiag ? logCount(node) : 0;
   const ms = liveNodeDuration(node, now, since, clock);
   const durTip = carried || rollupMark
     ? `${formatDuration(ms) || '—'} — measured on ${markAttempt != null ? `attempt ${markAttempt + 1}` : 'an earlier attempt'}`
@@ -622,10 +541,11 @@ function RowView({
       aria-expanded={expandable ? expanded : undefined}
       aria-label={`${displayName(node)}, ${status}${container ? `, ${counts.total} tests` : ''}`}
       tabIndex={0}
-      data-clickable={expandable}
+      data-clickable={expandable || hasDiag}
       data-fail={isTest && status === 'failed' && !cancelled}
+      data-sel={selected ? 'true' : undefined}
       data-running={status === 'running' ? 'true' : undefined}
-      onClick={expandable ? () => { if (!selectionClick()) activate(); } : undefined}
+      onClick={expandable || hasDiag ? () => { if (!selectionClick()) activate(); } : undefined}
       onMouseDown={markPointerFocus}
       onBlur={clearPointerFocus}
       onKeyDown={onKeyDown}
@@ -650,12 +570,6 @@ function RowView({
         // runner's "N subtests failed" card that used to restate it below.
         <span className="failchip" data-soft="failed" data-tip={`${counts.failed} failing ${counts.failed === 1 ? 'test' : 'tests'} inside`}>{counts.failed} failed</span>
       ) : null}
-      {hasDiag ? (
-        // Passive badge (never a control): output exists inside this node.
-        <span className="outbadge" data-stc={hasError ? 'failed' : undefined} data-tip={hasError ? 'Has error output — expand the row to view' : 'Has output — expand the row to view'}>
-          {hasError ? '✕' : '◇'}
-        </span>
-      ) : null}
       {todoLabel(node) ? (
         <span className="todotag" data-soft="todo"># {trimTag(todoLabel(node)!)}</span>
       ) : typeof node.skip === 'string' && node.skip ? (
@@ -665,6 +579,21 @@ function RowView({
         <span className="todotag" data-soft="todo" key={tag}>{trimTag(tag)}</span>
       ))}
       <span className="spacer" />
+      {logs > 0 ? (
+        <button
+          type="button"
+          className="logbtn"
+          data-on={selected ? 'true' : undefined}
+          aria-label="Logs and messages"
+          data-tip={`${formatCount(logs)} ${logs === 1 ? 'line' : 'lines'} of output — open`}
+          onClick={(e) => { e.stopPropagation(); openLogs(node); }}
+          onMouseDown={(e) => e.stopPropagation()}
+          onKeyDown={(e) => e.stopPropagation()}
+        >
+          <MessageIcon />
+          <span className="logbtn-n">{formatCount(logs)}</span>
+        </button>
+      ) : null}
       {renderNodeActions ? (
         // Custom content is interactive on its own terms: clicks and keys
         // inside must never toggle the row's disclosure.
@@ -810,9 +739,37 @@ export function TreeView({
   const toggle = (key: string, current: boolean) => {
     setOverrides((prev) => new Map(prev).set(key, !current));
   };
+
+  // Which node's logs are open, by key rather than by node: a live run replaces
+  // every node object on each poll, and the popup must survive that and show
+  // the newest output. `tab` is a preference — the popup falls back whenever
+  // the selected node has nothing on it.
+  const [sel, setSel] = useState<string | null>(null);
+  const [tab, setTab] = useState<TabKey>('error');
+  const trigger = useRef<HTMLElement | null>(null);
+  const selNode = sel != null ? findNode(files, sel) : undefined;
+  const selTabs = selNode ? logTabs(selNode) : [];
+  const openLogs = (node: TestNode) => {
+    trigger.current = document.activeElement as HTMLElement | null;
+    setSel(node.key);
+  };
+  const closeLogs = () => {
+    setSel(null);
+    // Focus goes back where it came from, not to the top of the document.
+    trigger.current?.focus?.();
+    trigger.current = null;
+  };
+  // A node that streamed its last line and lost its logs, or scrolled out of a
+  // filter, closes rather than showing an empty dialog.
+  useEffect(() => { if (sel != null && selTabs.length === 0) setSel(null); }, [sel, selTabs.length]);
+  useEffect(() => {
+    if (sel == null) return undefined;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') closeLogs(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [sel]);
+
   const [allCollapsed, setAllCollapsed] = useState(false);
-  // Logs live inside rows now, so collapsing rows inherently hides them —
-  // one hierarchy, one unambiguous collapse (revised design ruling).
   const toggleAll = () => {
     const keys: string[] = [];
     collectContainerKeys(files, keys);
@@ -823,6 +780,7 @@ export function TreeView({
       return next;
     });
     setAllCollapsed(!allCollapsed);
+    if (sel != null) closeLogs();
   };
 
   const inProgress = !snapshot.summary && (streaming || counts.running > 0 || counts.queued > 0);
@@ -864,7 +822,7 @@ export function TreeView({
     let stagger = 0;
     for (const row of rows) {
       if (row.node.type === 'file') stagger = 0;
-      const key = rowKey(row);
+      const key = row.node.key;
       const firstSeen = !seen.has(key);
       seen.add(key);
       if (firstSeen && inProgress) { enterMap.set(key, stagger); stagger += 1; }
@@ -984,30 +942,25 @@ export function TreeView({
         </div>
       </header>
 
+      <div className="treewrap">
       <div className="tree" role="tree" aria-label="Test results">
         {rows.length > 0 ? (
-          rows.map((row) => (row.kind === 'output' ? (
-            <OutputPanel
-              key={rowKey(row)}
-              row={row}
-              overrides={overrides}
-              toggle={toggle}
-              enter={enterMap.has(rowKey(row)) ? enterMap.get(rowKey(row))! : null}
-            />
-          ) : (
+          rows.map((row) => (
             <RowView
-              key={rowKey(row)}
+              key={row.node.key}
               row={row}
               toggle={toggle}
-              enter={enterMap.has(rowKey(row)) ? enterMap.get(rowKey(row))! : null}
+              enter={enterMap.has(row.node.key) ? enterMap.get(row.node.key)! : null}
               now={now}
               since={since}
               clock={clock}
               carriedRun={carriedRun}
               onlyRerun={onlyRerun}
               renderNodeActions={renderNodeActions}
+              openLogs={openLogs}
+              selected={row.node.key === sel}
             />
-          )))
+          ))
         ) : pending ? (
           <CenteredState icon="◐" iconStatus="running" spin title="Loading test log…" />
         ) : q || statuses.size > 0 || onlyRerun ? (
@@ -1037,6 +990,17 @@ export function TreeView({
             <code className="state-cmd">node --test --test-reporter @reporters/web</code>
           </CenteredState>
         )}
+      </div>
+      {selNode && selTabs.length > 0 ? (
+        <LogsPopup
+          node={selNode}
+          tabs={selTabs}
+          tab={tab}
+          onTab={setTab}
+          onClose={closeLogs}
+          running={selNode.status === 'running'}
+        />
+      ) : null}
       </div>
 
       <footer className="footer">

--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -176,12 +176,34 @@ export function realError(node: TestNode): { message: string; stack?: string } |
   return node.error;
 }
 
+export interface OutLine { stream: 'out' | 'err'; text: string; }
+
+/** stdout + stderr merged into one line list, stream-tagged (ANSI kept — the
+ *  renderer colors it). The one place output becomes lines, so the count on the
+ *  row button and the count on the Output tab can never disagree. */
+export function outputLines(node: TestNode): OutLine[] {
+  const lines: OutLine[] = [];
+  const add = (chunks: string[], stream: 'out' | 'err'): void => {
+    if (chunks.length === 0) return;
+    for (const line of chunks.join('').split('\n')) lines.push({ stream, text: line });
+  };
+  add(node.stdout, 'out');
+  add(node.stderr, 'err');
+  while (lines.length > 0 && lines[lines.length - 1].text === '') lines.pop();
+  return lines;
+}
+
+/** How much there is to read inside a node: the error, its output lines and its
+ *  messages. This is what the row's log button shows, and it is by construction
+ *  the sum of the popup's three tab counts. */
+export function logCount(node: TestNode): number {
+  return (realError(node) ? 1 : 0) + outputLines(node).length + node.messages.length;
+}
+
+/** The node has something the popup can show. A skip/todo reason alone doesn't
+ *  count — that lives on the row chip, not behind a button. */
 export function hasDiagnostics(node: TestNode): boolean {
-  return Boolean(realError(node))
-    || node.messages.length > 0
-    || node.stdout.length > 0
-    || node.stderr.length > 0
-    || Boolean(reasonOf(node));
+  return logCount(node) > 0;
 }
 
 function defaultExpanded(node: TestNode): boolean {
@@ -196,12 +218,11 @@ export interface FlatRow {
   node: TestNode;
   depth: number;
   status: TestStatus;
-  /** 'node' = a file/suite/test row; 'output' = its nested own-output panel slot. */
-  kind: 'node' | 'output';
-  /** The row has a region to reveal: children and/or its own output. */
+  /** The row has children to reveal. Output is no longer a disclosure — it
+   *  opens in the popup — so this is exactly "is a container". */
   expandable: boolean;
   expanded: boolean;
-  /** Node rows: the node carries its own output (drives the passive badge). */
+  /** The node carries logs, so the row shows a log button. */
   hasDiag: boolean;
 }
 
@@ -278,46 +299,41 @@ export function isExpanded(node: TestNode, opts: BuildOptions): boolean {
   return overrides.has(node.key) ? overrides.get(node.key)! : defaultExpanded(node);
 }
 
-/** Open state of one panel section inside a node's output region. Error opens
- *  by default (failures surface with zero clicks) and so does the one-line
- *  skip/todo reason; heavy Output/Diagnostics need a deliberate click. */
-export function isSectionOpen(node: TestNode, blockKey: string, overrides: Map<string, boolean>): boolean {
-  const key = `${node.key}::diag:${blockKey}`;
-  if (overrides.has(key)) return overrides.get(key)!;
-  return blockKey === 'error' || blockKey === 'reason';
-}
-
-// One disclosure per row: expanding a node reveals ONE region holding its own
-// output (boxed panel sections, never tree rows) followed by its child rows.
-// A pure leaf reveals only its output; a pure container only children; a
-// both-node reveals output then children.
+// The tree is one row per node, nothing else. A node's own output is not a
+// disclosure any more — it opens in the logs popup — so expanding only ever
+// reveals children.
 export function buildRows(files: TestNode[], opts: BuildOptions): FlatRow[] {
   const rows: FlatRow[] = [];
   const push = (node: TestNode, depth: number): void => {
     if (filtering(opts) && !opts.matches!.visible.has(node.key)) return;
-    const diag = hasDiagnostics(node);
-    const expandable = isContainer(node) || diag;
+    const expandable = isContainer(node);
     const expanded = expandable && isExpanded(node, opts);
-    const status = rollup(node);
     rows.push({
-      node, depth, status, kind: 'node', expandable, expanded, hasDiag: diag,
+      node, depth, status: rollup(node), expandable, expanded, hasDiag: hasDiagnostics(node),
     });
     if (!expanded) return;
-    if (diag) {
-      rows.push({
-        node, depth: depth + 1, status, kind: 'output', expandable: false, expanded: false, hasDiag: true,
-      });
-    }
     for (const child of node.children) push(child, depth + 1);
   };
   for (const file of files) push(file, 0);
   return rows;
 }
 
-/** Keys of every expandable row — containers plus nodes with their own output. */
+/** The node with this key, anywhere in the tree. The popup holds a key rather
+ *  than a node so it survives a live run rebuilding the snapshot underneath it,
+ *  and re-reads the node — with its newest output — on every poll. */
+export function findNode(nodes: TestNode[], key: string): TestNode | undefined {
+  for (const node of nodes) {
+    if (node.key === key) return node;
+    const hit = findNode(node.children, key);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/** Keys of every expandable row. */
 export function collectContainerKeys(nodes: TestNode[], into: string[]): void {
   for (const node of nodes) {
-    if (isContainer(node) || hasDiagnostics(node)) into.push(node.key);
+    if (isContainer(node)) into.push(node.key);
     collectContainerKeys(node.children, into);
   }
 }

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -3,7 +3,7 @@ const DARK = `
   --fg:#eceef3; --dim:#9aa1ad; --faint:#646b78;
   --line:rgba(255,255,255,.08); --line-2:rgba(255,255,255,.14);
   --row-hover:rgba(255,255,255,.04);
-  --accent:#8b7cff; --accent-ink:#0c0a1f;
+  --accent:#8b7cff; --accent-ink:#0c0a1f; --accent-soft:rgba(139,124,255,.16); --scrim:rgba(4,5,8,.55);
   --st-passed:#34d27b; --st-failed:#fb5a6a; --st-skipped:#8a93a1; --st-todo:#7c9cff; --st-running:#ffb13d; --st-queued:#5d6573;
   --st-cancelled:#8a93a1;
   --soft-passed:rgba(52,210,123,.15); --soft-failed:rgba(251,90,106,.16); --soft-skipped:rgba(138,147,161,.16); --soft-todo:rgba(124,156,255,.16); --soft-running:rgba(255,177,61,.17); --soft-queued:rgba(93,101,115,.18);
@@ -20,7 +20,7 @@ const LIGHT = `
   --fg:#161b22; --dim:#5a636f; --faint:#9099a5;
   --line:rgba(17,24,33,.10); --line-2:rgba(17,24,33,.18);
   --row-hover:rgba(17,24,33,.035);
-  --accent:#6357e6; --accent-ink:#ffffff;
+  --accent:#6357e6; --accent-ink:#ffffff; --accent-soft:rgba(99,87,230,.11); --scrim:rgba(17,24,33,.28);
   --st-passed:#16a34a; --st-failed:#e23744; --st-skipped:#697381; --st-todo:#3f63d6; --st-running:#bf7400; --st-queued:#97a0ad;
   --st-cancelled:#697381;
   --soft-passed:rgba(22,163,74,.12); --soft-failed:rgba(226,55,68,.10); --soft-skipped:rgba(105,115,129,.12); --soft-todo:rgba(63,99,214,.11); --soft-running:rgba(191,116,0,.13); --soft-queued:rgba(151,160,173,.14);
@@ -69,13 +69,6 @@ button { font-family: inherit; } input { font-family: inherit; }
 @keyframes ppulse { 0%,100% { opacity: 1; } 50% { opacity: .4; } }
 [data-spin="true"] { display: inline-block; animation: pspin 1s linear infinite; }
 [data-pulse="true"] { animation: ppulse 1.5s ease-in-out infinite; }
-
-/* expand/collapse: animate the disclosure to auto height via grid-rows 0fr->1fr */
-.collapsible { display: grid; grid-template-rows: 0fr; transition: grid-template-rows 200ms var(--ease-out); }
-.collapsible.open { grid-template-rows: 1fr; }
-.collapsible > .inner { overflow: hidden; min-height: 0; }
-.collapsible > .inner > .diag { opacity: 0; transition: opacity 200ms var(--ease-out); }
-.collapsible.open > .inner > .diag { opacity: 1; }
 
 /* live viewer: rows arriving, running, and settling (§9) */
 @keyframes rowEnter { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
@@ -147,7 +140,13 @@ button { font-family: inherit; } input { font-family: inherit; }
 .bar > span { height: 100%; }
 
 /* tree */
-.tree { flex: 1; overflow: auto; min-height: 0; padding: 8px 10px 28px; }
+.tree { flex: 1; overflow: auto; min-height: 0; padding: 7px 10px 26px; }
+.row[data-sel="true"] { background: var(--accent-soft); }
+/* the row's log button: idle it is quiet, active it is the popup's anchor */
+.logbtn { display: inline-flex; align-items: center; gap: 4px; flex: none; background: transparent; border: 1px solid transparent; color: var(--faint); border-radius: 7px; padding: 2px 7px; line-height: 16px; font-family: inherit; cursor: pointer; transition: background .13s, color .13s, border-color .13s; }
+.logbtn:hover { color: var(--fg); background: var(--row-hover); }
+.logbtn[data-on] { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
+.logbtn-n { font-size: 11px; font-weight: 700; font-variant-numeric: tabular-nums; }
 .row { display: flex; align-items: center; gap: 8px; min-height: var(--rh); padding: 0 10px 0 12px; border-radius: 9px; }
 .row[data-clickable="true"] { cursor: pointer; }
 .row:hover { background: var(--row-hover); }
@@ -185,58 +184,51 @@ button { font-family: inherit; } input { font-family: inherit; }
 .rt-tooltip { position: fixed; top: 0; left: 0; z-index: 99999; display: none; opacity: 0; pointer-events: none; max-width: 300px; overflow-wrap: anywhere; font: 600 11.5px/1.45 var(--sans); padding: 6px 10px; border-radius: 8px; background: var(--tip-bg); color: var(--tip-fg); border: 1px solid var(--tip-border); box-shadow: var(--tip-shadow); transition: opacity .12s ease; }
 @media (prefers-reduced-motion: reduce) { .rt-tooltip { transition: none; } }
 
-/* diagnostics */
-.diag { border: 1px solid var(--line); border-radius: 12px; overflow: hidden; background: var(--panel-2); }
-.diag-sec { display: flex; }
-.diag-sec + .diag-sec { border-top: 1px solid var(--line); }
-.diag-bar { width: 3px; flex: none; }
-.diag-body { flex: 1; min-width: 0; }
-/* the section header is the disclosure for just its panel; it sticks inside
-   the tree scroller, so Collapse is reachable at any depth (§10d) */
-.diag-head { display: flex; align-items: center; gap: 7px; padding: 6px 13px 6px 6px; position: sticky; top: 0; z-index: 1; background: var(--panel-2); cursor: pointer; min-height: 32px; }
-.diag-head:hover { background: var(--raise); }
-.diag-icon { font-weight: 800; font-size: 12px; }
-.diag-title { font-size: 11px; font-weight: 700; letter-spacing: .06em; text-transform: uppercase; color: var(--dim); }
-.diag-count { font-size: 10.5px; font-weight: 600; color: var(--faint); font-variant-numeric: tabular-nums; }
-.diag-tools { margin-left: auto; display: flex; gap: 6px; align-items: center; }
-.hbtn { background: transparent; border: 1px solid var(--line); color: var(--dim); border-radius: 7px; padding: 2px 8px; font-size: 10.5px; font-weight: 600; cursor: pointer; transition: background .13s, color .13s; }
-.hbtn:hover { background: var(--raise); color: var(--fg); }
-.hbtn[data-on] { color: var(--accent); border-color: var(--accent); }
-/* the capped scroll region (§10a): the panel never grows past ~1 screen; long
-   and wide content scrolls in here, never the page */
-.log-body { max-height: 260px; overflow: auto; overscroll-behavior: contain; }
-.diag-msg { padding: 0 14px; }
-.diag-msg span { font-size: 13px; font-weight: 600; }
-.diag pre { margin: 0; font-family: var(--mono); font-size: 11.5px; line-height: 1.55; }
-.diag pre.stack { padding: 2px 14px 13px; color: var(--fg); white-space: pre; }
+/* logs popup: one node's Error / Output / Messages, over the tree */
+@keyframes ppop { from { opacity: 0; transform: translateX(-50%) translateY(6px) scale(.985); } to { opacity: 1; transform: translateX(-50%); } }
+.treewrap { position: relative; flex: 1; min-height: 0; display: flex; flex-direction: column; }
+.scrim { position: absolute; inset: 0; background: var(--scrim); z-index: 8; }
+.pop { position: absolute; top: 16px; bottom: 20px; left: 50%; transform: translateX(-50%); width: min(1440px, calc(100% - 48px)); z-index: 9; background: var(--panel); border: 1px solid var(--line); border-radius: 16px; box-shadow: 0 26px 70px rgba(9,12,20,.28), 0 2px 10px rgba(9,12,20,.12); display: flex; flex-direction: column; overflow: hidden; outline: none; animation: ppop 160ms cubic-bezier(.2,.7,.3,1) both; }
+@media (prefers-reduced-motion: reduce) { .pop { animation: none; } }
+@media (max-width: 640px) { .pop { top: 0; bottom: 0; width: 100%; max-width: 100%; border: none; border-radius: 0; } }
+.pop-head { display: flex; align-items: center; gap: 10px; padding: 12px 12px 11px 16px; border-bottom: 1px solid var(--line); }
+.pop-badge { width: 22px; height: 22px; flex: none; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 800; }
+.pop-heading { flex: 1; min-width: 0; }
+.pop-title { font-size: 13.5px; font-weight: 650; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pop-path { font-size: 11.5px; font-family: var(--mono); color: var(--faint); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pop-tools { flex: none; display: flex; gap: 6px; align-items: center; }
+.pbtn { background: var(--panel-2); border: 1px solid var(--line); color: var(--dim); border-radius: 9px; padding: 6px 11px; font-size: 12px; font-family: inherit; cursor: pointer; transition: background .13s, color .13s, border-color .13s; }
+.pbtn:hover { background: var(--raise); color: var(--fg); }
+.pbtn[data-on] { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
+.pbtn-x { padding: 6px 9px; }
+.pop-tabs { display: flex; gap: 4px; padding: 8px 14px; background: var(--panel-2); border-bottom: 1px solid var(--line); }
+.pop-tab { background: transparent; border: none; color: var(--dim); font-family: inherit; font-size: 12px; font-weight: 500; border-radius: 8px; padding: 5px 12px; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; }
+.pop-tab:hover { background: var(--raise); }
+.pop-tab[data-on] { background: var(--accent); color: var(--accent-ink); font-weight: 650; }
+.pop-tab-n { opacity: .6; font-variant-numeric: tabular-nums; }
+.pop-body { flex: 1; min-height: 0; overflow: auto; overscroll-behavior: contain; background: var(--inset); }
+.pop-msg { padding: 14px 16px 0; }
+.pop-msg span { font-size: 13px; font-weight: 650; }
+.pop-body pre { margin: 0; font-family: var(--mono); font-size: 12px; line-height: 1.65; }
+.pop-body pre.stack { padding: 11px 16px 22px; color: var(--dim); white-space: pre; }
+.pop-body pre.stack[data-wrap] { white-space: pre-wrap; word-break: break-word; }
 .frame[data-kind="internal"] { color: var(--faint); }
 .stack-loc { color: var(--ansi-cyan); }
-.diag pre.text { padding: 2px 14px 13px; color: var(--fg); white-space: pre-wrap; word-break: break-word; }
 /* merged stdout+stderr: one block, per-line stream tagging */
-.out { padding: 4px 14px 12px; }
-.out-line { position: relative; padding-left: 12px; font-family: var(--mono); font-size: 11.5px; line-height: 1.55; color: var(--fg); white-space: pre-wrap; word-break: break-word; }
+.out { padding: 12px 16px 22px; }
+.out-line { position: relative; padding-left: 12px; font-family: var(--mono); font-size: 12px; line-height: 1.65; color: var(--fg); white-space: pre; }
+.out[data-wrap] .out-line { white-space: pre-wrap; word-break: break-word; }
 .out-line[data-err]::before { content: ""; position: absolute; left: 0; top: 3px; bottom: 3px; width: 2px; border-radius: 1px; background: var(--st-failed); }
-.diag-list { padding: 2px 14px 12px; display: flex; flex-direction: column; gap: 6px; }
+.diag-list { padding: 12px 16px 22px; display: flex; flex-direction: column; gap: 6px; }
 .diag-item { font-size: 12.5px; color: var(--fg); display: flex; gap: 9px; align-items: baseline; }
 /* huge logs stay smooth: offscreen lines skip layout/paint but remain scrollable (§10b) */
 .out-line, .diag-item { content-visibility: auto; contain-intrinsic-size: auto 19px; }
 .diag-level { font-size: 9.5px; font-weight: 700; letter-spacing: .05em; text-transform: uppercase; flex: none; border-radius: 5px; padding: 1px 6px; }
-.diag-item .txt { font-family: var(--mono); font-size: 12px; white-space: pre-wrap; word-break: break-word; }
+.diag-item .txt { font-family: var(--mono); font-size: 12px; white-space: pre; }
+.diag-list[data-wrap] .diag-item .txt { white-space: pre-wrap; word-break: break-word; }
 .diag-payload { margin-left: 7px; opacity: .68; word-break: break-all; }
-.diag a { color: var(--st-todo); text-decoration: underline; text-underline-offset: 2px; word-break: break-all; }
-.diag a:hover { filter: brightness(1.15); }
-
-/* full-log modal (§10c) */
-@keyframes modalIn { from { opacity: 0; transform: translateY(6px) scale(.985); } to { opacity: 1; transform: none; } }
-.modal-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,.55); z-index: 50; display: flex; align-items: center; justify-content: center; }
-.modal { background: var(--panel); border: 1px solid var(--line-2); border-radius: 16px; box-shadow: 0 24px 64px rgba(0,0,0,.45); width: min(1680px, 94vw); height: min(86vh, 100%); display: flex; flex-direction: column; outline: none; animation: modalIn 180ms var(--ease-out) both; }
-@media (max-width: 640px) { .modal-backdrop { padding: 0; } .modal { width: 100%; height: 100dvh; border: none; border-radius: 0; } }
-.modal-head { display: flex; align-items: center; gap: 8px; padding: 11px 16px; border-bottom: 1px solid var(--line); }
-.modal-title { font-size: 12.5px; font-weight: 700; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.modal-body { flex: 1; min-height: 0; overflow: auto; overscroll-behavior: contain; padding: 8px 4px; }
-.modal-body pre, .modal-body .out-line, .modal-body .diag-item .txt { white-space: pre; word-break: normal; }
-.modal.wrap .modal-body pre, .modal.wrap .modal-body .out-line, .modal.wrap .modal-body .diag-item .txt { white-space: pre-wrap; word-break: break-word; }
-@media (prefers-reduced-motion: reduce) { .modal { animation: none; } }
+.pop-body a { color: var(--st-todo); text-decoration: underline; text-underline-offset: 2px; word-break: break-all; }
+.pop-body a:hover { filter: brightness(1.15); }
 
 /* full-tree states */
 .state { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 13px; padding: 66px 20px; text-align: center; }
@@ -279,16 +271,13 @@ button { font-family: inherit; } input { font-family: inherit; }
   .tools .btn { min-height: 44px; min-width: 44px; justify-content: center; }
   .hdr-bar-row { padding: 12px 12px; }
   .bar { min-width: 0; }
-  .hbtn { min-height: 34px; min-width: 34px; padding: 5px 9px; font-size: 11px; }
-  .hbtn-label, .hbtn-collapse { display: none; }
-  .diag-head { min-height: 40px; padding: 4px 10px 4px 6px; }
-  .diag-msg { padding: 0 10px; }
-  .diag pre.stack, .diag pre.text { padding: 2px 10px 11px; }
-  .out { padding: 4px 10px 10px; }
-  .diag-list { padding: 2px 10px 10px; }
-  .modal-head { flex-wrap: wrap; row-gap: 6px; padding: 10px 12px; }
-  .modal-title { white-space: normal; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; }
-  .modal-head .diag-tools { flex: 1 1 100%; margin-left: 0; justify-content: flex-end; }
+  .pop-head { flex-wrap: wrap; row-gap: 8px; padding: 10px 12px; }
+  .pop-tools { flex: 1 1 100%; justify-content: flex-end; }
+  .pbtn { min-height: 34px; }
+  .pop-msg { padding: 12px 12px 0; }
+  .pop-body pre.stack { padding: 9px 12px 18px; }
+  .out, .diag-list { padding: 10px 12px 18px; }
+  .logbtn { min-height: 30px; }
   .footer { flex-wrap: wrap; row-gap: 5px; padding: 8px 12px; }
   .legend { margin-left: 0; flex-basis: 100%; flex-wrap: wrap; gap: 5px 12px; }
 }

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -4,7 +4,7 @@ import { createTreeStore } from '@reporters/tree-core';
 import type { Counts, TestEvent, TestNode } from '@reporters/tree-core';
 import {
   buildRows, collectContainerKeys, computeMatches, displayName, hasDiagnostics,
-  hasFailChip, isCancelled, isExpanded, isPassingTodo, isSectionOpen, isSubtestsRollup, liveNodeDuration, nodeDuration, reasonOf, realError, rollup,
+  hasFailChip, isCancelled, isExpanded, isPassingTodo, isSubtestsRollup, liveNodeDuration, logCount, nodeDuration, outputLines, reasonOf, realError, rollup,
 } from '../src/client/rowModel.ts';
 
 const zeroCounts = (): Counts => ({
@@ -46,40 +46,25 @@ test('a file node with its own stdout/stderr reports diagnostics', () => {
   assert.strictEqual(hasDiagnostics(fileNode()), true);
 });
 
-test('buildRows nests an output header row inside an expanded node with output', () => {
+test('the tree is one row per node — output is no longer a row', () => {
   const file = fileNode();
   const rows = buildRows([file], noQuery);
-  const fileRow = rows.find((r) => r.kind === 'node' && r.node.type === 'file')!;
-  assert.strictEqual(fileRow.expandable, true);
+  assert.strictEqual(rows.length, 2, 'the file and its one test, nothing else');
+  const fileRow = rows.find((r) => r.node.type === 'file')!;
+  assert.strictEqual(fileRow.expandable, true, 'it has children to reveal');
   assert.strictEqual(fileRow.expanded, true, 'a file defaults to expanded');
-  assert.strictEqual(fileRow.hasDiag, true, 'the row carries the passive output badge');
-  const outRow = rows.find((r) => r.kind === 'output')!;
-  assert.strictEqual(outRow.node.key, file.key, 'the output row belongs to the file node');
-  assert.strictEqual(outRow.depth, fileRow.depth + 1, 'own output is indented one level, before children');
-  assert.strictEqual(rows.indexOf(outRow), rows.indexOf(fileRow) + 1, 'output comes first inside the region');
+  assert.strictEqual(fileRow.hasDiag, true, 'and its own output drives the log button');
 });
 
-test('a collapsed node hides its output panel slot', () => {
-  const file = fileNode();
-  const collapsed = buildRows([file], { overrides: new Map([[file.key, false]]), query: '', matches: null });
-  assert.strictEqual(collapsed.some((r) => r.kind === 'output'), false, 'collapsed region hides the output panel');
-  assert.strictEqual(collapsed[0].hasDiag, true, 'the badge still marks that output exists');
-});
-
-test('a pure leaf with output is expandable and reveals only its output row', () => {
-  const leaf = node({
-    key: 'f/t', status: 'failed', error: { message: 'boom' },
-  });
+test('a leaf with logs is not expandable — its row opens the popup instead', () => {
+  const leaf = node({ key: 'f/t', status: 'failed', error: { message: 'boom' } });
   const file = node({
     key: 'f', type: 'file', file: '/repo/f.test.js', children: [leaf],
     counts: { ...zeroCounts(), failed: 1, total: 1 },
   });
-  const rows = buildRows([file], noQuery);
-  const leafRow = rows.find((r) => r.kind === 'node' && r.node.key === 'f/t')!;
-  assert.strictEqual(leafRow.expandable, true, 'a leaf with output can be expanded');
-  assert.strictEqual(leafRow.expanded, true, 'a failed node defaults to expanded');
-  assert.ok(rows.some((r) => r.kind === 'output' && r.node.key === 'f/t'), 'its output panel slot is present');
-  assert.strictEqual(isSectionOpen(leaf, 'error', new Map()), true, 'a failed leaf opens with its error visible');
+  const leafRow = buildRows([file], noQuery).find((r) => r.node.key === 'f/t')!;
+  assert.strictEqual(leafRow.expandable, false, 'nothing nested to disclose');
+  assert.strictEqual(leafRow.hasDiag, true, 'but there is something to read');
 });
 
 test('displayName shows the basename for files and the raw name otherwise', () => {
@@ -173,17 +158,27 @@ test('isExpanded honors query force, overrides, then per-type defaults', () => {
   assert.strictEqual(isExpanded(node({ key: 't', type: 'test' }), opts()), false);
 });
 
-test('isSectionOpen defaults open only for the error section, overrides win', () => {
-  const n = node({ key: 'a', status: 'failed' });
-  assert.strictEqual(isSectionOpen(n, 'error', new Map()), true, 'the error section surfaces with zero clicks');
-  assert.strictEqual(isSectionOpen(n, 'reason', new Map()), true, 'the one-line skip/todo reason is cheap — open it');
-  assert.strictEqual(isSectionOpen(n, 'diag', new Map()), false, 'heavy sections need a deliberate click');
-  assert.strictEqual(isSectionOpen(n, 'output', new Map()), false);
-  assert.strictEqual(isSectionOpen(n, 'error', new Map([['a::diag:error', false]])), false);
-  assert.strictEqual(isSectionOpen(n, 'diag', new Map([['a::diag:diag', true]])), true);
+test('logCount is the sum of what the three tabs will show', () => {
+  const n = node({
+    error: { message: 'boom' },
+    stdout: ['one\ntwo\n'],
+    stderr: ['three\n'],
+    messages: [
+      { kind: 'diagnostic', message: 'a', level: 'info' },
+      { kind: 'log', message: 'b', level: 'info' },
+    ],
+  });
+  // 1 error + 4 output lines + 2 messages. Four, not three: stdout's trailing
+  // newline leaves a blank line where stderr picks up, and only the very last
+  // empty line is trimmed.
+  assert.deepStrictEqual(outputLines(n).map((l) => l.text), ['one', 'two', '', 'three']);
+  assert.strictEqual(logCount(n), 7);
+  assert.strictEqual(logCount(node()), 0);
+  // A suppressed error is not counted — the popup would have no Error tab.
+  assert.strictEqual(logCount(node({ error: { message: 'cancelled', failureType: 'cancelledByParent' } })), 0);
 });
 
-test('collectContainerKeys includes leaves that carry their own output', () => {
+test('collectContainerKeys is containers only — a leaf has nothing to expand', () => {
   const file = node({
     key: 'f',
     type: 'file',
@@ -196,7 +191,7 @@ test('collectContainerKeys includes leaves that carry their own output', () => {
   });
   const keys: string[] = [];
   collectContainerKeys([file], keys);
-  assert.deepStrictEqual(keys, ['f', 'f/t1'], 'the plain passed leaf is not expandable');
+  assert.deepStrictEqual(keys, ['f'], 'a leaf with output opens the popup, it does not expand');
 });
 
 test('buildRows drops nodes filtered out by an active query', () => {
@@ -283,6 +278,8 @@ test('hasDiagnostics sees a container error', () => {
   assert.strictEqual(hasDiagnostics(node({ error: { message: 'real' } })), true);
   // and a node with nothing recorded has none
   assert.strictEqual(hasDiagnostics(node()), false);
+  // A skip reason is not output — it rides on the row chip, not behind a button.
+  assert.strictEqual(hasDiagnostics(node({ status: 'skipped', skip: 'needs a cluster' })), false);
 });
 
 test('nodeDuration prefers a measured wall-clock over summing concurrent children', () => {

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'node:test';
+import { afterEach, test } from 'node:test';
 import assert from 'node:assert';
 import { JSDOM } from 'jsdom';
 import type ReactTypes from 'react';
@@ -43,10 +43,22 @@ function fakeSource(initial: string) {
   return { state, fetchImpl };
 }
 
+// Every mounted root is torn down after its test, pass or fail. Without this a
+// throwing assertion leaks the viewer's poll timer, and node:test waits out the
+// whole file timeout instead of reporting the failure — one bad assert used to
+// cost 200s.
+const mounted: Root[] = [];
+afterEach(async () => {
+  const roots = mounted.splice(0);
+  await act(async () => { for (const r of roots) r.unmount(); });
+});
+
 function mount(): { root: Root; el: HTMLElement } {
   const el = dom.window.document.createElement('div');
   dom.window.document.body.appendChild(el);
-  return { root: createRoot(el), el };
+  const root = createRoot(el);
+  mounted.push(root);
+  return { root, el };
 }
 
 const tick = (ms: number) => act(async () => { await new Promise((r) => { setTimeout(r, ms); }); });
@@ -182,15 +194,15 @@ async function openMessages(): Promise<{ root: Root; el: HTMLElement; list: Elem
   const row = [...el.querySelectorAll('[role="treeitem"]')]
     .find((n) => n.getAttribute('aria-label')!.startsWith('uploads,')) as HTMLElement;
   assert.ok(row, 'the uploads row should render');
-  await act(async () => { row.click(); });
+  await act(async () => { (row.querySelector('.logbtn') as HTMLElement).click(); });
 
-  const head = [...el.querySelectorAll('.diag-head')]
-    .find((n) => n.textContent!.includes('Messages')) as HTMLElement;
-  assert.ok(head, 'a Messages section should render');
-  await act(async () => { head.click(); });
+  const tab = [...el.querySelectorAll('.pop-tab')]
+    .find((n) => n.textContent!.startsWith('Messages')) as HTMLElement;
+  assert.ok(tab, 'a Messages tab should render');
+  await act(async () => { tab.click(); });
 
   const list = el.querySelector('.diag-list');
-  assert.ok(list, 'the Messages list body should mount once opened');
+  assert.ok(list, 'the Messages list should render in the popup body');
   return { root, el, list: list! };
 }
 
@@ -225,6 +237,7 @@ test('a warn payload level drives the item severity', async () => {
  *  failing test with a real stack, and children the runner cancelled. */
 const CASCADE = [
   '{"type":"test:start","data":{"name":"EKS Namespace","nesting":0,"file":"eks.test.js","testId":1}}',
+  '{"type":"test:stdout","data":{"file":"eks.test.js","message":"creating namespace\\nwaiting for pods\\n"}}',
   '{"type":"test:start","data":{"name":"with S3 vault","nesting":1,"file":"eks.test.js","testId":2,"parentId":1}}',
   '{"type":"test:fail","data":{"name":"with S3 vault","nesting":1,"file":"eks.test.js","testId":2,"parentId":1,"details":{"duration_ms":0,"error":{"message":"test did not finish before its parent and was cancelled","failureType":"cancelledByParent","code":"ERR_TEST_FAILURE"}}}}',
   '{"type":"test:start","data":{"name":"discovers pg","nesting":1,"file":"eks.test.js","testId":3,"parentId":1}}',
@@ -257,12 +270,80 @@ test('a cancelled test renders muted, with no error panel to expand', async () =
   await act(async () => root.unmount());
 });
 
-test('a real failure keeps its mark, its tint and its full stack', async () => {
+test('a real failure keeps its mark and its tint, and opens on its stack', async () => {
   const { root, el } = await renderCascade();
   const row = rowOf(el, 'discovers pg');
   assert.strictEqual(row.querySelector('.tdot')!.getAttribute('data-stf'), 'failed', 'a test is a dot, not a glyph');
   assert.strictEqual(row.getAttribute('data-fail'), 'true');
-  assert.ok(el.querySelector('.stack')!.textContent!.includes('at eks.test.js:12:3'), 'the stack still renders');
+  assert.strictEqual(el.querySelector('.stack'), null, 'nothing is printed inline any more');
+  // The row itself is the affordance for a leaf — no caret to hunt for.
+  await act(async () => { row.click(); });
+  assert.strictEqual(el.querySelector('.pop-tab[data-on]')!.textContent, 'Error1', 'opens on the first tab it has');
+  assert.ok(el.querySelector('.stack')!.textContent!.includes('at eks.test.js:12:3'));
+  assert.strictEqual(el.querySelector('.pop-path')!.textContent, 'eks.test.js › EKS Namespace › discovers pg');
+  await act(async () => root.unmount());
+});
+
+test('Escape and the scrim both close the popup, and focus goes back to the button', async () => {
+  const { root, el } = await renderCascade();
+  const btn = rowOf(el, 'discovers pg').querySelector('.logbtn') as HTMLElement;
+  await act(async () => { btn.focus(); btn.click(); });
+  assert.ok(el.querySelector('.pop'), 'the popup is open');
+  assert.strictEqual(btn.getAttribute('data-on'), 'true', 'and its button reads as active');
+  await act(async () => { dom.window.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Escape' })); });
+  assert.strictEqual(el.querySelector('.pop'), null, 'Escape closes it');
+  assert.strictEqual(dom.window.document.activeElement, btn, 'focus returns to where it came from');
+
+  await act(async () => { btn.click(); });
+  await act(async () => { (el.querySelector('.scrim') as HTMLElement).click(); });
+  assert.strictEqual(el.querySelector('.pop'), null, 'a scrim click closes it too');
+  await act(async () => root.unmount());
+});
+
+test('a node with no error opens on Output, since there is no Error tab', async () => {
+  const { root, el } = await renderCascade();
+  // The file wrapper: it owns the run's stdout but reported no error of its own.
+  const row = rowOf(el, 'eks.test.js');
+  await act(async () => { (row.querySelector('.logbtn') as HTMLElement).click(); });
+  assert.deepStrictEqual(
+    [...el.querySelectorAll('.pop-tab')].map((n) => n.textContent),
+    ['Output2'],
+    'only tabs with content are rendered',
+  );
+  assert.strictEqual(el.querySelector('.pop-tab[data-on]')!.textContent, 'Output2');
+  await act(async () => root.unmount());
+});
+
+test('the error message is printed once, not repeated by its own stack', async () => {
+  const { root, el } = await renderCascade();
+  await act(async () => { rowOf(el, 'discovers pg').click(); });
+  const body = el.querySelector('.pop-body')!.textContent!;
+  assert.strictEqual(body.match(/expected 3 to equal 4/g)!.length, 1, 'headline only — the stack drops its preamble');
+  assert.ok(el.querySelector('.stack')!.textContent!.startsWith('    at '), 'the stack starts at the first frame');
+  await act(async () => root.unmount());
+});
+
+test('a synthetic error whose stack is just its message renders no stack at all', async () => {
+  const orphan = '{"type":"test:fail","data":{"name":"lonely","nesting":0,"file":"x.test.js","testId":9,"details":{"duration_ms":1,"error":{"message":"1 subtest failed","failureType":"subtestsFailed"}}}}';
+  const { fetchImpl } = fakeSource(`${orphan}\n`);
+  const { root, el } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filterState: memoryFilterState() }));
+  });
+  await tick(20);
+  await act(async () => { (rowOf(el, 'lonely').querySelector('.logbtn') as HTMLElement).click(); });
+  assert.strictEqual(el.querySelector('.pop-msg')!.textContent, '1 subtest failed');
+  assert.strictEqual(el.querySelector('.stack'), null, 'nothing left to print below it');
+  await act(async () => root.unmount());
+});
+
+test('the log button counts exactly what the tabs add up to', async () => {
+  const { root, el } = await renderCascade();
+  const row = rowOf(el, 'discovers pg');
+  const shown = Number(row.querySelector('.logbtn-n')!.textContent);
+  await act(async () => { (row.querySelector('.logbtn') as HTMLElement).click(); });
+  const tabTotal = [...el.querySelectorAll('.pop-tab-n')].reduce((sum, n) => sum + Number(n.textContent), 0);
+  assert.strictEqual(shown, tabTotal, 'one source, no separate math');
   await act(async () => root.unmount());
 });
 
@@ -278,7 +359,7 @@ test('the subtests rollup becomes a fail chip on the row, with no panel left', a
   const row = rowOf(el, 'EKS Namespace');
   assert.strictEqual(row.querySelector('.failchip')!.textContent, '2 failed');
   assert.ok(!el.textContent!.includes('2 subtests failed'), 'the runner’s wording is gone entirely');
-  assert.strictEqual(row.querySelector('.outbadge'), null, 'and nothing is left to disclose on that row');
+  assert.strictEqual(row.querySelector('.failchip')!.textContent, '2 failed');
   await act(async () => root.unmount());
 });
 
@@ -292,7 +373,9 @@ test('a rollup with no failing descendant to point at keeps its error', async ()
     root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filterState: memoryFilterState() }));
   });
   await tick(20);
-  assert.strictEqual(rowOf(el, 'lonely').querySelector('.failchip'), null, 'no chip to stand in for it');
-  assert.ok(el.textContent!.includes('1 subtest failed'), 'so the error still shows');
+  const row = rowOf(el, 'lonely');
+  assert.strictEqual(row.querySelector('.failchip'), null, 'no chip to stand in for it');
+  await act(async () => { (row.querySelector('.logbtn') as HTMLElement).click(); });
+  assert.ok(el.querySelector('.pop-msg')!.textContent!.includes('1 subtest failed'), 'so the error still shows');
   await act(async () => root.unmount());
 });


### PR DESCRIPTION
Slice 2 of the compact-run-view handoff, following #282. This is the one that changes what the tree *is*.

Every node with output used to stack panels under its row — an ERROR card, an OUTPUT card, a MESSAGES card, at every level of nesting. On a real run the tree was mostly not tree. Now a node with logs carries a small button with its line count, and one dialog opens over the tree with **Error / Output / Messages** tabs.

## Notable details

- **The popup holds a node key, not a node.** A live run replaces every node object on each poll; holding a key means the open dialog re-reads the newest one and keeps streaming, tail-following until you scroll up.
- **Only tabs with content render**, and the tab preference falls back — a node with no error opens on Output.
- **Modal as specced**: scrim, Escape, focus trap, focus returned to the button that opened it. Collapse-all closes it.
- **The counts can't drift.** The row button and the three tabs both come from `logCount()` / `outputLines()` — one source, asserted equal in a test.

## The message is printed once now

Node builds `err.stack` by prefixing `"Name: message"` to the frames, so rendering a headline *and* a verbatim stack said the same sentence twice — visible in every error card the viewer has ever shown, and called out in the handoff overview. The preamble is dropped when frames remain to show, and an error whose entire "stack" *is* its message (Node's synthetic ones) renders no stack block at all. Copy still hands over the error exactly as the runner wrote it.

## Popup width

Specced at 940px; I shipped `min(1440px, 100% - 48px)` after seeing it on a wide screen — 940px left most of the display empty and clipped long URLs mid-token. Easy to dial back if the designer disagrees.

## Test suite: 200s → 2.3s

Not cosmetic. A throwing assertion never reached its `root.unmount()`, so the viewer's poll timer stayed alive and `node:test` waited out the **whole file timeout at 200s** instead of reporting the failure. One bad assert cost 100× a full passing run. Roots now unmount in an `afterEach`, so failures report in ~2s and no future leak can stall the suite.

## Scope

Rows are one-per-node again (`FlatRow.kind` gone, `isSectionOpen` with it), a leaf is no longer "expandable" — its row opens its logs — and `LogModal` retires now that Output is a real tab with its own Copy and Wrap (the designer's open question 2). None of those were reachable from the package's public entry points; `TestReportViewer`'s props are unchanged, so this is **not** an API break.

**Known gap until slice 3:** a failed leaf now needs one click to show its error. The inline one-line error preview restores that and is the first thing in the next PR.

## Verification

138 web tests pass in 2.3s; full repo suite 456 pass / 6.3s (the 8 `@reporters/github` failures are pre-existing on `main`). Driven in a real browser in both themes: tab fallback, Escape, scrim, focus return, breadcrumb, and message-printed-once all checked against a served NDJSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)