### PR TITLE
fix(mocha): report suite hook failures

### DIFF
--- a/packages/mocha/.snapshots/1e467e89966f1dc487140f1b18eaffad/11.snap
+++ b/packages/mocha/.snapshots/1e467e89966f1dc487140f1b18eaffad/11.snap
@@ -1,0 +1,22 @@
+Object {
+  "exitCode": 0,
+  "stderr": "",
+  "stdout": "
+
+  suite with a failing after hook
+    ✔ passes its test
+    1) suite with a failing after hook
+
+
+  1 passing (*ms)
+  1 failing
+
+  1) 
+       suite with a failing after hook:
+     Error: after hook failed
+      *
+
+
+
+",
+}

--- a/packages/mocha/.snapshots/96a58cb0ea70661fbc431b75977b8d8e/11.snap
+++ b/packages/mocha/.snapshots/96a58cb0ea70661fbc431b75977b8d8e/11.snap
@@ -1,0 +1,22 @@
+Object {
+  "exitCode": 1,
+  "stderr": "",
+  "stdout": "
+
+  suite with a failing after hook
+    ✔ passes its test
+    1) suite with a failing after hook
+
+
+  1 passing (*ms)
+  1 failing
+
+  1) 
+       suite with a failing after hook:
+     Error: after hook failed
+      *
+
+
+
+",
+}

--- a/packages/mocha/.snapshots/cfb5c52c79bf4e0fca85f0849af3a80a/11.snap
+++ b/packages/mocha/.snapshots/cfb5c52c79bf4e0fca85f0849af3a80a/11.snap
@@ -1,0 +1,22 @@
+Object {
+  "exitCode": 1,
+  "stderr": "",
+  "stdout": "
+
+  suite with a failing after hook
+    ✔ passes its test
+    1) suite with a failing after hook
+
+
+  1 passing (*ms)
+  1 failing
+
+  1) 
+       suite with a failing after hook:
+     Error: after hook failed
+      *
+
+
+
+",
+}

--- a/packages/mocha/.snapshots/dc3fc117f81a81ae79e191693864201a/11.snap
+++ b/packages/mocha/.snapshots/dc3fc117f81a81ae79e191693864201a/11.snap
@@ -1,0 +1,22 @@
+Object {
+  "exitCode": 1,
+  "stderr": "",
+  "stdout": "
+
+  suite with a failing after hook
+    ✔ passes its test
+    1) suite with a failing after hook
+
+
+  1 passing (*ms)
+  1 failing
+
+  1) 
+       suite with a failing after hook:
+     Error: after hook failed
+      *
+
+
+
+",
+}

--- a/packages/mocha/index.js
+++ b/packages/mocha/index.js
@@ -276,6 +276,10 @@ class Runner extends EventEmitter {
     node.applyTestEvent(event, passed);
 
     if (event.data.details?.type === 'suite' || node.children.length > 0) {
+      if (!passed && event.data.details?.error?.failureType === 'hookFailed') {
+        this.stats.failures += 1;
+        this.emit(EVENT_TEST_FAIL, node, node.err);
+      }
       this.#closeSuite(node);
     } else {
       this.#reportTest(node);

--- a/packages/mocha/tests/fixtures/after-hook-failure.js
+++ b/packages/mocha/tests/fixtures/after-hook-failure.js
@@ -1,0 +1,9 @@
+import { after, describe, it } from 'node:test';
+
+describe('suite with a failing after hook', () => {
+  after(() => {
+    throw new Error('after hook failed');
+  });
+
+  it('passes its test', () => {});
+});

--- a/packages/mocha/tests/index.test.js
+++ b/packages/mocha/tests/index.test.js
@@ -142,3 +142,12 @@ test('preserves incoming completion order for concurrent children', async () => 
   });
   await snapshot(child);
 });
+
+test('reports an after hook failure and its failing suite', async () => {
+  const child = spawnSync(process.execPath, [
+    '--test-reporter',
+    './index.js',
+    './tests/fixtures/after-hook-failure.js',
+  ], { env: {}, cwd: pkgDir });
+  await snapshot(child);
+});


### PR DESCRIPTION
Emit a Mocha failure event when node:test reports a hook-failed suite. 

Added an `after`-hook test and snapshots for the supported Node versions.

Fixes issue #300 