### PR TITLE
fix(web): own the tab's icon rather than sit after the page's

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -181,12 +181,15 @@ failure turns it red.
 While the run is still going the dot **breathes** — a slow pulse that stops the
 moment the run lands, so the tab has a sign of life once the arcs stop moving.
 `prefers-reduced-motion: reduce` turns it off, and a hidden tab clamps the
-timer behind it to roughly a second, where it coarsens into a blink rather than
-stopping.
+timer behind it — five frames a second — to roughly one, where it coarsens into
+a blink rather than stopping.
 
-The icon goes on a `<link rel="icon">` of the viewer's own, appended after the
-page's — browsers honour the last icon declared, so removing it restores
-whatever the page shipped with. It is drawn on a canvas and handed over as a
+The icon goes on a `<link rel="icon">` of the viewer's own, and the page's own
+icons come down for as long as it is up — leaving them in place keeps them in
+the set the browser re-chooses from on every swap, with a `/favicon.ico` in it
+that it can still go and fetch. They are handed back, in the order the page
+declared them, when the viewer stops or unmounts. `apple-touch-icon` was never
+a candidate and is left alone. The icon is drawn on a canvas and handed over as a
 PNG `data:` URI, falling back to SVG where no 2D context is available: a
 browser decodes a new icon asynchronously and keeps painting the next-best
 candidate it already holds until that lands, which for an icon repainting many

--- a/packages/web/src/client/tabStatus.ts
+++ b/packages/web/src/client/tabStatus.ts
@@ -131,7 +131,7 @@ export function progressFavicon(progress: RunProgress): string {
 
 interface Scratch { canvas: HTMLCanvasElement; ctx: CanvasRenderingContext2D }
 
-/** One canvas for the life of the page: a breathing run repaints ten times a second, and a fresh
+/** One canvas for the life of the page: a breathing run repaints five times a second, and a fresh
  *  canvas per frame is the only cost in that loop that grows. `null` wherever the environment will
  *  not hand out a 2D context — the icon falls back to `progressFavicon`, which needs none. */
 let scratch: Scratch | null = null;
@@ -185,7 +185,7 @@ export function paintFavicon(progress: RunProgress, dotScale = 1): string | unde
 }
 
 const PULSE_PERIOD_MS = 1600;
-const PULSE_FRAME_MS = 100;
+const PULSE_FRAME_MS = 200;
 /** How far the dot shrinks at the bottom of a breath. Shallow deliberately: a tab strip is
  *  peripheral vision, and a dot that collapses reads as a second status rather than a heartbeat. */
 const PULSE_DEPTH = 0.28;
@@ -238,18 +238,41 @@ function iconType(href: string): string | undefined {
   return /^data:([^;,]+)/.exec(href)?.[1];
 }
 
-/** Show `href` as the tab's icon. Appended as a second `<link rel="icon">`
- *  rather than written into the page's own: browsers honour the last icon
- *  declared, so dropping ours restores whatever the page shipped with. */
+interface Held<T> { current: T | null }
+
+/** Detach the page's own icons, so ours is the only one the browser has to choose between.
+ *
+ *  Sitting ours after theirs and trusting "the last icon declared wins" leaves both in the
+ *  candidate set, and the browser re-runs that choice on every swap — with a `/favicon.ico` it
+ *  can still go and fetch sitting in it. An icon that changes several times a second turns that
+ *  into a standing cost. `rel~="icon"` is the candidate set exactly: it takes `shortcut icon`
+ *  along with `icon`, and leaves `apple-touch-icon`, which was never competing, alone. */
+function seizeIcons(): HTMLLinkElement[] {
+  const theirs = [...document.head.querySelectorAll<HTMLLinkElement>('link[rel~="icon"]')];
+  theirs.forEach((link) => link.remove());
+  return theirs;
+}
+
+/** Drop ours and hand the page its own icons back, in the order it declared them. */
+function releaseIcons(ours: Held<HTMLLinkElement>, theirs: Held<HTMLLinkElement[]>): void {
+  ours.current?.remove();
+  ours.current = null;
+  theirs.current?.forEach((link) => document.head.appendChild(link));
+  theirs.current = null;
+}
+
+/** Show `href` as the tab's icon, for as long as the viewer wants it — the page's own icons come
+ *  down for the duration and go back up when it stops. */
 export function useFavicon(href: string | undefined): void {
   const link = useRef<HTMLLinkElement | null>(null);
+  const theirs = useRef<HTMLLinkElement[] | null>(null);
   useEffect(() => {
     if (href === undefined) {
-      link.current?.remove();
-      link.current = null;
+      releaseIcons(link, theirs);
       return;
     }
     if (!link.current) {
+      theirs.current = seizeIcons();
       link.current = document.createElement('link');
       link.current.rel = 'icon';
       document.head.appendChild(link.current);
@@ -263,13 +286,13 @@ export function useFavicon(href: string | undefined): void {
       link.current.setAttribute('href', href);
     }
   }, [href]);
-  useEffect(() => () => { link.current?.remove(); link.current = null; }, []);
+  useEffect(() => () => releaseIcons(link, theirs), []);
 }
 
 /** Put the run in the tab's icon: rastered and breathing where a canvas allows it, flat SVG where
  *  it does not. `undefined` leaves the page's own icon alone. */
 export function useProgressFavicon(progress: RunProgress | undefined): void {
-  // Only the raster carries the breath, and a pulse the SVG cannot show is a timer waking ten
+  // Only the raster carries the breath, and a pulse the SVG cannot show is a timer waking five
   // times a second to redraw the icon it already drew.
   const dotScale = usePulse(progress?.inProgress === true && scratchIcon() !== null);
   useFavicon(progress && (paintFavicon(progress, dotScale) ?? progressFavicon(progress)));

--- a/packages/web/tests/tabStatus.test.ts
+++ b/packages/web/tests/tabStatus.test.ts
@@ -212,6 +212,8 @@ async function render(props: HarnessProps): Promise<{ root: Root; update: (next:
 }
 
 const icons = () => [...dom.window.document.head.querySelectorAll('link[rel="icon"]')] as HTMLLinkElement[];
+/** The whole candidate set the browser would choose between, not just ours. */
+const candidates = () => [...dom.window.document.head.querySelectorAll('link[rel~="icon"]')] as HTMLLinkElement[];
 
 test('useDocumentTitle: follows the title it is given', async () => {
   dom.window.document.title = 'host app';
@@ -257,6 +259,46 @@ test('useFavicon: adds one icon link and re-points that same element', async () 
   await update({ icon: 'data:image/svg+xml,%3Csvg%20id%3D%222%22%3E' });
   assert.deepStrictEqual(icons(), [link], 'the same link, re-pointed');
   assert.strictEqual(link.getAttribute('href'), 'data:image/svg+xml,%3Csvg%20id%3D%222%22%3E');
+});
+
+test("useFavicon: takes the page's own icons down while ours is up, and hands them back", async () => {
+  const { head } = dom.window.document;
+  const shortcut = dom.window.document.createElement('link');
+  shortcut.rel = 'shortcut icon';
+  shortcut.href = '/favicon.ico';
+  const touch = dom.window.document.createElement('link');
+  touch.rel = 'apple-touch-icon';
+  touch.href = '/touch.png';
+  head.append(shortcut, touch);
+  try {
+    const { root } = await render({ icon: 'data:image/png;base64,STUB' });
+    assert.deepStrictEqual(
+      candidates().map((link) => link.getAttribute('href')),
+      ['data:image/png;base64,STUB'],
+      'nothing is left for the browser to re-select over, or re-fetch',
+    );
+    assert.ok(head.contains(touch), 'apple-touch-icon was never a candidate, and stays');
+    await act(async () => root.unmount());
+    assert.deepStrictEqual(candidates().map((link) => link.getAttribute('href')), ['/favicon.ico']);
+  } finally {
+    shortcut.remove();
+    touch.remove();
+  }
+});
+
+test("useFavicon: switching off hands the page's icons back without an unmount", async () => {
+  const shortcut = dom.window.document.createElement('link');
+  shortcut.rel = 'icon';
+  shortcut.href = '/favicon.ico';
+  dom.window.document.head.appendChild(shortcut);
+  try {
+    const { update } = await render({ icon: 'data:image/png;base64,STUB' });
+    assert.strictEqual(candidates().length, 1);
+    await update({});
+    assert.deepStrictEqual(candidates().map((link) => link.getAttribute('href')), ['/favicon.ico']);
+  } finally {
+    shortcut.remove();
+  }
 });
 
 test('useFavicon: an href that does not carry its type is given no type hint', async () => {


### PR DESCRIPTION
Follow-up to #296. That PR removed the icon's *decode* gap; this one removes the reason the browser goes looking for another icon in the first place.

### The part #296 did not fix

`useFavicon` appended a second `<link rel="icon">` after the page's own and relied on "browsers honour the last icon declared", so that dropping ours restored whatever the page shipped with. That leaves **both** links in the candidate set permanently. Every href swap makes the browser re-run icon selection across that set — and the other candidate is a real, fetchable `/favicon.ico`.

Reported from a live run: the network panel filling with `favicon.ico` requests, most of them pending, alongside the report fetches.

### The fix

Take the page's icons down for as long as ours is up, and hand them back — in declaration order — when the viewer stops or unmounts. The restore guarantee now comes from *owning* the set rather than from ordering within it, and there is nothing left to re-select over or re-fetch.

`rel~="icon"` is that candidate set exactly: it takes `shortcut icon` along with `icon`, and leaves `apple-touch-icon` alone, which was never competing for the tab.

Also halves the pulse to five frames a second. A 1.6s breath does not need ten at the size a tab strip renders, and every frame is a swap.

### What I could not verify

I could not reproduce the request storm headlessly — a page with `<link rel="icon" href="/favicon.ico">` plus a second appended link swapped at 10Hz for 12s produced exactly **one** `/favicon.ico` request. Playwright's headless Chrome does not render a tab strip and does almost no favicon work, so that probe is inconclusive rather than exonerating.

So this is argued from the mechanism, not from a reproduction: two candidates where one will do is a cost with no upside, and removing the alternate removes the only thing the tab could fall back to. Confirmation has to come from a headed browser on a live run.

### Tests

`yarn test` in `packages/web`: **180 passed**, `tabStatus.ts` at 100% statements, branches, functions and lines. Two new tests cover the takeover — that ours is the only candidate while it is up, that `apple-touch-icon` survives, and that the page's icons come back on both unmount and switch-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

