### PR TITLE
feat(web): stop the favicon flickering, and give its dot a pulse

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -178,9 +178,21 @@ paints half a percent of the ring red — two pixels in a tab strip — and a ri
 alone would read as passing. The dot does not care about proportion: one
 failure turns it red.
 
-It is an SVG `data:` URI on a `<link rel="icon">` of the viewer's own, appended
-after the page's — browsers honour the last icon declared, so removing it
-restores whatever the page shipped with. Safari has historically ignored
+While the run is still going the dot **breathes** — a slow pulse that stops the
+moment the run lands, so the tab has a sign of life once the arcs stop moving.
+`prefers-reduced-motion: reduce` turns it off, and a hidden tab clamps the
+timer behind it to roughly a second, where it coarsens into a blink rather than
+stopping.
+
+The icon goes on a `<link rel="icon">` of the viewer's own, appended after the
+page's — browsers honour the last icon declared, so removing it restores
+whatever the page shipped with. It is drawn on a canvas and handed over as a
+PNG `data:` URI, falling back to SVG where no 2D context is available: a
+browser decodes a new icon asynchronously and keeps painting the next-best
+candidate it already holds until that lands, which for an icon repainting many
+times a second is a constant visible flicker back to the page's own favicon.
+The ring's arcs are rounded to whole pixels for the same reason — a boundary no
+display can resolve is not worth an icon swap. Safari has historically ignored
 favicons swapped at runtime; the title works everywhere.
 
 Both are **off by default** in the component: an embedded viewer shares the tab

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -9,14 +9,14 @@ import { STYLES } from '../template.ts';
 import { TreeView, type Density, type RenderHeaderActions, type RenderNodeActions } from './TreeView.tsx';
 import { initTooltips } from './tooltip.ts';
 import {
-  progressFavicon, progressTitle, runProgress, useDocumentTitle, useFavicon, type RunProgress,
+  progressTitle, runProgress, useDocumentTitle, useProgressFavicon, type RunProgress,
 } from './tabStatus.ts';
 import type { FilterStore } from './urlState.ts';
 
 export type { ReportSource } from '../source.ts';
 export type { FetchLike } from '../poll.ts';
 export type { Density, RenderHeaderActions, RenderNodeActions } from './TreeView.tsx';
-export { progressFavicon, progressTitle, type RunProgress } from './tabStatus.ts';
+export { paintFavicon, progressFavicon, progressTitle, type RunProgress } from './tabStatus.ts';
 export type { TestNode } from '@reporters/tree-core';
 export { memoryFilterState, urlFilterState, type FilterState, type FilterStore } from './urlState.ts';
 
@@ -150,8 +150,9 @@ export interface TestReportViewerProps {
    *  which owns what the tab says. */
   documentTitle?: DocumentTitle;
   /** Put the run in the browser tab's icon — a ring of failed/passed/skipped/
-   *  todo/running arcs over the not-yet-run remainder — restoring the page's
-   *  own icon on unmount. Off by default, for the same reason. */
+   *  todo/running arcs over the not-yet-run remainder, its centre dot breathing
+   *  while the run is still going — restoring the page's own icon on unmount.
+   *  Off by default, for the same reason. */
   favicon?: boolean;
 }
 
@@ -177,7 +178,7 @@ export function TestReportViewer({
   const [baseTitle] = useState(() => document.title);
   const progress = runProgress(snapshot, streaming);
   useDocumentTitle(titleFor(documentTitle, progress, baseTitle), baseTitle);
-  useFavicon(favicon ? progressFavicon(progress) : undefined);
+  useProgressFavicon(favicon ? progress : undefined);
   return (
     <TreeView
       snapshot={snapshot}

--- a/packages/web/src/client/tabStatus.ts
+++ b/packages/web/src/client/tabStatus.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { Counts, TreeSnapshot } from '@reporters/tree-core';
 
 /** What a tab can say about the run — the numbers the header already shows. */
@@ -29,6 +29,9 @@ const COLOR = {
  *  o'clock, wherever the rest of the ring lands. `queued` is the track they are drawn over. */
 const RING: readonly (keyof Counts & keyof typeof COLOR)[] = ['failed', 'passed', 'skipped', 'todo', 'running'];
 
+/** The icon's own coordinate space. A unit is a pixel at the 16px a tab strip actually shows. */
+const VIEWBOX = 16;
+const CENTRE = VIEWBOX / 2;
 const RADIUS = 6.5;
 const RING_WIDTH = 3;
 /** The verdict dot, sized to leave a gap inside the arcs so the two never read as one shape. It is
@@ -36,6 +39,9 @@ const RING_WIDTH = 3;
  *  fails two of four hundred tests would otherwise paint two red pixels and read as passing. */
 const DOT_RADIUS = 3.5;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+/** Side of the raster drawn from that space: 2× covers a 16px tab strip on a retina display, and
+ *  browsers downscale a too-large icon far more gracefully than they upscale a too-small one. */
+const RASTER = VIEWBOX * 2;
 
 export function runProgress(snapshot: TreeSnapshot, streaming: boolean): RunProgress {
   const { counts } = snapshot;
@@ -61,10 +67,40 @@ export function progressTitle(progress: RunProgress, baseTitle: string): string 
 
 const round = (n: number): number => Math.round(n * 100) / 100;
 
+/** Arc lengths around the ring, one per `RING` status, in viewBox units.
+ *
+ *  Rounded, because the counts behind them change several times a second and an exact ring mints a
+ *  new icon for boundaries no display can resolve — every one of which costs the browser an icon
+ *  swap. Rounded *cumulatively* rather than per arc, so the arcs still tile the ring end to end
+ *  instead of drifting apart. A status holding anything at all keeps one unit even when its share
+ *  rounds to nothing, borrowed from the longest arc: two failures in four hundred is precisely the
+ *  case the ring must not swallow. */
+function ringLengths(counts: Counts): number[] {
+  const total = Math.max(counts.total, 1);
+  const lengths: number[] = [];
+  let share = 0;
+  let drawn = 0;
+  for (const status of RING) {
+    share += counts[status] / total;
+    const end = Math.min(Math.round(share * CIRCUMFERENCE), CIRCUMFERENCE);
+    lengths.push(end - drawn);
+    drawn = end;
+  }
+  RING.forEach((status, i) => {
+    if (counts[status] === 0 || lengths[i] > 0) return;
+    const longest = lengths.indexOf(Math.max(...lengths));
+    if (longest !== i && lengths[longest] > 1) {
+      lengths[longest] -= 1;
+      lengths[i] = 1;
+    }
+  });
+  return lengths;
+}
+
 function arc(color: string, length: number, offset: number): string {
-  return `<circle cx="8" cy="8" r="${RADIUS}" fill="none" stroke="${color}" stroke-width="${RING_WIDTH}"`
+  return `<circle cx="${CENTRE}" cy="${CENTRE}" r="${RADIUS}" fill="none" stroke="${color}" stroke-width="${RING_WIDTH}"`
     + ` stroke-dasharray="${round(length)} ${round(CIRCUMFERENCE - length)}"`
-    + ` stroke-dashoffset="${round(-offset)}" transform="rotate(-90 8 8)"/>`;
+    + ` stroke-dashoffset="${round(-offset)}" transform="rotate(-90 ${CENTRE} ${CENTRE})"/>`;
 }
 
 /** The colour the run as a whole is going: one failure makes it red, whatever the other counts. */
@@ -74,24 +110,109 @@ function verdictColor(progress: RunProgress): string {
 }
 
 /** A `data:` URI for the run: a filled dot in the verdict's colour, ringed by the breakdown — one
- *  arc per status over the not-yet-run remainder. */
+ *  arc per status over the not-yet-run remainder. The fallback icon, for anything that cannot hand
+ *  out a 2D context; `paintFavicon` is what a browser normally shows. */
 export function progressFavicon(progress: RunProgress): string {
-  const total = Math.max(progress.counts.total, 1);
+  const lengths = ringLengths(progress.counts);
   const arcs: string[] = [];
   let offset = 0;
-  for (const status of RING) {
-    const length = (progress.counts[status] / total) * CIRCUMFERENCE;
-    if (length > 0) {
-      arcs.push(arc(COLOR[status], length, offset));
-      offset += length;
-    }
-  }
-  const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">'
-    + `<circle cx="8" cy="8" r="${RADIUS}" fill="none" stroke="${COLOR.queued}" stroke-width="${RING_WIDTH}"/>`
+  RING.forEach((status, i) => {
+    if (lengths[i] <= 0) return;
+    arcs.push(arc(COLOR[status], lengths[i], offset));
+    offset += lengths[i];
+  });
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${VIEWBOX} ${VIEWBOX}">`
+    + `<circle cx="${CENTRE}" cy="${CENTRE}" r="${RADIUS}" fill="none" stroke="${COLOR.queued}" stroke-width="${RING_WIDTH}"/>`
     + arcs.join('')
-    + `<circle cx="8" cy="8" r="${DOT_RADIUS}" fill="${verdictColor(progress)}"/>`
+    + `<circle cx="${CENTRE}" cy="${CENTRE}" r="${DOT_RADIUS}" fill="${verdictColor(progress)}"/>`
     + '</svg>';
   return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+interface Scratch { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D }
+
+/** One canvas for the life of the page: a breathing run repaints ten times a second, and a fresh
+ *  canvas per frame is the only cost in that loop that grows. `null` wherever the environment will
+ *  not hand out a 2D context — the icon falls back to `progressFavicon`, which needs none. */
+let scratch: Scratch | null = null;
+
+function scratchIcon(): Scratch | null {
+  if (scratch) return scratch;
+  const canvas = document.createElement('canvas');
+  canvas.width = RASTER;
+  canvas.height = RASTER;
+  const ctx = canvas.getContext('2d');
+  scratch = ctx ? { canvas, ctx } : null;
+  return scratch;
+}
+
+/** The same icon, rasterised — a PNG `data:` URI, or `undefined` where no canvas is available.
+ *
+ *  Worth the canvas because of how a browser swaps an icon: the new href is decoded asynchronously,
+ *  and until it lands the tab paints the next-best candidate it already holds — the page's own
+ *  `<link rel="icon">`, sitting right there. A run that repaints constantly turns that gap into a
+ *  visible flicker back to the host's favicon. A raster is decoded then and there.
+ *
+ *  `dotScale` shrinks the verdict dot for the pulse; the ring is never touched by it. */
+export function paintFavicon(progress: RunProgress, dotScale = 1): string | undefined {
+  const icon = scratchIcon();
+  if (!icon) return undefined;
+  const { canvas, ctx } = icon;
+  ctx.setTransform(RASTER / VIEWBOX, 0, 0, RASTER / VIEWBOX, 0, 0);
+  ctx.clearRect(0, 0, VIEWBOX, VIEWBOX);
+  ctx.lineWidth = RING_WIDTH;
+  const stroke = (color: string, from: number, to: number) => {
+    ctx.beginPath();
+    ctx.strokeStyle = color;
+    ctx.arc(CENTRE, CENTRE, RADIUS, from, to);
+    ctx.stroke();
+  };
+  stroke(COLOR.queued, 0, 2 * Math.PI);
+  const lengths = ringLengths(progress.counts);
+  // Twelve o'clock, matching the SVG's rotate(-90): the arcs start where the eye does.
+  let angle = -Math.PI / 2;
+  RING.forEach((status, i) => {
+    if (lengths[i] <= 0) return;
+    const end = angle + lengths[i] / RADIUS;
+    stroke(COLOR[status], angle, end);
+    angle = end;
+  });
+  ctx.beginPath();
+  ctx.fillStyle = verdictColor(progress);
+  ctx.arc(CENTRE, CENTRE, DOT_RADIUS * dotScale, 0, 2 * Math.PI);
+  ctx.fill();
+  return canvas.toDataURL('image/png');
+}
+
+const PULSE_PERIOD_MS = 1600;
+const PULSE_FRAME_MS = 100;
+/** How far the dot shrinks at the bottom of a breath. Shallow deliberately: a tab strip is
+ *  peripheral vision, and a dot that collapses reads as a second status rather than a heartbeat. */
+const PULSE_DEPTH = 0.28;
+
+function pulseScale(elapsedMs: number): number {
+  const phase = ((elapsedMs % PULSE_PERIOD_MS) / PULSE_PERIOD_MS) * 2 * Math.PI;
+  return 1 - (PULSE_DEPTH * (1 - Math.cos(phase))) / 2;
+}
+
+/** The breath the verdict dot takes while the run is going, and the still `1` the moment it lands
+ *  — stopping is how the icon says "finished" without changing shape.
+ *
+ *  On an interval rather than animation frames: frames are suspended outright in a background tab,
+ *  which is the tab this icon exists for. A hidden tab clamps the interval to about a second, so
+ *  the pulse coarsens there into a slow blink instead of freezing. */
+function usePulse(active: boolean): number {
+  const [scale, setScale] = useState(1);
+  useEffect(() => {
+    if (!active || window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      setScale(1);
+      return undefined;
+    }
+    const started = Date.now();
+    const timer = setInterval(() => setScale(pulseScale(Date.now() - started)), PULSE_FRAME_MS);
+    return () => clearInterval(timer);
+  }, [active]);
+  return scale;
 }
 
 /** Show `next` in the tab, handing `baseTitle` back when it goes undefined or
@@ -110,6 +231,12 @@ export function useDocumentTitle(next: string | undefined, baseTitle: string): v
   useEffect(() => () => { if (owned.current) document.title = baseTitle; }, [baseTitle]);
 }
 
+/** A `<link rel="icon">`'s `type`, which browsers use to skip icons they cannot decode — so it has
+ *  to follow the href across the raster/vector fallback rather than being fixed at either. */
+function iconType(href: string): string {
+  return /^data:([^;,]+)/.exec(href)?.[1] ?? 'image/svg+xml';
+}
+
 /** Show `href` as the tab's icon. Appended as a second `<link rel="icon">`
  *  rather than written into the page's own: browsers honour the last icon
  *  declared, so dropping ours restores whatever the page shipped with. */
@@ -124,12 +251,23 @@ export function useFavicon(href: string | undefined): void {
     if (!link.current) {
       link.current = document.createElement('link');
       link.current.rel = 'icon';
-      link.current.type = 'image/svg+xml';
       document.head.appendChild(link.current);
     }
     // Re-assigning an unchanged href re-fetches the icon in some browsers, and
     // a live run re-renders several times a second.
-    if (link.current.getAttribute('href') !== href) link.current.setAttribute('href', href);
+    if (link.current.getAttribute('href') !== href) {
+      link.current.type = iconType(href);
+      link.current.setAttribute('href', href);
+    }
   }, [href]);
   useEffect(() => () => { link.current?.remove(); link.current = null; }, []);
+}
+
+/** Put the run in the tab's icon: rastered and breathing where a canvas allows it, flat SVG where
+ *  it does not. `undefined` leaves the page's own icon alone. */
+export function useProgressFavicon(progress: RunProgress | undefined): void {
+  // Only the raster carries the breath, and a pulse the SVG cannot show is a timer waking ten
+  // times a second to redraw the icon it already drew.
+  const dotScale = usePulse(progress?.inProgress === true && scratchIcon() !== null);
+  useFavicon(progress && (paintFavicon(progress, dotScale) ?? progressFavicon(progress)));
 }

--- a/packages/web/src/client/tabStatus.ts
+++ b/packages/web/src/client/tabStatus.ts
@@ -232,9 +232,10 @@ export function useDocumentTitle(next: string | undefined, baseTitle: string): v
 }
 
 /** A `<link rel="icon">`'s `type`, which browsers use to skip icons they cannot decode — so it has
- *  to follow the href across the raster/vector fallback rather than being fixed at either. */
-function iconType(href: string): string {
-  return /^data:([^;,]+)/.exec(href)?.[1] ?? 'image/svg+xml';
+ *  to follow the href across the raster/vector fallback rather than being fixed at either. Absent
+ *  for an href that does not carry its type: no hint beats a wrong one, and the browser sniffs. */
+function iconType(href: string): string | undefined {
+  return /^data:([^;,]+)/.exec(href)?.[1];
 }
 
 /** Show `href` as the tab's icon. Appended as a second `<link rel="icon">`
@@ -256,7 +257,9 @@ export function useFavicon(href: string | undefined): void {
     // Re-assigning an unchanged href re-fetches the icon in some browsers, and
     // a live run re-renders several times a second.
     if (link.current.getAttribute('href') !== href) {
-      link.current.type = iconType(href);
+      const type = iconType(href);
+      if (type) link.current.type = type;
+      else link.current.removeAttribute('type');
       link.current.setAttribute('href', href);
     }
   }, [href]);

--- a/packages/web/tests/tabStatus.test.ts
+++ b/packages/web/tests/tabStatus.test.ts
@@ -259,6 +259,14 @@ test('useFavicon: adds one icon link and re-points that same element', async () 
   assert.strictEqual(link.getAttribute('href'), 'data:image/svg+xml,%3Csvg%20id%3D%222%22%3E');
 });
 
+test('useFavicon: an href that does not carry its type is given no type hint', async () => {
+  const { update } = await render({ icon: 'data:image/png;base64,STUB' });
+  assert.strictEqual(icons()[0].getAttribute('type'), 'image/png');
+  await update({ icon: '/favicon.ico' });
+  assert.strictEqual(icons()[0].getAttribute('href'), '/favicon.ico');
+  assert.strictEqual(icons()[0].getAttribute('type'), null, 'a wrong hint is worse than none');
+});
+
 test('useFavicon: drops its link when switched off, and on unmount', async () => {
   const { root, update } = await render({ icon: 'data:image/svg+xml,%3Csvg%3E' });
   await update({});
@@ -356,4 +364,22 @@ test('useProgressFavicon: the dot breathes while the run does, and holds still o
 test('useProgressFavicon: no progress leaves the page\'s own icon alone', async () => {
   await renderIcon({});
   assert.deepStrictEqual(icons(), []);
+});
+
+
+test('useProgressFavicon: prefers-reduced-motion leaves the dot still', async (t) => {
+  t.mock.timers.enable({ apis: ['setInterval', 'Date'] });
+  (dom.window as any).matchMedia = (query: string) => ({ matches: query.includes('prefers-reduced-motion') });
+  try {
+    await renderIcon({
+      progress: runProgress(snapshot({ passed: 5, running: 1, queued: 4, total: 10 }), true),
+    });
+    const shapes = painted.length;
+    assert.strictEqual(dotRadius(), DOT);
+    await act(async () => { t.mock.timers.tick(5_000); });
+    assert.strictEqual(painted.length, shapes, 'a run that would breathe is never repainted');
+    assert.strictEqual(dotRadius(), DOT);
+  } finally {
+    delete (dom.window as any).matchMedia;
+  }
 });

--- a/packages/web/tests/tabStatus.test.ts
+++ b/packages/web/tests/tabStatus.test.ts
@@ -4,7 +4,8 @@ import { JSDOM } from 'jsdom';
 import type ReactTypes from 'react';
 import type { Root } from 'react-dom/client';
 import {
-  progressFavicon, progressTitle, runProgress, useDocumentTitle, useFavicon,
+  paintFavicon, progressFavicon, progressTitle, runProgress,
+  useDocumentTitle, useFavicon, useProgressFavicon, type RunProgress,
 } from '../src/client/tabStatus.ts';
 import type { Counts, TreeSnapshot } from '@reporters/tree-core';
 
@@ -13,6 +14,30 @@ const dom = new JSDOM('', { url: 'http://localhost/' });
 (globalThis as any).document = dom.window.document;
 Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+// jsdom draws nothing, and the rastered icon is the one a browser actually gets. A recording
+// context stands in for the real one: every arc the painter asks for, in the order it asks.
+interface Painted { color: string; args: number[] }
+const painted: Painted[] = [];
+let pending: number[] = [];
+const recorder = {
+  strokeStyle: '',
+  fillStyle: '',
+  lineWidth: 0,
+  setTransform() {},
+  clearRect() { painted.length = 0; },
+  beginPath() { pending = []; },
+  arc(...args: number[]) { pending = args; },
+  stroke() { painted.push({ color: recorder.strokeStyle, args: pending }); },
+  fill() { painted.push({ color: recorder.fillStyle, args: pending }); },
+};
+const PNG = 'data:image/png;base64,STUB';
+let context2d: unknown = recorder;
+dom.window.HTMLCanvasElement.prototype.getContext = (() => context2d) as never;
+dom.window.HTMLCanvasElement.prototype.toDataURL = (() => PNG) as never;
+
+/** Radius of the last shape painted — the verdict dot is always drawn last. */
+const dotRadius = (): number => painted[painted.length - 1].args[2];
 
 // react-dom snapshots the environment at module evaluation, so it loads only
 // once the DOM globals above exist. The hooks under test are the source
@@ -119,9 +144,9 @@ test('favicon: the dot is the verdict — one failure in a sea of passes still r
     passed: 347, failed: 2, skipped: 9, todo: 6, total: 364,
   }, true), false)));
   assert.strictEqual(dotColor(markup), '#fb5a6a');
-  // The arc that colour stands in for is half a percent of the ring — two pixels at favicon size.
+  // The arc that colour stands in for is the ring's rounding floor: one unit of red in forty.
   const [failedArc] = [...markup.matchAll(/stroke-dasharray="([\d.]+) /g)].map((m) => Number(m[1]));
-  assert.ok(failedArc < RING_CIRCUMFERENCE / 100, `failed arc is ${failedArc} of ${RING_CIRCUMFERENCE}`);
+  assert.strictEqual(failedArc, 1);
 });
 
 test('favicon: a clean run is amber while it runs and green once it lands', () => {
@@ -136,6 +161,30 @@ test('favicon: a failure outranks a run still in progress', () => {
     passed: 4, failed: 1, running: 1, queued: 4, total: 10,
   }), true)));
   assert.strictEqual(dotColor(markup), '#fb5a6a');
+});
+
+test('favicon: the ring is quantised, so a change no pixel can show does not mint a new icon', () => {
+  const icon = (passed: number) => progressFavicon(runProgress(snapshot({
+    passed, queued: 1000 - passed, total: 1000,
+  }), true));
+  assert.strictEqual(icon(501), icon(500), 'one test in a thousand moves no boundary');
+  assert.notStrictEqual(icon(520), icon(500), 'two percent of the ring is a pixel, and does');
+});
+
+test('favicon: quantised arcs still tile the ring end to end', () => {
+  const markup = svg(progressFavicon(runProgress(snapshot({
+    passed: 137, failed: 11, skipped: 3, todo: 2, running: 4, queued: 43, total: 200,
+  }), true)));
+  const lengths = [...markup.matchAll(/stroke-dasharray="([\d.]+) /g)].map((m) => Number(m[1]));
+  const offsets = [...markup.matchAll(/stroke-dashoffset="(-?[\d.]+)"/g)].map((m) => Number(m[1]));
+  // Each arc begins exactly where the one before it ended: no seams, no overlap.
+  let end = 0;
+  lengths.forEach((length, i) => {
+    assert.strictEqual(Math.abs(offsets[i]), end, `arc ${i} starts at ${-offsets[i]}, not ${end}`);
+    assert.strictEqual(length, Math.round(length), `arc ${i} is ${length}, not a whole unit`);
+    end += length;
+  });
+  assert.ok(end <= RING_CIRCUMFERENCE, `arcs total ${end}, past the ring's ${RING_CIRCUMFERENCE}`);
 });
 
 const mounted: Root[] = [];
@@ -217,5 +266,94 @@ test('useFavicon: drops its link when switched off, and on unmount', async () =>
   await update({ icon: 'data:image/svg+xml,%3Csvg%3E' });
   assert.strictEqual(icons().length, 1);
   await act(async () => root.unmount());
+  assert.deepStrictEqual(icons(), []);
+});
+
+interface IconProps { progress?: RunProgress }
+
+function IconHarness({ progress }: IconProps) {
+  useProgressFavicon(progress);
+  return null;
+}
+
+async function renderIcon(props: IconProps): Promise<{ update: (next: IconProps) => Promise<void> }> {
+  const root = createRoot(dom.window.document.createElement('div'));
+  mounted.push(root);
+  const draw = (p: IconProps) => act(async () => {
+    root.render(React.createElement(IconHarness as ReactTypes.FunctionComponent<IconProps>, p));
+  });
+  await draw(props);
+  return { update: draw };
+}
+
+const DOT = 3.5;
+const PULSE_DEPTH = 0.28;
+
+// Everything below paints, and the module keeps the first canvas it is given a context for — so
+// the environment that has none has to be asked about before any of it runs.
+test('paintFavicon: with no 2D context there is no raster, and the SVG stands in', async () => {
+  context2d = null;
+  try {
+    const progress = runProgress(snapshot({ passed: 1, queued: 1, total: 2 }), true);
+    assert.strictEqual(paintFavicon(progress), undefined);
+    await renderIcon({ progress });
+    assert.strictEqual(icons()[0].getAttribute('href'), progressFavicon(progress));
+    assert.strictEqual(icons()[0].getAttribute('type'), 'image/svg+xml');
+  } finally {
+    context2d = recorder;
+  }
+});
+
+test('paintFavicon: the track, then one arc per status in ring order, then the verdict dot', () => {
+  assert.strictEqual(paintFavicon(runProgress(snapshot({
+    passed: 5, failed: 1, running: 2, queued: 2, total: 10,
+  }), true)), PNG);
+  assert.deepStrictEqual(
+    painted.map((shape) => shape.color),
+    ['#5d6573', '#fb5a6a', '#34d27b', '#ffb13d', '#fb5a6a'],
+  );
+  const arcs = painted.slice(1, -1);
+  assert.strictEqual(arcs[0].args[3], -Math.PI / 2, 'the ring opens at twelve o\'clock');
+  arcs.forEach((shape, i) => {
+    if (i > 0) assert.strictEqual(shape.args[3], arcs[i - 1].args[4], `arc ${i} leaves a seam`);
+  });
+});
+
+test('paintFavicon: dotScale moves the dot and nothing else', () => {
+  const progress = runProgress(snapshot({ passed: 5, running: 1, queued: 4, total: 10 }), true);
+  paintFavicon(progress);
+  const ring = painted.slice(0, -1).map((shape) => shape.args.join());
+  assert.strictEqual(dotRadius(), DOT);
+  paintFavicon(progress, 1 - PULSE_DEPTH);
+  assert.strictEqual(dotRadius(), DOT * (1 - PULSE_DEPTH));
+  assert.deepStrictEqual(painted.slice(0, -1).map((shape) => shape.args.join()), ring);
+});
+
+test('useProgressFavicon: the tab gets the raster, and the link type follows it', async () => {
+  await renderIcon({ progress: runProgress(snapshot({ passed: 5, running: 1, queued: 4, total: 10 }), true) });
+  assert.strictEqual(icons().length, 1);
+  assert.strictEqual(icons()[0].getAttribute('href'), PNG);
+  assert.strictEqual(icons()[0].getAttribute('type'), 'image/png');
+});
+
+test('useProgressFavicon: the dot breathes while the run does, and holds still once it lands', async (t) => {
+  t.mock.timers.enable({ apis: ['setInterval', 'Date'] });
+  const { update } = await renderIcon({
+    progress: runProgress(snapshot({ passed: 5, running: 1, queued: 4, total: 10 }), true),
+  });
+  assert.strictEqual(dotRadius(), DOT, 'a breath starts full');
+  await act(async () => { t.mock.timers.tick(800); });
+  assert.strictEqual(dotRadius(), DOT * (1 - PULSE_DEPTH), 'half a period in, at its smallest');
+  await act(async () => { t.mock.timers.tick(800); });
+  assert.strictEqual(dotRadius(), DOT, 'and back');
+
+  await update({ progress: runProgress(snapshot({ passed: 10, total: 10 }, true), false) });
+  assert.strictEqual(dotRadius(), DOT, 'a landed run sits at full');
+  await act(async () => { t.mock.timers.tick(5_000); });
+  assert.strictEqual(painted.length, 3, 'and is not repainted again');
+});
+
+test('useProgressFavicon: no progress leaves the page\'s own icon alone', async () => {
+  await renderIcon({});
   assert.deepStrictEqual(icons(), []);
 });


### PR DESCRIPTION
The tab icon flickered back to the page's own favicon throughout a live run — the title kept reading `83% · run 42` while the icon showed the host's.

### Why it flickered

`useFavicon` appends a second `<link rel="icon">` after the page's own, so removing it restores whatever the page shipped with. That leaves the page's icon as a live candidate right next to ours. A browser decodes a new icon asynchronously and keeps painting the next-best candidate it already holds until the new one lands — and `progressFavicon` rebuilt its SVG `data:` URI on every snapshot, several times a second, because every arc's `stroke-dasharray` had moved.

So the gap was permanent for the whole run. The title never flickered because `document.title` is a synchronous assignment.

### What changed

**The icon is rastered.** `paintFavicon` draws the same ring on a reused 32×32 canvas and returns a PNG `data:` URI, decoded then and there. `progressFavicon` keeps its signature and format and becomes the fallback for anything with no 2D context. The `<link>`'s `type` now follows the href across that fallback.

**The ring is quantised.** A viewBox unit is a pixel at the 16px a tab strip shows, so an exact ring was buying an icon swap for boundaries no display can resolve. Boundaries round cumulatively, so the arcs still tile end to end. A status holding anything at all keeps one unit instead of rounding away — 2 failures in 364 now paints a pixel of red rather than a sub-pixel sliver. 501 vs 500 passed out of 1000 is byte-identical, so it costs no swap at all.

**The dot breathes.** With the swap cheap, the verdict dot pulses between full and 0.72 radius on a 1.6s cosine while the run is going, and stops the moment it lands — the stop is the "finished" signal, no shape change needed. The ring never moves, so failed still paints red at 12 o'clock.

- On `setInterval`, not `requestAnimationFrame`: frames are suspended outright in a background tab, which is the tab this icon exists for. Hidden tabs clamp to ~1Hz, where it coarsens into a blink rather than freezing.
- Off under `prefers-reduced-motion: reduce`, and off wherever the canvas is unavailable — a pulse the SVG cannot show is a timer waking ten times a second to redraw the icon it already drew.

### Verification

`yarn test` in `packages/web`: **176 passed**. Eight new tests cover quantisation stability, arc tiling, the sub-pixel floor, ring paint order and seams, `dotScale` isolation, PNG-vs-SVG selection, and the pulse under mocked timers. jsdom has no canvas, so a recording 2D context stands in for the raster path.

Every state and one full breath were also rendered in Chrome from the real painter and checked at both 96px and 16px: geometry, colours, wrap order and the pulse all read correctly.

One caveat: the absence of the flicker itself cannot be asserted headlessly — Playwright cannot see the tab strip. The mechanism is addressed and the swap count is down by orders of magnitude, but confirmation is watching a live run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

