### PR TITLE
fix(web): keep the hover cue visible on a row that is updating

### DIFF
--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -153,10 +153,16 @@ button { font-family: inherit; } input { font-family: inherit; }
 .errline-x { flex: none; font-size: 11px; font-weight: 800; color: var(--st-failed); }
 .errline-msg { flex: 1; min-width: 0; font-family: var(--mono); font-size: 12px; color: var(--st-failed); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .errline-open { flex: none; font-size: 11px; font-weight: 600; color: var(--st-failed); opacity: .7; }
-.row { display: flex; align-items: center; gap: 8px; min-height: var(--rh); padding: 0 10px 0 12px; border-radius: 9px; }
+.row { display: flex; align-items: center; gap: 8px; min-height: var(--rh); padding: 0 10px 0 12px; border-radius: 9px; position: relative; isolation: isolate; }
 .row[data-clickable="true"] { cursor: pointer; }
-.row:hover { background: var(--row-hover); }
 .row[data-fail="true"] { background: var(--fail-tint); }
+/* Hover is a layer over the row background, never another writer of it: the
+   running pulse animates that background (and an animated value outranks any
+   rule), the fail tint sets it, and either would swallow the hover cue. The
+   row isolates so this negative layer lands above its own background and
+   below its content. */
+.row::before { content: ""; position: absolute; inset: 0; z-index: -1; border-radius: inherit; background: var(--row-hover); opacity: 0; pointer-events: none; }
+.row:hover::before { opacity: 1; }
 .guides { display: flex; flex: none; align-self: stretch; }
 .guide { width: var(--ind); align-self: stretch; border-left: 1px solid var(--line); }
 .caret { width: 14px; flex: none; display: flex; align-items: center; justify-content: center; color: var(--faint); font-size: 10px; transition: transform 160ms var(--ease-out); }


### PR DESCRIPTION
Hovering a row that was receiving updates showed no hover indication at all.

## Cause

`.row:hover` set the `background` property — and three other rules wrote that same property and won:

| Writer | Why it beat hover |
|---|---|
| `rowPulse` on `.row[data-running="true"]` | animated values outrank every normal declaration |
| `failFlash` on `.settle-failed` | same, for 500ms after a failure lands |
| `.row[data-fail="true"]` | equal specificity to `.row:hover`, declared after it |

So a running row, a row that had just settled to failed, and every failed row silently swallowed the hover cue. The pulse peaking at `var(--row-hover)` — the literal hover color — made the two states indistinguishable even where hover did paint.

## Fix

Hover is now a layer over the row background rather than another writer of it. `isolation: isolate` makes the row a stacking context so the `z-index: -1` layer lands above the row's own (animated) background and below its content, and hover composites over whatever the row is doing: pulsing, flashing, fail-tinted, or selected.

## Verification

Driven against the live viewer over a truncated `demo-run.ndjson` with running and failed rows on screen:

- **Paint order** — with temporary red `rowPulse` keyframes and a blue overlay, the hovered running row rendered fully blue over the animated red with its text still on top, confirming the layer sits between background and content.
- **Computed styles** — on a hovered running row, `::before` opacity was `1` while the row's own background sat at the pulse trough (`rgba(17,24,33,0)`).
- **Real tints, both themes** — the hovered running row reads clearly lighter than its pulsing siblings in dark; the hovered failed row reads darker than the fail tint in light.
- `packages/web/tests/*.test.ts`: 144 pass, 0 fail.

## Not changed

`rowPulse` still peaks at `var(--row-hover)`, so "pulsing" and "hovered" remain the same tint at different strengths. Hover is now always one step darker than the row's current state, which is unambiguous in motion, but fully separating the cues (e.g. moving the pulse to a faint `--soft-running` amber so pointer state stays neutral ink) is a design call left open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)