### PR TITLE
feat(web): renderHeaderTitle, a slot at the top of the viewer header

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -119,6 +119,7 @@ const filters = memoryFilterState();
     ? <button onClick={() => rerun(node)}>↻ rerun</button>
     : null)}
   renderHeaderActions={() => <button onClick={rerunAll}>↻ rerun all</button>}
+  renderHeaderTitle={() => <a href={pullUrl}>PR #841 · fix: handle empty tags</a>}
 />
 ```
 
@@ -219,8 +220,9 @@ startViewer({
     const credentials = await acquireCredentialsSomehow();
     return { url: params.get('key')!, fetch: authenticatedFetch(credentials) };
   },
-  renderNodeActions: ...,   // both hooks work here too
+  renderNodeActions: ...,   // every hook works here too
   renderHeaderActions: ...,
+  renderHeaderTitle: ...,
 });
 ```
 
@@ -254,3 +256,34 @@ Visibility is yours to style — e.g. reveal on row hover:
 Renders custom content in the header toolbar, to the right of the built-in
 buttons (search, theme, collapse all), wrapped in a `.header-actions` element.
 Same contract as `renderNodeActions`: called on every render, so keep it cheap.
+
+### `renderHeaderTitle`
+
+Renders custom content on its own full-width row at the top of the header,
+above the verdict and status chips, wrapped in a `.header-title` element. Same
+contract as the other two: called on every render, so keep it cheap.
+
+This is where a host says *what run this is* — a PR number and title, a branch,
+a link back to the job that produced the log. The viewer's own header answers
+"how did it go"; nothing in it answers "of what", and a host that puts its own
+bar above `<TestReportViewer>` gets a second scroll container and a seam
+between two headers that are really one.
+
+```tsx
+<TestReportViewer
+  src={reportUrl}
+  renderHeaderTitle={() => (
+    <a className="run-src" href={pullUrl} target="_blank" rel="noreferrer">
+      <GitHubLogo /> PR #841 · fix: handle empty tags
+    </a>
+  )}
+/>
+```
+
+The wrapper carries the header's own horizontal padding and nothing else — no
+border, no background — so the row reads as part of the header rather than a
+strip stacked on it. Styling what you put inside it is yours.
+
+It is not rendered on the load-error screen, which replaces the whole header
+with a centred message; the run's identity comes back with the header when a
+report loads.

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -476,6 +476,11 @@ export type RenderNodeActions = (node: TestNode) => React.ReactNode;
  *  built-in buttons. Called on every render, so it must be cheap. */
 export type RenderHeaderActions = () => React.ReactNode;
 
+/** Embedder hook: render custom content on its own row at the top of the
+ *  header, above the verdict and status chips. Called on every render, so it
+ *  must be cheap. */
+export type RenderHeaderTitle = () => React.ReactNode;
+
 interface RowViewProps {
   row: FlatRow;
   toggle: (key: string, current: boolean) => void;
@@ -726,6 +731,8 @@ export interface TreeViewProps {
   renderNodeActions?: RenderNodeActions;
   /** Render custom content at the end of the header toolbar. */
   renderHeaderActions?: RenderHeaderActions;
+  /** Render custom content on its own row at the top of the header. */
+  renderHeaderTitle?: RenderHeaderTitle;
   /** Where filter state lives; defaults to the shareable page URL (?q,
    *  ?status, ?rerun). Pass memoryFilterState() (or your own store) when the
    *  host app owns the address bar. Must be stable across renders. */
@@ -737,7 +744,7 @@ export interface TreeViewProps {
 }
 
 export function TreeView({
-  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions, renderHeaderActions, filters, dense = 'compact',
+  snapshot, streaming = false, pending = false, loadError = false, onRetry, renderNodeActions, renderHeaderActions, renderHeaderTitle, filters, dense = 'compact',
 }: TreeViewProps) {
   const [theme, toggleTheme] = useTheme();
   // The default store is per-mount so its debounce timer dies with the view.
@@ -904,6 +911,9 @@ export function TreeView({
   return (
     <div className="app" data-dense={dense}>
       <header className="hdr">
+        {renderHeaderTitle ? (
+          <div className="header-title">{renderHeaderTitle()}</div>
+        ) : null}
         <div className="hdr-row">
           <Verdict counts={counts} inProgress={inProgress} duration={duration} />
           <div className="chips">

--- a/packages/web/src/client/start.tsx
+++ b/packages/web/src/client/start.tsx
@@ -6,7 +6,9 @@ import { createTreeStore, type TreeSnapshot } from '@reporters/tree-core';
 import { createNdjsonReader, DEFAULT_POLL_MS, type FetchLike } from '../poll.ts';
 import { resolveReportSource, type ViewerOptions as SourceOptions } from '../source.ts';
 import { STYLES } from '../template.ts';
-import { TreeView, type Density, type RenderHeaderActions, type RenderNodeActions } from './TreeView.tsx';
+import {
+  TreeView, type Density, type RenderHeaderActions, type RenderHeaderTitle, type RenderNodeActions,
+} from './TreeView.tsx';
 import { initTooltips } from './tooltip.ts';
 import {
   progressTitle, runProgress, useDocumentTitle, useProgressFavicon, type RunProgress,
@@ -15,7 +17,9 @@ import type { FilterStore } from './urlState.ts';
 
 export type { ReportSource } from '../source.ts';
 export type { FetchLike } from '../poll.ts';
-export type { Density, RenderHeaderActions, RenderNodeActions } from './TreeView.tsx';
+export type {
+  Density, RenderHeaderActions, RenderHeaderTitle, RenderNodeActions,
+} from './TreeView.tsx';
 export { paintFavicon, progressFavicon, progressTitle, type RunProgress } from './tabStatus.ts';
 export type { TestNode } from '@reporters/tree-core';
 export { memoryFilterState, urlFilterState, type FilterState, type FilterStore } from './urlState.ts';
@@ -38,6 +42,11 @@ export interface ViewerOptions extends SourceOptions {
    *  buttons (search, theme, collapse all), inside a `.header-actions` wrapper.
    *  Called on each render (frequent during a live run), so keep it cheap. */
   renderHeaderActions?: RenderHeaderActions;
+  /** Render custom content on its own full-width row at the top of the header,
+   *  above the verdict and status chips, inside a `.header-title` wrapper —
+   *  what run this is, where it came from. Called on each render, so keep it
+   *  cheap. Not rendered on the load-error screen, which has no header. */
+  renderHeaderTitle?: RenderHeaderTitle;
   /** Keep the run in the page's title. On by default — the page is the
    *  viewer's own. Pass `false` to leave the title alone. */
   documentTitle?: DocumentTitle;
@@ -136,6 +145,7 @@ export interface TestReportViewerProps {
   pollMs?: number;
   renderNodeActions?: RenderNodeActions;
   renderHeaderActions?: RenderHeaderActions;
+  renderHeaderTitle?: RenderHeaderTitle;
   /** Where filter state (?q, ?status, ?rerun) lives; defaults to the
    *  shareable page URL. Pass memoryFilterState() when the host app owns the
    *  address bar, or your own store to bind filters to a router or state
@@ -167,7 +177,8 @@ function titleFor(option: DocumentTitle, progress: RunProgress, baseTitle: strin
  *  Polls `src`, live-updates until the run's summary, and stops polling on
  *  unmount. Injects its stylesheet into document.head before first paint. */
 export function TestReportViewer({
-  src, fetch: fetchImpl, pollMs = DEFAULT_POLL_MS, renderNodeActions, renderHeaderActions, filters, onRetry, dense,
+  src, fetch: fetchImpl, pollMs = DEFAULT_POLL_MS, renderNodeActions, renderHeaderActions, renderHeaderTitle,
+  filters, onRetry, dense,
   documentTitle = false, favicon = false,
 }: TestReportViewerProps) {
   useInsertionEffect(() => { injectStyles(); }, []);
@@ -190,6 +201,7 @@ export function TestReportViewer({
       onRetry={onRetry ?? (src ? retry : undefined)}
       renderNodeActions={renderNodeActions}
       renderHeaderActions={renderHeaderActions}
+      renderHeaderTitle={renderHeaderTitle}
       filters={filters}
       dense={dense}
     />
@@ -214,6 +226,7 @@ export async function startViewer(options: ViewerOptions = {}): Promise<void> {
       pollMs={source?.pollMs}
       renderNodeActions={options.renderNodeActions}
       renderHeaderActions={options.renderHeaderActions}
+      renderHeaderTitle={options.renderHeaderTitle}
       documentTitle={options.documentTitle ?? true}
       favicon={options.favicon ?? true}
       // No usable source (missing/rejected ?src=): a retry must re-run source

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -111,6 +111,7 @@ button { font-family: inherit; } input { font-family: inherit; }
 
 /* header */
 .hdr { flex: none; background: var(--panel); border-bottom: 1px solid var(--line); position: sticky; top: 0; z-index: 5; }
+.header-title { display: flex; align-items: center; min-width: 0; padding: 11px 18px 0; font-size: 13px; }
 .hdr-row { display: flex; align-items: center; gap: 16px; padding: 13px 18px 11px; flex-wrap: wrap; }
 .verdict { display: inline-flex; align-items: center; gap: 9px; padding: 6px 13px 6px 10px; border-radius: 11px; }
 .verdict-glyph { font-size: 15px; font-weight: 800; line-height: 1; }
@@ -277,6 +278,7 @@ button { font-family: inherit; } input { font-family: inherit; }
   .caret { width: 20px; align-self: stretch; }
   /* one content column: headline row, breakdown pills, controls, progress bar —
      stacked on a single 12px gutter and spacing step */
+  .header-title { padding: 12px 12px 0; }
   .hdr-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 12px 12px 0; }
   .verdict { align-self: flex-start; }
   .chips { gap: 8px; }

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -125,7 +125,7 @@ test('tags collapse to one chip whose tooltip and row label carry the names', as
   await act(async () => root.unmount());
 });
 
-test('renderNodeActions and renderHeaderActions render in the embedded component', async () => {
+test('renderNodeActions, renderHeaderActions and renderHeaderTitle render in the embedded component', async () => {
   const { fetchImpl } = fakeSource(`${LOG}\n${SUMMARY}\n`);
   const { root, el } = mount();
   await act(async () => {
@@ -135,11 +135,29 @@ test('renderNodeActions and renderHeaderActions render in the embedded component
       pollMs: 10,
       renderNodeActions: (node) => React.createElement('button', { className: 'x-node' }, `go ${node.name}`),
       renderHeaderActions: () => React.createElement('button', { className: 'x-header' }, 'all'),
+      renderHeaderTitle: () => React.createElement('a', { className: 'x-title' }, 'run #7'),
     }));
   });
   await tick(30);
   assert.ok(el.querySelector('.node-actions .x-node'), 'node action button should render');
   assert.ok(el.querySelector('.header-actions .x-header'), 'header action button should render');
+  const header = el.querySelector('.hdr')!;
+  assert.ok(header.querySelector('.header-title .x-title'), 'header title should render inside the header');
+  // The slot exists to sit above the verdict and chips; anywhere else and an
+  // embedder is back to reaching into the DOM for the position it wanted.
+  assert.strictEqual(header.firstElementChild!.className, 'header-title');
+  await act(async () => root.unmount());
+});
+
+test('renderHeaderTitle is absent on the load-error screen, which has no header', async () => {
+  const { root, el } = mount();
+  await act(async () => {
+    root.render(React.createElement(TestReportViewer, {
+      renderHeaderTitle: () => React.createElement('a', { className: 'x-title' }, 'run #7'),
+    }));
+  });
+  assert.strictEqual(el.querySelector('.hdr'), null);
+  assert.strictEqual(el.querySelector('.x-title'), null);
   await act(async () => root.unmount());
 });
 


### PR DESCRIPTION
## The gap

The viewer's header answers **"how did this run go"** — verdict, counts, duration, progress. Nothing in it answers **"of what"**: which PR, which branch, which job produced the log. That's host knowledge, so it can only come from a slot, and there isn't one above `.hdr-row`.

`renderHeaderActions` reaches the toolbar and nothing else. A host that wants a line of run identity above the verdict and chips has two options today, and both are bad:

1. **Stack its own bar above `<TestReportViewer>`.** Two scroll containers, and a visible seam between two headers that read as one.
2. **Reach into the DOM.** Create a node, `insertBefore` it into `.hdr`, portal React into it — and then add a `MutationObserver`, because `TreeView` returns the load-error screen before the header exists, and mounts a fresh header when a report loads. Real code doing exactly this:

   ```tsx
   const el = document.createElement('div');
   const attach = () => {
     const hdr = document.querySelector('.hdr');
     if (!hdr || el.parentElement === hdr) return;
     hdr.insertBefore(el, hdr.firstChild);
   };
   attach();
   const obs = new MutationObserver(attach);
   obs.observe(document.getElementById('root'), { childList: true, subtree: true });
   ```

   Every line of that exists because the slot isn't upstream — and it's pinned to `.hdr` being the header, first-child insertion surviving React's reconciliation, and the load-error screen being the only teardown.

## The change

One render prop, alongside the two that already exist:

```tsx
<TestReportViewer
  src={reportUrl}
  renderHeaderTitle={() => (
    <a href={pullUrl}><GitHubLogo /> PR #841 · fix: handle empty tags</a>
  )}
/>
```

It renders as the header's **first child**, on its own full-width row above the verdict and chips, wrapped in `.header-title`:

```
<header class="hdr">
  <div class="header-title">   ← new
  <div class="hdr-row">        verdict · chips · tools(… .header-actions)
  <div class="hdr-bar-row">    progress bar
</header>
```

The wrapper carries the header's own horizontal padding and nothing else — no border, no background — so the row reads as part of the header rather than a strip stacked on it. Styling the content is the host's. It follows the header: absent on the load-error screen, back when a report loads.

`startViewer()` takes it too, same as the other hooks.

## Verification

- `renderHeaderTitle` renders inside `.hdr` and is its `firstElementChild` — the position *is* the feature, so it's asserted, not just presence. Removing the four-line render block fails that test.
- A second test pins the load-error contract: no `.hdr`, no title.
- Driven in the real viewer over `assets/demo-run.ndjson` at 1400px and 480px: one scroll container, the mobile breakpoint lands the row on the same 12px gutter as the stacked column below it.
- `yarn lint` clean; `packages/web` 29/29. The 9 `packages/gh` / `packages/github` failures on `main` locally are snapshot mismatches on node-internal stack line numbers — neither package depends on `@reporters/web`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
