### PR TITLE
feat(web): reflect the run in the browser tab

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -113,6 +113,8 @@ const filters = memoryFilterState();
   pollMs={250}                // optional; default 1000
   filters={filters}           // optional; defaults to the shareable page URL
   dense="cozy"                // optional; 'compact' (default) or 'cozy'
+  documentTitle                // optional; off by default — see below
+  favicon                      // optional; off by default — see below
   renderNodeActions={(node: TestNode) => (node.type === 'test'
     ? <button onClick={() => rerun(node)}>↻ rerun</button>
     : null)}
@@ -140,6 +142,43 @@ outside the render (or in `useState`/`useMemo`).
 `dense` picks the row metrics: `compact` (26px rows, the default — a real run is
 hundreds of rows) or `cozy` (34px, a roomier hit area). Below 640px both give
 way to 40px touch rows.
+
+### `documentTitle` and `favicon` — the run in the browser tab
+
+A long run is usually watched from another tab, so the viewer can put its state
+where a background tab still shows it.
+
+`documentTitle` prefixes the page's own title with the run: `62% · CI #841`
+while it streams, `62% 3✕ · CI #841` once something fails, and `✓ · CI #841` or
+`3✕ · CI #841` when it ends. State leads because a tab strip truncates from the
+right, and the percentage floors — a run with one test left never reads 100%.
+Pass a function to build the whole title yourself:
+
+```tsx
+<TestReportViewer
+  src={reportUrl}
+  documentTitle={({ counts, inProgress }, baseTitle) => (
+    inProgress ? `${counts.failed} ✕ so far · ${baseTitle}` : baseTitle
+  )}
+/>
+```
+
+It receives the same progress the header renders — `counts`, `progress` (the
+finished share of the tests discovered *so far*), `inProgress`, `idle` — plus
+the title the page was serving when the viewer mounted.
+
+`favicon` draws the run as a ring: failed, passed, skipped, todo and running
+arcs over the not-yet-run remainder, with failed at 12 o'clock so a failing run
+always paints red in the same place. It is an SVG `data:` URI on a `<link
+rel="icon">` of the viewer's own, appended after the page's — browsers honour
+the last icon declared, so removing it restores whatever the page shipped with.
+Safari has historically ignored favicons swapped at runtime; the title works
+everywhere.
+
+Both are **off by default** in the component: an embedded viewer shares the tab
+with its host, and the host owns what the tab says. Both restore the page's
+title and icon when the viewer unmounts. `startViewer()` turns both on — that
+page is the viewer's own — and takes the same options to turn them off.
 
 ### `startViewer()` — a full viewer page
 

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -8,13 +8,23 @@ import { resolveReportSource, type ViewerOptions as SourceOptions } from '../sou
 import { STYLES } from '../template.ts';
 import { TreeView, type Density, type RenderHeaderActions, type RenderNodeActions } from './TreeView.tsx';
 import { initTooltips } from './tooltip.ts';
+import {
+  progressFavicon, progressTitle, runProgress, useDocumentTitle, useFavicon, type RunProgress,
+} from './tabStatus.ts';
 import type { FilterStore } from './urlState.ts';
 
 export type { ReportSource } from '../source.ts';
 export type { FetchLike } from '../poll.ts';
 export type { Density, RenderHeaderActions, RenderNodeActions } from './TreeView.tsx';
+export { progressFavicon, progressTitle, type RunProgress } from './tabStatus.ts';
 export type { TestNode } from '@reporters/tree-core';
 export { memoryFilterState, urlFilterState, type FilterState, type FilterStore } from './urlState.ts';
+
+/** How the browser tab's title reflects the run: `true` for the built-in
+ *  `62% 3✕ · <page title>` format, or a function returning the whole title —
+ *  it receives the same progress the header renders, plus the title the page
+ *  was serving when the viewer mounted. */
+export type DocumentTitle = boolean | ((progress: RunProgress, baseTitle: string) => string);
 
 export interface ViewerOptions extends SourceOptions {
   /** Render custom trailing content (e.g. action buttons) at the end of every
@@ -28,6 +38,11 @@ export interface ViewerOptions extends SourceOptions {
    *  buttons (search, theme, collapse all), inside a `.header-actions` wrapper.
    *  Called on each render (frequent during a live run), so keep it cheap. */
   renderHeaderActions?: RenderHeaderActions;
+  /** Keep the run in the page's title. On by default — the page is the
+   *  viewer's own. Pass `false` to leave the title alone. */
+  documentTitle?: DocumentTitle;
+  /** Keep the run in the page's icon, as a ring of status arcs. On by default. */
+  favicon?: boolean;
 }
 
 const delay = (ms: number) => new Promise((resolve) => { setTimeout(resolve, ms); });
@@ -130,6 +145,19 @@ export interface TestReportViewerProps {
   onRetry?: () => void;
   /** Row density: `compact` (default) or `cozy`. */
   dense?: Density;
+  /** Put the run in the browser tab's title, restoring the page's own on
+   *  unmount. Off by default: an embedded viewer shares the tab with its host,
+   *  which owns what the tab says. */
+  documentTitle?: DocumentTitle;
+  /** Put the run in the browser tab's icon — a ring of failed/passed/skipped/
+   *  todo/running arcs over the not-yet-run remainder — restoring the page's
+   *  own icon on unmount. Off by default, for the same reason. */
+  favicon?: boolean;
+}
+
+function titleFor(option: DocumentTitle, progress: RunProgress, baseTitle: string): string | undefined {
+  if (!option) return undefined;
+  return typeof option === 'function' ? option(progress, baseTitle) : progressTitle(progress, baseTitle);
 }
 
 /** The report viewer as a React component: render it anywhere in a host app.
@@ -137,12 +165,19 @@ export interface TestReportViewerProps {
  *  unmount. Injects its stylesheet into document.head before first paint. */
 export function TestReportViewer({
   src, fetch: fetchImpl, pollMs = DEFAULT_POLL_MS, renderNodeActions, renderHeaderActions, filters, onRetry, dense,
+  documentTitle = false, favicon = false,
 }: TestReportViewerProps) {
   useInsertionEffect(() => { injectStyles(); }, []);
   useEffect(() => { initTooltips(); }, []);
   const {
     snapshot, streaming, pending, loadError, retry,
   } = useReportStream(src, fetchImpl, pollMs);
+  // Read before the first badge is written, so restoring can't hand back a
+  // title of our own making.
+  const [baseTitle] = useState(() => document.title);
+  const progress = runProgress(snapshot, streaming);
+  useDocumentTitle(titleFor(documentTitle, progress, baseTitle), baseTitle);
+  useFavicon(favicon ? progressFavicon(progress) : undefined);
   return (
     <TreeView
       snapshot={snapshot}
@@ -176,6 +211,8 @@ export async function startViewer(options: ViewerOptions = {}): Promise<void> {
       pollMs={source?.pollMs}
       renderNodeActions={options.renderNodeActions}
       renderHeaderActions={options.renderHeaderActions}
+      documentTitle={options.documentTitle ?? true}
+      favicon={options.favicon ?? true}
       // No usable source (missing/rejected ?src=): a retry must re-run source
       // resolution, so reload the page rather than restart a stream.
       onRetry={source ? undefined : () => window.location.reload()}

--- a/packages/web/src/client/tabStatus.ts
+++ b/packages/web/src/client/tabStatus.ts
@@ -1,0 +1,119 @@
+import { useEffect, useRef } from 'react';
+import type { Counts, TreeSnapshot } from '@reporters/tree-core';
+
+/** What a tab can say about the run — the numbers the header already shows. */
+export interface RunProgress {
+  counts: Counts;
+  /** Finished share (0–1) of the tests discovered *so far*. A live run's total
+   *  grows as files are dequeued, so this can move backwards. */
+  progress: number;
+  /** Nothing has arrived yet: no counts, no summary — there is no run to show. */
+  idle: boolean;
+  /** Still streaming, or something is running or queued. */
+  inProgress: boolean;
+}
+
+/** Statuses that get an arc, outermost first — failed leads so a failing run
+ *  always paints red at 12 o'clock, wherever the rest of the ring lands. */
+const RING: readonly (readonly [keyof Counts, string])[] = [
+  ['failed', '#fb5a6a'],
+  ['passed', '#34d27b'],
+  ['skipped', '#8a93a1'],
+  ['todo', '#7c9cff'],
+  ['running', '#ffb13d'],
+];
+/** The not-yet-run remainder. A favicon is its own document, with no access to
+ *  the page's CSS variables, so the ring's palette is spelled out here. */
+const TRACK = '#5d6573';
+const RADIUS = 6;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export function runProgress(snapshot: TreeSnapshot, streaming: boolean): RunProgress {
+  const { counts } = snapshot;
+  const finished = counts.total - counts.running - counts.queued;
+  return {
+    counts,
+    progress: counts.total > 0 ? finished / counts.total : 0,
+    idle: counts.total === 0 && !snapshot.summary,
+    inProgress: !snapshot.summary && (streaming || counts.running > 0 || counts.queued > 0),
+  };
+}
+
+/** `62% 3✕ · <page title>`. State leads because a tab strip truncates from the
+ *  right, and floors because a run that has one test left is not at 100%. */
+export function progressTitle(progress: RunProgress, baseTitle: string): string {
+  if (progress.idle) return baseTitle;
+  const failed = progress.counts.failed > 0 ? `${progress.counts.failed}✕` : '';
+  const lead = progress.inProgress
+    ? [`${Math.floor(progress.progress * 100)}%`, failed].filter(Boolean).join(' ')
+    : failed || '✓';
+  return baseTitle ? `${lead} · ${baseTitle}` : lead;
+}
+
+const round = (n: number): number => Math.round(n * 100) / 100;
+
+function arc(color: string, length: number, offset: number): string {
+  return `<circle cx="8" cy="8" r="${RADIUS}" fill="none" stroke="${color}" stroke-width="4"`
+    + ` stroke-dasharray="${round(length)} ${round(CIRCUMFERENCE - length)}"`
+    + ` stroke-dashoffset="${round(-offset)}" transform="rotate(-90 8 8)"/>`;
+}
+
+/** A `data:` URI for the run as a ring: one arc per status over the track, so
+ *  the tab carries how far along the run is and how much of it is red without
+ *  being read as text. */
+export function progressFavicon(progress: RunProgress): string {
+  const total = Math.max(progress.counts.total, 1);
+  const arcs: string[] = [];
+  let offset = 0;
+  for (const [status, color] of RING) {
+    const length = (progress.counts[status] / total) * CIRCUMFERENCE;
+    if (length > 0) {
+      arcs.push(arc(color, length, offset));
+      offset += length;
+    }
+  }
+  const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'
+    + `<circle cx="8" cy="8" r="${RADIUS}" fill="none" stroke="${TRACK}" stroke-width="4"/>`
+    + `${arcs.join('')}</svg>`;
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+/** Show `next` in the tab, handing `baseTitle` back when it goes undefined or
+ *  the viewer unmounts. */
+export function useDocumentTitle(next: string | undefined, baseTitle: string): void {
+  const owned = useRef(false);
+  useEffect(() => {
+    if (next === undefined) {
+      if (owned.current) document.title = baseTitle;
+      owned.current = false;
+      return;
+    }
+    owned.current = true;
+    if (document.title !== next) document.title = next;
+  }, [next, baseTitle]);
+  useEffect(() => () => { if (owned.current) document.title = baseTitle; }, [baseTitle]);
+}
+
+/** Show `href` as the tab's icon. Appended as a second `<link rel="icon">`
+ *  rather than written into the page's own: browsers honour the last icon
+ *  declared, so dropping ours restores whatever the page shipped with. */
+export function useFavicon(href: string | undefined): void {
+  const link = useRef<HTMLLinkElement | null>(null);
+  useEffect(() => {
+    if (href === undefined) {
+      link.current?.remove();
+      link.current = null;
+      return;
+    }
+    if (!link.current) {
+      link.current = document.createElement('link');
+      link.current.rel = 'icon';
+      link.current.type = 'image/svg+xml';
+      document.head.appendChild(link.current);
+    }
+    // Re-assigning an unchanged href re-fetches the icon in some browsers, and
+    // a live run re-renders several times a second.
+    if (link.current.getAttribute('href') !== href) link.current.setAttribute('href', href);
+  }, [href]);
+  useEffect(() => () => { link.current?.remove(); link.current = null; }, []);
+}

--- a/packages/web/tests/tabStatus.test.ts
+++ b/packages/web/tests/tabStatus.test.ts
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert';
+import { progressFavicon, progressTitle, runProgress } from '../src/client/tabStatus.ts';
+import type { Counts, TreeSnapshot } from '@reporters/tree-core';
+
+const counts = (over: Partial<Counts> = {}): Counts => ({
+  passed: 0, failed: 0, skipped: 0, todo: 0, running: 0, queued: 0, carried: 0, total: 0, ...over,
+});
+
+const snapshot = (c: Partial<Counts>, summary?: boolean): TreeSnapshot => ({
+  version: 1,
+  root: {} as TreeSnapshot['root'],
+  counts: counts(c),
+  ...(summary ? { summary: { durationMs: 1, success: true } as TreeSnapshot['summary'] } : {}),
+});
+
+test('progress is the finished share of what has been discovered so far', () => {
+  const p = runProgress(snapshot({
+    passed: 3, failed: 1, running: 2, queued: 4, total: 10,
+  }), true);
+  assert.strictEqual(p.progress, 0.4);
+  assert.strictEqual(p.inProgress, true);
+  assert.strictEqual(p.idle, false);
+});
+
+test('an empty stream is idle, and a finished run is neither idle nor in progress', () => {
+  assert.strictEqual(runProgress(snapshot({}), true).idle, true);
+  const done = runProgress(snapshot({ passed: 2, total: 2 }, true), false);
+  assert.strictEqual(done.idle, false);
+  assert.strictEqual(done.inProgress, false);
+  assert.strictEqual(done.progress, 1);
+});
+
+test('a stream that has stopped without a summary is no longer in progress', () => {
+  assert.strictEqual(runProgress(snapshot({ passed: 2, total: 2 }), false).inProgress, false);
+});
+
+test('title: an idle viewer keeps the page title untouched', () => {
+  assert.strictEqual(progressTitle(runProgress(snapshot({}), true), 'node:test viewer'), 'node:test viewer');
+});
+
+test('title: a live run leads with the percentage, and the failures once there are any', () => {
+  const live = (c: Partial<Counts>) => progressTitle(runProgress(snapshot(c), true), 'run 42');
+  assert.strictEqual(live({ passed: 5, queued: 5, total: 10 }), '50% · run 42');
+  assert.strictEqual(live({ passed: 4, failed: 3, queued: 3, total: 10 }), '70% 3✕ · run 42');
+});
+
+test('title: the percentage floors, so a run with anything left never reads 100%', () => {
+  const p = runProgress(snapshot({ passed: 999, running: 1, total: 1000 }), true);
+  assert.strictEqual(progressTitle(p, 'run 42'), '99% · run 42');
+});
+
+test('title: a finished run reads as its verdict', () => {
+  const done = (c: Partial<Counts>) => progressTitle(runProgress(snapshot(c, true), false), 'run 42');
+  assert.strictEqual(done({ passed: 10, total: 10 }), '✓ · run 42');
+  assert.strictEqual(done({ passed: 7, failed: 3, total: 10 }), '3✕ · run 42');
+});
+
+test('title: a page with no title of its own gets the run alone', () => {
+  assert.strictEqual(progressTitle(runProgress(snapshot({ passed: 1, queued: 1, total: 2 }), true), ''), '50%');
+});
+
+const svg = (uri: string): string => {
+  assert.ok(uri.startsWith('data:image/svg+xml,'));
+  return decodeURIComponent(uri.slice('data:image/svg+xml,'.length));
+};
+
+test('favicon: an idle run is the bare track ring', () => {
+  const markup = svg(progressFavicon(runProgress(snapshot({}), true)));
+  assert.match(markup, /^<svg xmlns="http:\/\/www\.w3\.org\/2000\/svg" viewBox="0 0 16 16">/);
+  assert.strictEqual(markup.match(/<circle/g)?.length, 1);
+});
+
+test('favicon: one arc per non-empty status, failed first and laid end to end', () => {
+  const markup = svg(progressFavicon(runProgress(snapshot({
+    passed: 5, failed: 1, running: 2, queued: 2, total: 10,
+  }), true)));
+  const strokes = [...markup.matchAll(/stroke="(#[0-9a-f]{6})"/g)].map((m) => m[1]);
+  assert.deepStrictEqual(strokes, ['#5d6573', '#fb5a6a', '#34d27b', '#ffb13d']);
+  const offsets = [...markup.matchAll(/stroke-dashoffset="(-?[\d.]+)"/g)].map((m) => Number(m[1]));
+  const lengths = [...markup.matchAll(/stroke-dasharray="([\d.]+) /g)].map((m) => Number(m[1]));
+  assert.deepStrictEqual(offsets, [0, -lengths[0], -(lengths[0] + lengths[1])].map((n) => Math.round(n * 100) / 100));
+  // Queued is the only status left unpainted: it is what the track shows.
+  assert.ok(lengths.reduce((a, b) => a + b, 0) < 2 * Math.PI * 6);
+});
+
+test('favicon: an all-passing run closes the ring', () => {
+  const markup = svg(progressFavicon(runProgress(snapshot({ passed: 4, total: 4 }, true), false)));
+  const [dash, gap] = [...markup.matchAll(/stroke-dasharray="([\d.]+) ([\d.]+)"/g)][0].slice(1).map(Number);
+  assert.strictEqual(dash, Math.round(2 * Math.PI * 6 * 100) / 100);
+  assert.strictEqual(gap, 0);
+});

--- a/packages/web/tests/tabStatus.test.ts
+++ b/packages/web/tests/tabStatus.test.ts
@@ -1,7 +1,26 @@
-import { test } from 'node:test';
+import { afterEach, test } from 'node:test';
 import assert from 'node:assert';
-import { progressFavicon, progressTitle, runProgress } from '../src/client/tabStatus.ts';
+import { JSDOM } from 'jsdom';
+import type ReactTypes from 'react';
+import type { Root } from 'react-dom/client';
+import {
+  progressFavicon, progressTitle, runProgress, useDocumentTitle, useFavicon,
+} from '../src/client/tabStatus.ts';
 import type { Counts, TreeSnapshot } from '@reporters/tree-core';
+
+const dom = new JSDOM('', { url: 'http://localhost/' });
+(globalThis as any).window = dom.window;
+(globalThis as any).document = dom.window.document;
+Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// react-dom snapshots the environment at module evaluation, so it loads only
+// once the DOM globals above exist. The hooks under test are the source
+// module's, not the bundle's — they own the page's title and icon, which no
+// pure assertion can reach.
+const React = (await import('react')).default;
+const { act } = await import('react');
+const { createRoot } = await import('react-dom/client');
 
 const counts = (over: Partial<Counts> = {}): Counts => ({
   passed: 0, failed: 0, skipped: 0, todo: 0, running: 0, queued: 0, carried: 0, total: 0, ...over,
@@ -89,4 +108,86 @@ test('favicon: an all-passing run closes the ring', () => {
   const [dash, gap] = [...markup.matchAll(/stroke-dasharray="([\d.]+) ([\d.]+)"/g)][0].slice(1).map(Number);
   assert.strictEqual(dash, Math.round(2 * Math.PI * 6 * 100) / 100);
   assert.strictEqual(gap, 0);
+});
+
+const mounted: Root[] = [];
+afterEach(async () => {
+  const roots = mounted.splice(0);
+  await act(async () => { for (const r of roots) r.unmount(); });
+});
+
+interface HarnessProps { title?: string; baseTitle?: string; icon?: string }
+
+function Harness({ title, baseTitle = '', icon }: HarnessProps) {
+  useDocumentTitle(title, baseTitle);
+  useFavicon(icon);
+  return null;
+}
+
+async function render(props: HarnessProps): Promise<{ root: Root; update: (next: HarnessProps) => Promise<void> }> {
+  const root = createRoot(dom.window.document.createElement('div'));
+  mounted.push(root);
+  const draw = (p: HarnessProps) => act(async () => {
+    root.render(React.createElement(Harness as ReactTypes.FunctionComponent<HarnessProps>, p));
+  });
+  await draw(props);
+  return { root, update: draw };
+}
+
+const icons = () => [...dom.window.document.head.querySelectorAll('link[rel="icon"]')] as HTMLLinkElement[];
+
+test('useDocumentTitle: follows the title it is given', async () => {
+  dom.window.document.title = 'host app';
+  const { update } = await render({ title: '10% · host app', baseTitle: 'host app' });
+  assert.strictEqual(dom.window.document.title, '10% · host app');
+  await update({ title: '90% 2✕ · host app', baseTitle: 'host app' });
+  assert.strictEqual(dom.window.document.title, '90% 2✕ · host app');
+});
+
+test('useDocumentTitle: hands the base title back when switched off, and again on unmount', async () => {
+  dom.window.document.title = 'host app';
+  const { root, update } = await render({ title: '10% · host app', baseTitle: 'host app' });
+  await update({ baseTitle: 'host app' });
+  assert.strictEqual(dom.window.document.title, 'host app');
+
+  // Switched off, the hook owns nothing: a title the host sets afterwards has
+  // to survive the unmount that follows.
+  dom.window.document.title = 'host app, elsewhere';
+  await act(async () => root.unmount());
+  assert.strictEqual(dom.window.document.title, 'host app, elsewhere');
+});
+
+test('useDocumentTitle: restores on unmount', async () => {
+  dom.window.document.title = 'host app';
+  const { root } = await render({ title: '10% · host app', baseTitle: 'host app' });
+  await act(async () => root.unmount());
+  assert.strictEqual(dom.window.document.title, 'host app');
+});
+
+test('useDocumentTitle: leaves a page it was never given a title for alone', async () => {
+  dom.window.document.title = 'host app';
+  const { root } = await render({ baseTitle: 'host app' });
+  assert.strictEqual(dom.window.document.title, 'host app');
+  await act(async () => root.unmount());
+  assert.strictEqual(dom.window.document.title, 'host app');
+});
+
+test('useFavicon: adds one icon link and re-points that same element', async () => {
+  const { update } = await render({ icon: 'data:image/svg+xml,%3Csvg%3E' });
+  assert.strictEqual(icons().length, 1);
+  const [link] = icons();
+  assert.strictEqual(link.getAttribute('type'), 'image/svg+xml');
+  await update({ icon: 'data:image/svg+xml,%3Csvg%20id%3D%222%22%3E' });
+  assert.deepStrictEqual(icons(), [link], 'the same link, re-pointed');
+  assert.strictEqual(link.getAttribute('href'), 'data:image/svg+xml,%3Csvg%20id%3D%222%22%3E');
+});
+
+test('useFavicon: drops its link when switched off, and on unmount', async () => {
+  const { root, update } = await render({ icon: 'data:image/svg+xml,%3Csvg%3E' });
+  await update({});
+  assert.deepStrictEqual(icons(), []);
+  await update({ icon: 'data:image/svg+xml,%3Csvg%3E' });
+  assert.strictEqual(icons().length, 1);
+  await act(async () => root.unmount());
+  assert.deepStrictEqual(icons(), []);
 });

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -489,3 +489,58 @@ test('a rollup with no failing descendant to point at keeps its error', async ()
   assert.ok(el.querySelector('.pop-msg')!.textContent!.includes('1 subtest failed'), 'so the error still shows');
   await act(async () => root.unmount());
 });
+
+test('the tab is left alone unless the host asks for it', async () => {
+  dom.window.document.title = 'host app';
+  const { fetchImpl } = fakeSource(`${LOG}\n${SUMMARY}\n`);
+  const { root } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, { src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filters: memoryFilterState() }));
+  });
+  await tick(30);
+  assert.strictEqual(dom.window.document.title, 'host app');
+  assert.strictEqual(dom.window.document.head.querySelector('link[rel="icon"]'), null);
+  await act(async () => root.unmount());
+});
+
+test('documentTitle and favicon follow the run, and hand the page back on unmount', async () => {
+  dom.window.document.title = 'host app';
+  const { state, fetchImpl } = fakeSource(`${LOG}\n`);
+  const { root } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, {
+      src: '/run.ndjson', fetch: fetchImpl, pollMs: 10, filters: memoryFilterState(), documentTitle: true, favicon: true,
+    }));
+  });
+  await tick(30);
+  assert.strictEqual(dom.window.document.title, '100% · host app');
+  const icon = dom.window.document.head.querySelector('link[rel="icon"]') as HTMLLinkElement;
+  assert.match(icon.getAttribute('href')!, /^data:image\/svg\+xml,/);
+
+  state.body += `${SUMMARY}\n`;
+  await tick(30);
+  assert.strictEqual(dom.window.document.title, '✓ · host app');
+
+  await act(async () => root.unmount());
+  assert.strictEqual(dom.window.document.title, 'host app');
+  assert.strictEqual(dom.window.document.head.querySelector('link[rel="icon"]'), null);
+});
+
+test('a documentTitle function owns the whole title', async () => {
+  dom.window.document.title = 'host app';
+  const { fetchImpl } = fakeSource(`${LOG}\n${SUMMARY}\n`);
+  const { root } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, {
+      src: '/run.ndjson',
+      fetch: fetchImpl,
+      pollMs: 10,
+      filters: memoryFilterState(),
+      documentTitle: (progress: { counts: { passed: number } }, base: string) => `${progress.counts.passed} passed — ${base}`,
+    }));
+  });
+  await tick(30);
+  assert.strictEqual(dom.window.document.title, '1 passed — host app');
+  await act(async () => root.unmount());
+  assert.strictEqual(dom.window.document.title, 'host app');
+});


### PR DESCRIPTION
## What

A long run is usually watched from another tab — the tree is out of sight for most of it. The viewer can now carry the run's state where a background tab still shows it, in the title and the favicon.

**`documentTitle`** prefixes the page's own title: `62% · CI #841` while it streams, `62% 3✕ · CI #841` once something fails, `✓ · CI #841` or `3✕ · CI #841` when it ends. State leads because a tab strip truncates from the right, and the percentage floors, so a run with one test left never reads 100%. Passing a function instead of `true` hands the caller the whole title, with the same progress the header renders (`counts`, `progress`, `inProgress`, `idle`) plus the title the page was serving when the viewer mounted.

**`favicon`** draws the run as a ring — failed, passed, skipped, todo and running arcs over the not-yet-run remainder, failed first so a failing run always paints red at 12 o'clock. It is an SVG `data:` URI on a `<link rel="icon">` of the viewer's own, appended after the page's: browsers honour the last icon declared, so removing it restores whatever the page shipped with, and the page's own icon never has to be remembered. The palette is spelled out in `tabStatus.ts` rather than taken from the theme — a favicon is its own document and sees none of the page's CSS variables.

Both are **off by default** in `<TestReportViewer>`: an embedded viewer shares a tab with its host, and the host owns what that tab says. `startViewer()` turns both on, since that page is the viewer's own, and takes the same two options to turn them off. Both restore the page's title and icon on unmount.

The progress the tab shows is the same `snapshot.counts` the header renders — no new state, and `inProgress` is computed exactly as `TreeView` computes it.

## Verified

- Rendered every state of the ring (idle, just started, half way, half way failing, mixed statuses, done green, done failing) at 64px and 16px over both a dark and a light tab strip: arcs lay end to end from 12 o'clock, the track carries the queued remainder, and the red/green split stays legible at favicon size.
- New `packages/web/tests/tabStatus.test.ts` covers the progress maths (including a live total that grows), the title in each state, the floor, an empty base title, and the ring's arc order, offsets and closure.
- New cases in `packages/web/tests/viewer-component.test.ts` mount the built bundle and assert the tab is untouched by default, follows the run when asked, takes a function's title verbatim, and hands the page back its title and icon on unmount.
- `packages/web` suite: 159/159 passing. `yarn lint` clean (only the 5 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)