### PR TITLE
fix(web): let rows collapse and expand while a filter is active

### DIFF
--- a/packages/web/src/client/rowModel.ts
+++ b/packages/web/src/client/rowModel.ts
@@ -293,10 +293,20 @@ function filtering(opts: BuildOptions): boolean {
   return opts.query !== '' || (opts.statuses?.size ?? 0) > 0 || opts.onlyRerun === true;
 }
 
+/**
+ * Open state, most specific first: what the reader asked for, then what the
+ * active filter needs, then the per-type default.
+ *
+ * The filter's force-expand is a default, not a lock. It exists so a match is
+ * on screen without being hunted for — but it used to sit above `overrides`,
+ * which meant every caret under an active search or status chip computed a new
+ * state and then had it overwritten. Rows simply would not close.
+ */
 export function isExpanded(node: TestNode, opts: BuildOptions): boolean {
-  if (filtering(opts) && opts.matches?.force.has(node.key)) return true;
   const { overrides } = opts;
-  return overrides.has(node.key) ? overrides.get(node.key)! : defaultExpanded(node);
+  if (overrides.has(node.key)) return overrides.get(node.key)!;
+  if (filtering(opts) && opts.matches?.force.has(node.key)) return true;
+  return defaultExpanded(node);
 }
 
 // The tree is one row per node, nothing else. A node's own output is not a

--- a/packages/web/tests/rowModel.test.ts
+++ b/packages/web/tests/rowModel.test.ts
@@ -139,14 +139,32 @@ test('collectContainerKeys gathers file and suite keys, skipping leaves', () => 
   assert.deepStrictEqual(keys, ['f', 's']);
 });
 
-test('isExpanded honors query force, overrides, then per-type defaults', () => {
+test('a filter force-expands as a default, never as a lock', () => {
+  const forced = {
+    overrides: new Map<string, boolean>(), query: 'x', matches: { visible: new Set<string>(), force: new Set(['s']) },
+  };
+  const suite = node({ key: 's', type: 'suite', children: [node()], counts: { ...zeroCounts(), failed: 1, total: 1 } });
+  assert.strictEqual(isExpanded(suite, forced), true, 'a match is revealed without asking');
+  // ...but the reader can still close it, which is the whole point of a caret.
+  const closed = { ...forced, overrides: new Map([['s', false]]) };
+  assert.strictEqual(isExpanded(suite, closed), false, 'an explicit collapse outranks the filter');
+  // And re-open it against a default that would have kept it shut.
+  const leaf = node({ key: 't', type: 'suite', children: [node()] });
+  assert.strictEqual(isExpanded(leaf, { ...forced, overrides: new Map([['t', true]]) }), true);
+});
+
+test('isExpanded honors overrides, then query force, then per-type defaults', () => {
   const opts = (over: Partial<Parameters<typeof isExpanded>[1]> = {}) => ({
     overrides: new Map<string, boolean>(), query: '', matches: null, ...over,
   });
   const suite = node({ key: 's', type: 'suite', children: [node()], counts: { ...zeroCounts(), failed: 1, total: 1 } });
 
-  // A query match force-expands regardless of type/default.
+  // A query match force-expands past the type/default...
   assert.strictEqual(isExpanded(suite, opts({ query: 'x', matches: { visible: new Set(), force: new Set(['s']) } })), true);
+  // ...but not past the reader.
+  assert.strictEqual(isExpanded(suite, opts({
+    query: 'x', matches: { visible: new Set(), force: new Set(['s']) }, overrides: new Map([['s', false]]),
+  })), false);
   // An explicit override wins over the default.
   assert.strictEqual(isExpanded(suite, opts({ overrides: new Map([['s', false]]) })), false);
   // Defaults: a failing suite opens, a fully-queued file stays closed, a leaf is closed.

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -249,7 +249,7 @@ async function renderCascade() {
   const { fetchImpl } = fakeSource(`${CASCADE}\n`);
   const { root, el } = mount();
   await act(async () => {
-    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filterState: memoryFilterState() }));
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filters: memoryFilterState() }));
   });
   await tick(20);
   return { root, el };
@@ -328,7 +328,7 @@ test('a synthetic error whose stack is just its message renders no stack at all'
   const { fetchImpl } = fakeSource(`${orphan}\n`);
   const { root, el } = mount();
   await act(async () => {
-    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filterState: memoryFilterState() }));
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filters: memoryFilterState() }));
   });
   await tick(20);
   await act(async () => { (rowOf(el, 'lonely').querySelector('.logbtn') as HTMLElement).click(); });
@@ -365,7 +365,7 @@ test('a container previews its own failure — the cascade\u2019s only real caus
   const { fetchImpl } = fakeSource(`${hook}\n`);
   const { root, el } = mount();
   await act(async () => {
-    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filterState: memoryFilterState() }));
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filters: memoryFilterState() }));
   });
   await tick(20);
   assert.deepStrictEqual(
@@ -393,6 +393,28 @@ test('a cancelled test gets no preview — it never ran, so nothing broke', asyn
   const row = rowOf(el, 'with S3 vault');
   assert.ok(!row.nextElementSibling?.classList.contains('errline'), 'no line follows it');
   assert.ok(!row.getAttribute('aria-label')!.includes('did not finish'), 'and nothing on its label');
+  await act(async () => root.unmount());
+});
+
+test('rows still collapse and expand while a filter is active', async () => {
+  const { fetchImpl } = fakeSource(`${CASCADE}\n`);
+  const { root, el } = mount();
+  const filters = memoryFilterState({ query: 'vault' });
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filters }));
+  });
+  await tick(20);
+
+  const suite = rowOf(el, 'EKS Namespace');
+  assert.strictEqual(suite.getAttribute('aria-expanded'), 'true', 'the query forced it open to reveal the matches');
+  assert.ok(rowOf(el, 'with S3 vault'), 'and the matching child is on screen');
+
+  await act(async () => { suite.click(); });
+  assert.strictEqual(rowOf(el, 'EKS Namespace').getAttribute('aria-expanded'), 'false', 'the caret still works under a filter');
+  assert.strictEqual(rowOf(el, 'with S3 vault'), undefined, 'so its children are gone');
+
+  await act(async () => { rowOf(el, 'EKS Namespace').click(); });
+  assert.strictEqual(rowOf(el, 'EKS Namespace').getAttribute('aria-expanded'), 'true', 'and opens again');
   await act(async () => root.unmount());
 });
 
@@ -429,7 +451,7 @@ test('a rollup with no failing descendant to point at keeps its error', async ()
   const { fetchImpl } = fakeSource(`${orphan}\n`);
   const { root, el } = mount();
   await act(async () => {
-    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filterState: memoryFilterState() }));
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filters: memoryFilterState() }));
   });
   await tick(20);
   const row = rowOf(el, 'lonely');


### PR DESCRIPTION
Reported against the merged compact-run-view work: with a status chip or a search query active, carets did nothing.

## Cause

[`isExpanded`](https://github.com/MoLow/reporters/blob/main/packages/web/src/client/rowModel.ts) checked the filter's force-expand set *before* the reader's overrides:

```ts
if (filtering(opts) && opts.matches?.force.has(node.key)) return true;   // ← won
const { overrides } = opts;
return overrides.has(node.key) ? overrides.get(node.key)! : defaultExpanded(node);
```

So clicking a row did toggle state — `toggle()` ran, the override was stored — and then the very next render discarded it. The row was never stuck; its answer was just being overwritten.

## Fix

Most specific first: reader → filter → per-type default. Force-expand is a **default, not a lock**. Every row the reader hasn't touched still opens automatically to reveal its matches; a row they close stays closed, and one they open stays open.

## Also in here

Three component tests passed `filterState`, which isn't a prop — they were silently falling back to the URL store instead of the in-memory one they meant to use. Harmless for what they asserted, but wrong. The new regression test needs the real `filters` prop to set a query, which is how the typo surfaced.

## Verification

Unit test on `isExpanded` (override beats force in both directions) plus a DOM regression test that filters, collapses and re-expands. Confirmed live in the browser at `?status=failed`: 15 rows → collapse → 11 with children gone → expand → 15 back.

144 web tests pass. Full repo 462 pass / 8 failed, against 460 / 8 on clean `main` — same 8 pre-existing `@reporters/github` failures, plus the 2 tests this PR adds.

⚠️ Two things worth separate attention, not fixed here:

1. **`pretest` is dead config.** `packages/{web,live,mux,sink}` each declare `pretest` to rebuild `dist`, but Yarn 4 doesn't run `pre`/`post` lifecycle scripts. Running a package's tests directly silently exercises a **stale `dist/`** — it gave me a false failure while writing this fix. The root `yarn test` is fine (it runs `yarn build &&` explicitly).
2. **The `@reporters/github` failures are flaky as well as failing.** One run in this session reported 12 failures instead of 8; it did not reproduce across 5 further runs on either branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)