### PR TITLE
feat(web): carry the row's tag chip into the logs popup header

### DIFF
--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -390,7 +390,7 @@ function LogsPopup({
         className="pop"
         role="dialog"
         aria-modal="true"
-        aria-label={`Logs for ${displayName(node)}`}
+        aria-label={`Logs for ${displayName(node)}${node.tags?.length ? `, ${tagTip(node.tags)}` : ''}`}
         ref={boxRef}
         tabIndex={-1}
         onKeyDown={onKeyDown}
@@ -398,7 +398,15 @@ function LogsPopup({
         <div className="pop-head">
           <span className="pop-badge" data-soft={status}>{GLYPH[status]}</span>
           <div className="pop-heading">
-            <div className="pop-title">{displayName(node)}</div>
+            <div className="pop-titlerow">
+              <div className="pop-title">{displayName(node)}</div>
+              {node.tags?.length ? (
+                <span className="tagchip" data-tip={tagTip(node.tags)} aria-hidden="true">
+                  <TagIcon />
+                  {node.tags.length > 1 ? <span className="tagchip-n">{node.tags.length}</span> : null}
+                </span>
+              ) : null}
+            </div>
             <div className="pop-path">{path.join(' › ')}</div>
           </div>
           <div className="pop-tools">

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -209,7 +209,8 @@ button { font-family: inherit; } input { font-family: inherit; }
 .pop-head { display: flex; align-items: center; gap: 10px; padding: 12px 12px 11px 16px; border-bottom: 1px solid var(--line); }
 .pop-badge { width: 22px; height: 22px; flex: none; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 800; }
 .pop-heading { flex: 1; min-width: 0; }
-.pop-title { font-size: 13.5px; font-weight: 650; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.pop-titlerow { display: flex; align-items: center; gap: 6px; min-width: 0; }
+.pop-title { min-width: 0; font-size: 13.5px; font-weight: 650; color: var(--fg); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .pop-path { font-size: 11.5px; font-family: var(--mono); color: var(--faint); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .pop-tools { flex: none; display: flex; gap: 6px; align-items: center; }
 .pbtn { background: var(--panel-2); border: 1px solid var(--line); color: var(--dim); border-radius: 9px; padding: 6px 11px; font-size: 12px; font-family: inherit; cursor: pointer; transition: background .13s, color .13s, border-color .13s; }

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -99,9 +99,9 @@ test('unmount stops polling a live stream', async () => {
 test('tags collapse to one chip whose tooltip and row label carry the names', async () => {
   const tags = ['aws-rds-workflow-test', 'rds-tests-workflow-test'];
   const tagged = [
-    `{"type":"test:pass","data":{"name":"tagged","nesting":0,"file":"t.test.js","tags":${JSON.stringify(tags)},"details":{"duration_ms":1},"testNumber":1}}`,
+    `{"type":"test:pass","data":{"name":"tagged","nesting":0,"file":"t.test.js","testId":1,"tags":${JSON.stringify(tags)},"details":{"duration_ms":1},"testNumber":1}}`,
     '{"type":"test:pass","data":{"name":"single","nesting":0,"file":"t.test.js","tags":["smoke"],"details":{"duration_ms":1},"testNumber":2}}',
-    '{"type":"test:pass","data":{"name":"plain","nesting":0,"file":"t.test.js","details":{"duration_ms":1},"testNumber":3}}',
+    '{"type":"test:pass","data":{"name":"plain","nesting":0,"file":"t.test.js","testId":2,"details":{"duration_ms":1},"testNumber":3}}',
     SUMMARY,
   ].join('\n');
   const { fetchImpl } = fakeSource(`${tagged}\n`);
@@ -122,6 +122,41 @@ test('tags collapse to one chip whose tooltip and row label carry the names', as
   assert.strictEqual(one.querySelector('.tagchip')!.getAttribute('data-tip'), 'Tag: smoke');
   assert.strictEqual(one.querySelector('.tagchip-n'), null, 'a lone tag needs no count');
   assert.strictEqual(rowOf('plain').querySelector('.tagchip'), null);
+  await act(async () => root.unmount());
+});
+
+test('the logs popup header carries the same tag chip as the row', async () => {
+  const tags = ['aws-rds-workflow-test', 'rds-tests-workflow-test'];
+  const tagged = [
+    `{"type":"test:dequeue","data":{"name":"tagged","nesting":0,"file":"t.test.js","testId":1,"tags":${JSON.stringify(tags)}}}`,
+    '{"type":"test:log","data":{"name":"tagged","nesting":0,"file":"t.test.js","testId":1,"message":"a line of output"}}',
+    `{"type":"test:pass","data":{"name":"tagged","nesting":0,"file":"t.test.js","testId":1,"tags":${JSON.stringify(tags)},"details":{"duration_ms":1},"testNumber":1}}`,
+    '{"type":"test:dequeue","data":{"name":"plain","nesting":0,"file":"t.test.js","testId":2}}',
+    '{"type":"test:log","data":{"name":"plain","nesting":0,"file":"t.test.js","testId":2,"message":"another line"}}',
+    '{"type":"test:pass","data":{"name":"plain","nesting":0,"file":"t.test.js","testId":2,"details":{"duration_ms":1},"testNumber":2}}',
+    SUMMARY,
+  ].join('\n');
+  const { fetchImpl } = fakeSource(`${tagged}\n`);
+  const { root, el } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10 }));
+  });
+  await tick(30);
+  const rowOf = (name: string) => [...el.querySelectorAll('.row')]
+    .find((r) => r.querySelector('.name')?.textContent === name)!;
+
+  await act(async () => { (rowOf('tagged').querySelector('.logbtn') as HTMLElement).click(); });
+  const head = el.querySelector('.pop-head')!;
+  const chip = head.querySelector('.tagchip')!;
+  assert.ok(head.querySelector('.pop-titlerow')!.contains(chip), 'the chip sits beside the title');
+  assert.strictEqual(chip.getAttribute('data-tip'), `2 tags: ${tags.join(' · ')}`);
+  assert.strictEqual(head.querySelector('.tagchip-n')!.textContent, '2');
+  assert.ok(!head.textContent!.includes(tags[0]), 'tag names stay out of the header text');
+  assert.ok(el.querySelector('.pop')!.getAttribute('aria-label')!.includes(`2 tags: ${tags.join(' · ')}`));
+
+  await act(async () => { (el.querySelector('.pbtn-x') as HTMLElement).click(); });
+  await act(async () => { (rowOf('plain').querySelector('.logbtn') as HTMLElement).click(); });
+  assert.strictEqual(el.querySelector('.pop-head')!.querySelector('.tagchip'), null, 'no tags, no chip');
   await act(async () => root.unmount());
 });
 


### PR DESCRIPTION
## What

Tags collapse to one chip on the row (#288), but opening a node's logs covers the tree — and with it the only place the tags were shown. The dialog header names the node and its path, so it should carry the node's metadata too.

The same `.tagchip` now sits beside `.pop-title`, in a new `.pop-titlerow` flex row: the tag glyph, the count when there is more than one tag, and the names in the shared body-level tooltip (`3 tags: @slow · @integration · @flaky`, or `Tag: @smoke` for a lone one). `.pop-title` keeps its ellipsis and gains `min-width: 0`, so a long test name truncates instead of pushing the chip out of the header.

As on the row, the chip is `aria-hidden` and the names are appended to the dialog's existing `aria-label` instead — screen readers still get them, and the modal gains no extra tab stop inside its focus trap.

## Verified

- Ran a `node --test` file with tagged tests (3 tags, 2 tags, untagged) through the `web` reporter, then mounted the built viewer over the resulting NDJSON and opened each logs dialog: the chip renders inside `.pop-titlerow`, carries the same `data-tip` as its row, shows the count only when there is more than one tag, and is absent for an untagged node.
- Served the same log through `startViewerServer` and confirmed the header in the browser.
- New regression test in `packages/web/tests/viewer-component.test.ts` covers the chip's placement, tooltip text, count badge, the tag names staying out of the header text, the dialog `aria-label`, and the untagged case.
- `packages/web` suite: 146/146 passing. `yarn lint` clean (only the 5 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
