### PR TITLE
fix(web): read the stream whole once, so a host can compress it

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -109,7 +109,7 @@ const filters = memoryFilterState();
 
 <TestReportViewer
   src={reportUrl}
-  fetch={authenticatedFetch}  // optional; receives the Range header
+  fetch={authenticatedFetch}  // optional; receives the Range header, bar the first read
   pollMs={250}                // optional; default 1000
   filters={filters}           // optional; defaults to the shareable page URL
   dense="cozy"                // optional; 'compact' (default) or 'cozy'
@@ -226,10 +226,12 @@ startViewer({
 
 `resolveSource` runs before anything renders. Return `null`/`undefined` to fall
 through to the default `?src=` handling; return `{ url, fetch?, pollMs? }` to
-take over. The custom `fetch` receives the reader's `Range` header and must
-return a standard `Response`; a thrown error shows the viewer's load-error
-screen, and a promise that never resolves is fine while an auth redirect is in
-flight.
+take over. The custom `fetch` must return a standard `Response`; a thrown error
+shows the viewer's load-error screen, and a promise that never resolves is fine
+while an auth redirect is in flight. It is handed the reader's `Range` header on
+incremental reads and none on the first - the first read is deliberately
+unranged, so a host can compress it - so pass the headers you are given through
+as they come.
 
 ### `renderNodeActions`
 

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -127,8 +127,10 @@ export interface TestReportViewerProps {
    *  Omit (e.g. while the host is still resolving where the report lives and
    *  has nothing to show) to render the load-error screen. */
   src?: string;
-  /** Transport for reads; defaults to the global fetch. Receives the reader's
-   *  Range header and must return a standard Response. */
+  /** Transport for reads; defaults to the global fetch. Must return a standard
+   *  Response. Carries the reader's Range header on incremental reads and none
+   *  on the first, so it must pass whatever headers it is given straight through
+   *  rather than assume a Range is always there to forward. */
   fetch?: FetchLike;
   /** Poll cadence while the run is live. */
   pollMs?: number;

--- a/packages/web/src/poll.ts
+++ b/packages/web/src/poll.ts
@@ -2,8 +2,10 @@ import type { TestEvent } from '@reporters/tree-core';
 
 export interface PullResult {
   events: TestEvent[];
-  /** True when the source did not honor Range and was re-read in full; the
-   *  caller should rebuild its store from scratch before applying `events`. */
+  /** True when a read that asked for a Range got the whole body back, so
+   *  `events` repeats what was already applied; the caller should rebuild its
+   *  store from scratch before applying them. The unranged first read of a
+   *  stream has nothing to rebuild and never sets it. */
   reset: boolean;
 }
 
@@ -30,25 +32,30 @@ function byteLength(text: string): number {
 }
 
 /**
- * Incrementally reads an append-only NDJSON stream over HTTP. Uses a Range
- * request to fetch only newly appended bytes; if the host ignores Range and
- * returns the whole body (200), it reports `reset` so the caller can rebuild.
- * A truncated trailing line is buffered until the next pull completes it.
+ * Incrementally reads an append-only NDJSON stream over HTTP. Reads the stream
+ * whole once, then Ranges from the offset reached to fetch only newly appended
+ * bytes; if the host ignores Range and returns the whole body (200), it reports
+ * `reset` so the caller can rebuild. A truncated trailing line is buffered
+ * until the next pull completes it.
  */
 export function createNdjsonReader(url: string, fetchImpl: FetchLike = fetch) {
   let offset = 0;
   let buffer = '';
 
   async function pull(): Promise<PullResult> {
-    const res = await fetchImpl(url, { headers: { Range: `bytes=${offset}-` } });
+    // Only a non-zero offset is worth a Range: a browser drops `Accept-Encoding` to `identity` on
+    // any ranged request, so asking for `bytes=0-` forfeits compression and pulls the whole stream
+    // raw - on a multi-megabyte NDJSON report that is an order of magnitude more bytes than a 200.
+    const ranged = offset > 0;
+    const res = await fetchImpl(url, ranged ? { headers: { Range: `bytes=${offset}-` } } : {});
     if (res.status === 416) return { events: [], reset: false };
 
     const text = await res.text();
     let reset = false;
     if (res.status !== 206) {
+      reset = ranged;
       offset = 0;
       buffer = '';
-      reset = true;
     }
     offset += byteLength(text);
     buffer += text;

--- a/packages/web/src/source.ts
+++ b/packages/web/src/source.ts
@@ -3,8 +3,10 @@ import { resolvePollMs, type FetchLike } from './poll.ts';
 export interface ReportSource {
   /** Passed to the NDJSON reader as the URL/identifier. */
   url: string;
-  /** Transport for reads; defaults to the global fetch. Receives the reader's
-   *  Range header and must return a standard Response. */
+  /** Transport for reads; defaults to the global fetch. Must return a standard
+   *  Response. Carries the reader's Range header on incremental reads and none
+   *  on the first, so it must pass whatever headers it is given straight through
+   *  rather than assume a Range is always there to forward. */
   fetch?: FetchLike;
   /** Poll cadence override; else resolved from ?poll= as today. */
   pollMs?: number;

--- a/packages/web/tests/poll.test.ts
+++ b/packages/web/tests/poll.test.ts
@@ -21,7 +21,7 @@ function mockFetch(responses: MockResponse[]) {
 
 test('range-supporting source returns only newly appended events', async () => {
   const { fetchImpl, ranges } = mockFetch([
-    { status: 206, body: '{"type":"a"}\n{"type":"b"}\n' },
+    { status: 200, body: '{"type":"a"}\n{"type":"b"}\n' },
     { status: 206, body: '{"type":"c"}\n' },
   ]);
   const reader = createNdjsonReader('http://x/run.ndjson', fetchImpl);
@@ -36,9 +36,39 @@ test('range-supporting source returns only newly appended events', async () => {
   assert.match(ranges[1]!, /^bytes=26-/);
 });
 
+test('the first read sends no Range, so a host may compress it', async () => {
+  const { fetchImpl, ranges } = mockFetch([
+    { status: 200, body: '{"type":"a"}\n' },
+    { status: 206, body: '{"type":"b"}\n' },
+  ]);
+  const reader = createNdjsonReader('http://x/run.ndjson', fetchImpl);
+
+  await reader.pull();
+  await reader.pull();
+  assert.strictEqual(ranges[0], null);
+  assert.match(ranges[1]!, /^bytes=13-/);
+});
+
+test('an empty stream stays unranged until it has bytes to skip', async () => {
+  const { fetchImpl, ranges } = mockFetch([
+    { status: 200, body: '' },
+    { status: 200, body: '{"type":"a"}\n' },
+  ]);
+  const reader = createNdjsonReader('http://x/run.ndjson', fetchImpl);
+
+  const first = await reader.pull();
+  assert.deepStrictEqual(first.events, []);
+  assert.strictEqual(first.reset, false);
+
+  const second = await reader.pull();
+  assert.deepStrictEqual(second.events.map((e) => e.type), ['a']);
+  assert.strictEqual(second.reset, false);
+  assert.deepStrictEqual(ranges, [null, null]);
+});
+
 test('a truncated trailing line is buffered until completed', async () => {
   const { fetchImpl } = mockFetch([
-    { status: 206, body: '{"type":"a"}\n{"type":"b' },
+    { status: 200, body: '{"type":"a"}\n{"type":"b' },
     { status: 206, body: '"}\n' },
   ]);
   const reader = createNdjsonReader('http://x/run.ndjson', fetchImpl);
@@ -50,19 +80,25 @@ test('a truncated trailing line is buffered until completed', async () => {
   assert.deepStrictEqual(second.events.map((e) => e.type), ['b']);
 });
 
-test('a non-range source (200) returns all events and flags a reset', async () => {
-  const { fetchImpl } = mockFetch([
+test('a source that ignores Range is re-read in full and flags a reset', async () => {
+  const { fetchImpl, ranges } = mockFetch([
     { status: 200, body: '{"type":"a"}\n{"type":"b"}\n' },
   ]);
   const reader = createNdjsonReader('http://x/run.ndjson', fetchImpl);
-  const result = await reader.pull();
-  assert.strictEqual(result.reset, true);
-  assert.deepStrictEqual(result.events.map((e) => e.type), ['a', 'b']);
+
+  const first = await reader.pull();
+  assert.strictEqual(first.reset, false);
+  assert.deepStrictEqual(first.events.map((e) => e.type), ['a', 'b']);
+
+  const second = await reader.pull();
+  assert.match(ranges[1]!, /^bytes=26-/);
+  assert.strictEqual(second.reset, true);
+  assert.deepStrictEqual(second.events.map((e) => e.type), ['a', 'b']);
 });
 
 test('blank and malformed lines are skipped, valid ones still parsed', async () => {
   const { fetchImpl } = mockFetch([
-    { status: 206, body: '{"type":"a"}\n\n   \nnot json\n{"type":"b"}\n' },
+    { status: 200, body: '{"type":"a"}\n\n   \nnot json\n{"type":"b"}\n' },
   ]);
   const reader = createNdjsonReader('http://x/run.ndjson', fetchImpl);
   const { events } = await reader.pull();
@@ -83,7 +119,7 @@ test('defaults to the global fetch when none is provided', async () => {
 
 test('416 (nothing new) yields no events', async () => {
   const { fetchImpl } = mockFetch([
-    { status: 206, body: '{"type":"a"}\n' },
+    { status: 200, body: '{"type":"a"}\n' },
     { status: 416, body: '' },
   ]);
   const reader = createNdjsonReader('http://x/run.ndjson', fetchImpl);


### PR DESCRIPTION
## What

`createNdjsonReader` sent `Range: bytes=${offset}-` on **every** read, including the first — where the offset is `0` and the range is the entire stream.

Browsers drop `Accept-Encoding` to `identity` on any request that carries a `Range` header, so that first read forfeited compression and pulled the whole report raw. The bigger the report, the worse it got.

Now a `Range` is sent only from a non-zero offset. Incremental reads are untouched.

## Measured

Same 4.6MB report, same session, back to back, through a compressing host (fastify + `@fastify/compress`, zstd):

| Read | Status | Transferred | Wall |
|---|---|---|---|
| `Range: bytes=0-` | 206, `identity` | 4,617,968 B | 6,323 ms |
| no `Range` | 200, `zstd` | **252,525 B** | **739 ms** |

18x fewer bytes, 8.5x faster. Parsing the 7,357 lines takes 8 ms, so transfer was the whole cost.

Worth noting there was no host-side fix available: `@fastify/compress` (and any correct proxy) refuses to compress a `206` at all, since `Content-Range` describes unencoded offsets. The only way to get a compressed first read is not to range it.

## Correctness

- **Offsets are unaffected.** `offset += byteLength(text)` counts *decoded* bytes, so a compressed transfer still yields the right uncompressed offset for the next `Range`.
- **`reset` got more precise.** It now fires only when a read that *did* ask for a `Range` got the whole body back — the case where `events` repeats what the caller already applied. The unranged first read has nothing to rebuild, so it no longer claims one. `PullResult.reset` documents this.
- **An empty stream stays unranged** until it has bytes to skip, so a report that does not exist yet behaves as before.
- **Custom `fetch` implementations** are handed no `Range` on the first read. The `fetch` docs on `TestReportViewerProps`, `ReportSource` and in the README now say so — an implementation must pass through whatever headers it is given rather than assume a `Range` is always there to forward.

## Tests

`packages/web/tests/poll.test.ts`, 10/10 green locally:

- new: the first read sends no `Range`, and the second ranges from the byte count it reached
- new: an empty stream stays unranged until it has bytes to skip
- rewritten: a source that ignores `Range` is re-read in full and flags a reset on the *second* pull (the first, being unranged, correctly does not)
- the remaining mocks now answer the unranged first read with `200`, as a real host would

I could not run `viewer-component.test.ts` locally (it loads the built `dist/` and needs `jsdom`; no yarn on this machine), so CI is the check on that one. Its in-memory source already answers `start === 0` with a `200`, so it should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)