### PR TITLE
feat(web): collapse row tags into one chip

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -270,6 +270,13 @@ const SearchIcon = () => (
   </svg>
 );
 
+const TagIcon = () => (
+  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+    <path d="M20.6 13.6l-7 7a2 2 0 0 1-2.8 0l-7.4-7.4A2 2 0 0 1 3 11.8V4a1 1 0 0 1 1-1h7.8a2 2 0 0 1 1.4.6l7.4 7.4a2 2 0 0 1 0 2.6z" />
+    <circle cx="7.5" cy="7.5" r="1.3" fill="currentColor" stroke="none" />
+  </svg>
+);
+
 const CarryIcon = () => (
   <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
     <path d="M3 12a9 9 0 1 0 2.6-6.4" />
@@ -441,6 +448,10 @@ function useSettle(status: TestStatus): boolean {
 
 const trimTag = (s: string): string => (s.length > 32 ? `${s.slice(0, 31)}…` : s);
 
+const tagTip = (tags: readonly string[]): string => (tags.length === 1
+  ? `Tag: ${tags[0]}`
+  : `${tags.length} tags: ${tags.join(' · ')}`);
+
 /** Focus that arrived from a pointer press gets tagged so CSS can skip the
  *  ring (Safari matches :focus-visible on clicked tabindex elements); we
  *  can't preventDefault the mousedown instead — that blocks text selection. */
@@ -550,7 +561,7 @@ function RowView({
       style={rowStyle}
       role="treeitem"
       aria-expanded={expandable ? expanded : undefined}
-      aria-label={`${displayName(node)}, ${status}${container ? `, ${counts.total} tests` : ''}${previewText ? `: ${previewText}` : ''}`}
+      aria-label={`${displayName(node)}, ${status}${container ? `, ${counts.total} tests` : ''}${node.tags?.length ? `, ${tagTip(node.tags)}` : ''}${previewText ? `: ${previewText}` : ''}`}
       tabIndex={0}
       data-clickable={expandable || hasDiag}
       data-fail={isTest && status === 'failed' && !cancelled}
@@ -586,9 +597,12 @@ function RowView({
       ) : typeof node.skip === 'string' && node.skip ? (
         <span className="todotag" data-soft="skipped">⊘ {trimTag(node.skip)}</span>
       ) : null}
-      {node.tags?.map((tag) => (
-        <span className="todotag" data-soft="todo" key={tag}>{trimTag(tag)}</span>
-      ))}
+      {node.tags?.length ? (
+        <span className="tagchip" data-tip={tagTip(node.tags)} aria-hidden="true">
+          <TagIcon />
+          {node.tags.length > 1 ? <span className="tagchip-n">{node.tags.length}</span> : null}
+        </span>
+      ) : null}
       <span className="spacer" />
       {logs > 0 ? (
         <button

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -179,6 +179,9 @@ button { font-family: inherit; } input { font-family: inherit; }
 .outbadge { flex: none; color: var(--faint); font-size: 11px; font-weight: 700; margin-left: 2px; }
 .failchip { flex: none; font-size: 10.5px; font-weight: 700; border-radius: 6px; padding: 1px 7px; }
 .todotag { flex: none; font-size: 10.5px; font-weight: 600; border-radius: 6px; padding: 1px 7px; }
+.tagchip { flex: none; display: inline-flex; align-items: center; gap: 2px; color: var(--faint); line-height: 1; cursor: default; transition: color .13s; }
+.tagchip:hover { color: var(--dim); }
+.tagchip-n { font-size: 10px; font-weight: 700; font-variant-numeric: tabular-nums; }
 .spacer { flex: 1; min-width: 10px; }
 .pills { display: inline-flex; gap: 5px; flex: none; margin-right: 9px; }
 .pill { font-size: 11px; font-weight: 700; border-radius: 999px; padding: 1px 8px; font-variant-numeric: tabular-nums; }

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -96,6 +96,35 @@ test('unmount stops polling a live stream', async () => {
   assert.strictEqual(state.calls, atUnmount, 'no fetches after unmount');
 });
 
+test('tags collapse to one chip whose tooltip and row label carry the names', async () => {
+  const tags = ['aws-rds-workflow-test', 'rds-tests-workflow-test'];
+  const tagged = [
+    `{"type":"test:pass","data":{"name":"tagged","nesting":0,"file":"t.test.js","tags":${JSON.stringify(tags)},"details":{"duration_ms":1},"testNumber":1}}`,
+    '{"type":"test:pass","data":{"name":"single","nesting":0,"file":"t.test.js","tags":["smoke"],"details":{"duration_ms":1},"testNumber":2}}',
+    '{"type":"test:pass","data":{"name":"plain","nesting":0,"file":"t.test.js","details":{"duration_ms":1},"testNumber":3}}',
+    SUMMARY,
+  ].join('\n');
+  const { fetchImpl } = fakeSource(`${tagged}\n`);
+  const { root, el } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10 }));
+  });
+  await tick(30);
+  const rowOf = (name: string) => [...el.querySelectorAll('.row')]
+    .find((r) => r.querySelector('.name')?.textContent === name)!;
+  const many = rowOf('tagged');
+  assert.strictEqual(many.querySelectorAll('.tagchip').length, 1, 'one chip stands for every tag');
+  assert.ok(!many.textContent!.includes(tags[0]), 'tag names stay out of the row title');
+  assert.strictEqual(many.querySelector('.tagchip')!.getAttribute('data-tip'), `2 tags: ${tags.join(' · ')}`);
+  assert.strictEqual(many.querySelector('.tagchip-n')!.textContent, '2');
+  assert.ok(many.getAttribute('aria-label')!.includes(`2 tags: ${tags.join(' · ')}`));
+  const one = rowOf('single');
+  assert.strictEqual(one.querySelector('.tagchip')!.getAttribute('data-tip'), 'Tag: smoke');
+  assert.strictEqual(one.querySelector('.tagchip-n'), null, 'a lone tag needs no count');
+  assert.strictEqual(rowOf('plain').querySelector('.tagchip'), null);
+  await act(async () => root.unmount());
+});
+
 test('renderNodeActions and renderHeaderActions render in the embedded component', async () => {
   const { fetchImpl } = fakeSource(`${LOG}\n${SUMMARY}\n`);
   const { root, el } = mount();


### PR DESCRIPTION
## What

A run that tags every test with the same suite-wide labels (`aws-rds-workflow-test`, `rds-tests-workflow-test`, `long-running-workflow-test`, …) turned every row into a wall of chips, and the test name — the thing you actually scan for — got buried behind them.

Tags now collapse to one quiet affordance on the row: an outline tag glyph plus the count (no count when there is exactly one tag), painted in `--faint` and brightening to `--dim` on hover. The names live in the shared body-level tooltip:

- `3 tags: aws-rds-workflow-test · rds-tests-workflow-test · long-running-workflow-test`
- `Tag: smoke` for a single one

`# todo` and `⊘ skip` labels are untouched — those are the row's own state, not metadata about it.

The chip is `aria-hidden`; the tag names are appended to the row's existing `aria-label` instead, so screen readers still get them and a tagged row doesn't add a second tab stop next to the row itself.

## Verified

- Served a synthetic NDJSON (3-tag rows, a 1-tag row, an untagged row, a todo+tags row, a tagged suite) through `startViewerServer` and drove the real viewer in the browser — rows read `name 🏷 3`, tooltip lists the names, untagged rows carry no chip. Checked light and dark.
- New regression test in `packages/web/tests/viewer-component.test.ts` covers the single chip, the tooltip text for one vs. many, the absent count for a lone tag, the absent chip when untagged, and the aria-label.
- `packages/web` suite: 145/145 passing. `yarn lint` clean (only the 5 pre-existing warnings).
- The README demo log carries only `"tags":[]`, so the committed screenshots are unaffected.

## Note

The filter box matches names only, so tags are not searchable — that was already true, but with the names off the row you can no longer eyeball them either. Adding `node.tags` to `computeMatches`' text match would make "Filter tests" search tags too; left out of this PR since it changes filter semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)