### PR TITLE
fix(web): make the favicon's verdict survive a mostly-passing run

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -167,13 +167,21 @@ It receives the same progress the header renders — `counts`, `progress` (the
 finished share of the tests discovered *so far*), `inProgress`, `idle` — plus
 the title the page was serving when the viewer mounted.
 
-`favicon` draws the run as a ring: failed, passed, skipped, todo and running
-arcs over the not-yet-run remainder, with failed at 12 o'clock so a failing run
-always paints red in the same place. It is an SVG `data:` URI on a `<link
-rel="icon">` of the viewer's own, appended after the page's — browsers honour
-the last icon declared, so removing it restores whatever the page shipped with.
-Safari has historically ignored favicons swapped at runtime; the title works
-everywhere.
+`favicon` draws the run as a dot inside a ring. The **dot** is the verdict —
+red if anything has failed, amber while the run is going, green once it lands
+clean — and it is what survives being scaled to 16px. The **ring** is the
+breakdown: failed, passed, skipped, todo and running arcs over the not-yet-run
+remainder, failed first so red lands at 12 o'clock.
+
+Splitting the two matters more than it sounds. A run that fails 2 of 364 tests
+paints half a percent of the ring red — two pixels in a tab strip — and a ring
+alone would read as passing. The dot does not care about proportion: one
+failure turns it red.
+
+It is an SVG `data:` URI on a `<link rel="icon">` of the viewer's own, appended
+after the page's — browsers honour the last icon declared, so removing it
+restores whatever the page shipped with. Safari has historically ignored
+favicons swapped at runtime; the title works everywhere.
 
 Both are **off by default** in the component: an embedded viewer shares the tab
 with its host, and the host owns what the tab says. Both restore the page's

--- a/packages/web/src/client/tabStatus.ts
+++ b/packages/web/src/client/tabStatus.ts
@@ -13,19 +13,28 @@ export interface RunProgress {
   inProgress: boolean;
 }
 
-/** Statuses that get an arc, outermost first — failed leads so a failing run
- *  always paints red at 12 o'clock, wherever the rest of the ring lands. */
-const RING: readonly (readonly [keyof Counts, string])[] = [
-  ['failed', '#fb5a6a'],
-  ['passed', '#34d27b'],
-  ['skipped', '#8a93a1'],
-  ['todo', '#7c9cff'],
-  ['running', '#ffb13d'],
-];
-/** The not-yet-run remainder. A favicon is its own document, with no access to
- *  the page's CSS variables, so the ring's palette is spelled out here. */
-const TRACK = '#5d6573';
-const RADIUS = 6;
+/** The favicon's palette. A favicon is its own document, with no access to the page's CSS
+ *  variables, so the colours are spelled out here. */
+const COLOR = {
+  failed: '#fb5a6a',
+  passed: '#34d27b',
+  skipped: '#8a93a1',
+  todo: '#7c9cff',
+  running: '#ffb13d',
+  /** Discovered but not yet run — the ring's unspent remainder. */
+  queued: '#5d6573',
+} as const;
+
+/** Statuses that get an arc, in ring order — failed leads so a failing run paints red at 12
+ *  o'clock, wherever the rest of the ring lands. `queued` is the track they are drawn over. */
+const RING: readonly (keyof Counts & keyof typeof COLOR)[] = ['failed', 'passed', 'skipped', 'todo', 'running'];
+
+const RADIUS = 6.5;
+const RING_WIDTH = 3;
+/** The verdict dot, sized to leave a gap inside the arcs so the two never read as one shape. It is
+ *  the part that survives being scaled to a favicon: at 16px the arcs are texture, and a run that
+ *  fails two of four hundred tests would otherwise paint two red pixels and read as passing. */
+const DOT_RADIUS = 3.5;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
 export function runProgress(snapshot: TreeSnapshot, streaming: boolean): RunProgress {
@@ -53,28 +62,35 @@ export function progressTitle(progress: RunProgress, baseTitle: string): string 
 const round = (n: number): number => Math.round(n * 100) / 100;
 
 function arc(color: string, length: number, offset: number): string {
-  return `<circle cx="8" cy="8" r="${RADIUS}" fill="none" stroke="${color}" stroke-width="4"`
+  return `<circle cx="8" cy="8" r="${RADIUS}" fill="none" stroke="${color}" stroke-width="${RING_WIDTH}"`
     + ` stroke-dasharray="${round(length)} ${round(CIRCUMFERENCE - length)}"`
     + ` stroke-dashoffset="${round(-offset)}" transform="rotate(-90 8 8)"/>`;
 }
 
-/** A `data:` URI for the run as a ring: one arc per status over the track, so
- *  the tab carries how far along the run is and how much of it is red without
- *  being read as text. */
+/** The colour the run as a whole is going: one failure makes it red, whatever the other counts. */
+function verdictColor(progress: RunProgress): string {
+  if (progress.counts.failed > 0) return COLOR.failed;
+  return progress.inProgress ? COLOR.running : COLOR.passed;
+}
+
+/** A `data:` URI for the run: a filled dot in the verdict's colour, ringed by the breakdown — one
+ *  arc per status over the not-yet-run remainder. */
 export function progressFavicon(progress: RunProgress): string {
   const total = Math.max(progress.counts.total, 1);
   const arcs: string[] = [];
   let offset = 0;
-  for (const [status, color] of RING) {
+  for (const status of RING) {
     const length = (progress.counts[status] / total) * CIRCUMFERENCE;
     if (length > 0) {
-      arcs.push(arc(color, length, offset));
+      arcs.push(arc(COLOR[status], length, offset));
       offset += length;
     }
   }
   const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'
-    + `<circle cx="8" cy="8" r="${RADIUS}" fill="none" stroke="${TRACK}" stroke-width="4"/>`
-    + `${arcs.join('')}</svg>`;
+    + `<circle cx="8" cy="8" r="${RADIUS}" fill="none" stroke="${COLOR.queued}" stroke-width="${RING_WIDTH}"/>`
+    + arcs.join('')
+    + `<circle cx="8" cy="8" r="${DOT_RADIUS}" fill="${verdictColor(progress)}"/>`
+    + '</svg>';
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
 }
 

--- a/packages/web/tests/tabStatus.test.ts
+++ b/packages/web/tests/tabStatus.test.ts
@@ -84,10 +84,14 @@ const svg = (uri: string): string => {
   return decodeURIComponent(uri.slice('data:image/svg+xml,'.length));
 };
 
-test('favicon: an idle run is the bare track ring', () => {
+const RING_CIRCUMFERENCE = Math.round(2 * Math.PI * 6.5 * 100) / 100;
+/** The verdict dot is the last circle drawn, and the only filled one. */
+const dotColor = (markup: string): string | undefined => /<circle[^>]*fill="(#[0-9a-f]{6})"/.exec(markup)?.[1];
+
+test('favicon: an idle run is the bare track ring around the dot', () => {
   const markup = svg(progressFavicon(runProgress(snapshot({}), true)));
   assert.match(markup, /^<svg xmlns="http:\/\/www\.w3\.org\/2000\/svg" viewBox="0 0 16 16">/);
-  assert.strictEqual(markup.match(/<circle/g)?.length, 1);
+  assert.strictEqual(markup.match(/<circle/g)?.length, 2, 'the track and the dot, no arcs');
 });
 
 test('favicon: one arc per non-empty status, failed first and laid end to end', () => {
@@ -100,14 +104,38 @@ test('favicon: one arc per non-empty status, failed first and laid end to end', 
   const lengths = [...markup.matchAll(/stroke-dasharray="([\d.]+) /g)].map((m) => Number(m[1]));
   assert.deepStrictEqual(offsets, [0, -lengths[0], -(lengths[0] + lengths[1])].map((n) => Math.round(n * 100) / 100));
   // Queued is the only status left unpainted: it is what the track shows.
-  assert.ok(lengths.reduce((a, b) => a + b, 0) < 2 * Math.PI * 6);
+  assert.ok(lengths.reduce((a, b) => a + b, 0) < RING_CIRCUMFERENCE);
 });
 
 test('favicon: an all-passing run closes the ring', () => {
   const markup = svg(progressFavicon(runProgress(snapshot({ passed: 4, total: 4 }, true), false)));
   const [dash, gap] = [...markup.matchAll(/stroke-dasharray="([\d.]+) ([\d.]+)"/g)][0].slice(1).map(Number);
-  assert.strictEqual(dash, Math.round(2 * Math.PI * 6 * 100) / 100);
+  assert.strictEqual(dash, RING_CIRCUMFERENCE);
   assert.strictEqual(gap, 0);
+});
+
+test('favicon: the dot is the verdict — one failure in a sea of passes still reads red', () => {
+  const markup = svg(progressFavicon(runProgress(snapshot({
+    passed: 347, failed: 2, skipped: 9, todo: 6, total: 364,
+  }, true), false)));
+  assert.strictEqual(dotColor(markup), '#fb5a6a');
+  // The arc that colour stands in for is half a percent of the ring — two pixels at favicon size.
+  const [failedArc] = [...markup.matchAll(/stroke-dasharray="([\d.]+) /g)].map((m) => Number(m[1]));
+  assert.ok(failedArc < RING_CIRCUMFERENCE / 100, `failed arc is ${failedArc} of ${RING_CIRCUMFERENCE}`);
+});
+
+test('favicon: a clean run is amber while it runs and green once it lands', () => {
+  const live = svg(progressFavicon(runProgress(snapshot({ passed: 5, running: 1, queued: 4, total: 10 }), true)));
+  assert.strictEqual(dotColor(live), '#ffb13d');
+  const done = svg(progressFavicon(runProgress(snapshot({ passed: 10, total: 10 }, true), false)));
+  assert.strictEqual(dotColor(done), '#34d27b');
+});
+
+test('favicon: a failure outranks a run still in progress', () => {
+  const markup = svg(progressFavicon(runProgress(snapshot({
+    passed: 4, failed: 1, running: 1, queued: 4, total: 10,
+  }), true)));
+  assert.strictEqual(dotColor(markup), '#fb5a6a');
 });
 
 const mounted: Root[] = [];


### PR DESCRIPTION
## What

The favicon gave every status a proportional arc, which meant the thing it most needed to say was the thing it could not say. A run that fails **2 of 364** tests paints half a percent of the ring red — two pixels in a tab strip — so a failing run's icon was, for all practical purposes, green.

The fix splits the two jobs the icon was trying to do with one shape:

- **The dot** (filled, centre) is the verdict: red if anything has failed, amber while the run is going, green once it lands clean. It has no proportion to be diluted by — one failure turns it red.
- **The ring** keeps the breakdown: failed, passed, skipped, todo and running arcs over the not-yet-run remainder, failed first so red lands at 12 o'clock.

A failure outranks in-progress, so a run that fails early is red for the rest of its life rather than going amber again.

The ring is now `r=6.5` at `stroke-width=3` (it was `r=6` at `4`) to make room for an `r=3.5` dot with a clear gap between them, so the two never read as one shape.

## Verified

Rendered at 64px and 16px over both a dark and a light tab strip, including the run that prompted this — 347 passed / 2 failed / 9 skipped / 6 todo, which now reads as a red dot in a green ring: failing at a glance, while the ring still says almost everything passed.

Also covered: one failure at 4% (the case where the old ring was *also* mostly grey), a clean run at 2% / 49% / done, and idle.

- New cases in `packages/web/tests/tabStatus.test.ts` pin the dot's colour for the sea-of-passes run (asserting alongside it that the failed arc really is under 1% of the ring), for clean-live vs clean-done, and for failure-outranks-running.
- `packages/web` suite: 168/168 passing, `tabStatus.ts` at 100% coverage. `yarn lint` clean (only the 5 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
