### PR TITLE
fix(web): seat the header title beside the verdict instead of on its own row

### DIFF
--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -259,15 +259,21 @@ Same contract as `renderNodeActions`: called on every render, so keep it cheap.
 
 ### `renderHeaderTitle`
 
-Renders custom content on its own full-width row at the top of the header,
-above the verdict and status chips, wrapped in a `.header-title` element. Same
-contract as the other two: called on every render, so keep it cheap.
+Renders custom content directly above the status chips, beside the verdict,
+wrapped in a `.header-title` element. Same contract as the other two: called on
+every render, so keep it cheap.
 
 This is where a host says *what run this is* — a PR number and title, a branch,
 a link back to the job that produced the log. The viewer's own header answers
 "how did it go"; nothing in it answers "of what", and a host that puts its own
 bar above `<TestReportViewer>` gets a second scroll container and a seam
 between two headers that are really one.
+
+It costs almost nothing vertically. The verdict block is already two lines
+tall, so a title line stacked over the chips fits in height the header was
+spending anyway — about 5px, against the ~30px a row of its own would take.
+That also leaves no empty band beside the title for the toolbar to float in:
+verdict, title-and-chips, and toolbar stay on one centre line.
 
 ```tsx
 <TestReportViewer
@@ -280,9 +286,11 @@ between two headers that are really one.
 />
 ```
 
-The wrapper carries the header's own horizontal padding and nothing else — no
-border, no background — so the row reads as part of the header rather than a
-strip stacked on it. Styling what you put inside it is yours.
+The wrapper adds no border, background or padding of its own — the header row
+already supplies the gutter — so the line reads as part of the header rather
+than a strip stacked on it. Styling what you put inside it is yours. Give long
+text `min-width: 0` and `text-overflow: ellipsis`: the column truncates rather
+than pushing the toolbar off the edge.
 
 It is not rendered on the load-error screen, which replaces the whole header
 with a centred message; the run's identity comes back with the header when a

--- a/packages/web/src/client/TreeView.tsx
+++ b/packages/web/src/client/TreeView.tsx
@@ -911,35 +911,39 @@ export function TreeView({
   return (
     <div className="app" data-dense={dense}>
       <header className="hdr">
-        {renderHeaderTitle ? (
-          <div className="header-title">{renderHeaderTitle()}</div>
-        ) : null}
         <div className="hdr-row">
           <Verdict counts={counts} inProgress={inProgress} duration={duration} />
-          <div className="chips">
-            {statChips.map((s) => (
-              <button
-                type="button"
-                className="chip"
-                data-soft={s}
-                data-active={statuses.has(s) ? 'true' : undefined}
-                aria-pressed={statuses.has(s)}
-                data-tip={statuses.has(s) ? `Stop filtering by ${STATUS_LABEL[s]}` : chipTip(s, counts[s], counts.total)}
-                onClick={() => toggleStatus(s)}
-                key={s}
-              >
-                <span className="chip-dot" data-stf={s} />
-                {counts[s]}
-                <span className="chip-label">{STATUS_LABEL[s]}</span>
-              </button>
-            ))}
+          <div className="hdr-ident">
+            {renderHeaderTitle ? (
+              <div className="header-title">{renderHeaderTitle()}</div>
+            ) : null}
+            <div className="hdr-status">
+              <div className="chips">
+                {statChips.map((s) => (
+                  <button
+                    type="button"
+                    className="chip"
+                    data-soft={s}
+                    data-active={statuses.has(s) ? 'true' : undefined}
+                    aria-pressed={statuses.has(s)}
+                    data-tip={statuses.has(s) ? `Stop filtering by ${STATUS_LABEL[s]}` : chipTip(s, counts[s], counts.total)}
+                    onClick={() => toggleStatus(s)}
+                    key={s}
+                  >
+                    <span className="chip-dot" data-stf={s} />
+                    {counts[s]}
+                    <span className="chip-label">{STATUS_LABEL[s]}</span>
+                  </button>
+                ))}
+              </div>
+              {carriedRun ? (
+                <span className="carry-sum">
+                  {runAttempt != null ? `attempt ${runAttempt + 1} of ${runAttempt + 1} · ` : ''}
+                  {freshCount} re-run · {counts.carried} carried{summaryAttempt != null ? ` from attempt ${summaryAttempt + 1}` : ''}
+                </span>
+              ) : null}
+            </div>
           </div>
-          {carriedRun ? (
-            <span className="carry-sum">
-              {runAttempt != null ? `attempt ${runAttempt + 1} of ${runAttempt + 1} · ` : ''}
-              {freshCount} re-run · {counts.carried} carried{summaryAttempt != null ? ` from attempt ${summaryAttempt + 1}` : ''}
-            </span>
-          ) : null}
           <div className="tools">
             <div className="search">
               <SearchIcon />

--- a/packages/web/src/template.ts
+++ b/packages/web/src/template.ts
@@ -111,7 +111,12 @@ button { font-family: inherit; } input { font-family: inherit; }
 
 /* header */
 .hdr { flex: none; background: var(--panel); border-bottom: 1px solid var(--line); position: sticky; top: 0; z-index: 5; }
-.header-title { display: flex; align-items: center; min-width: 0; padding: 11px 18px 0; font-size: 13px; }
+/* The title rides beside the verdict rather than on a row of its own: the verdict block is already
+   two lines tall, so a title line stacked over the chips costs the header a few pixels instead of a
+   whole row, and leaves no empty band for the toolbar to float in. */
+.hdr-ident { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.hdr-status { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+.header-title { display: flex; align-items: center; min-width: 0; font-size: 13px; }
 .hdr-row { display: flex; align-items: center; gap: 16px; padding: 13px 18px 11px; flex-wrap: wrap; }
 .verdict { display: inline-flex; align-items: center; gap: 9px; padding: 6px 13px 6px 10px; border-radius: 11px; }
 .verdict-glyph { font-size: 15px; font-weight: 800; line-height: 1; }
@@ -278,8 +283,10 @@ button { font-family: inherit; } input { font-family: inherit; }
   .caret { width: 20px; align-self: stretch; }
   /* one content column: headline row, breakdown pills, controls, progress bar —
      stacked on a single 12px gutter and spacing step */
-  .header-title { padding: 12px 12px 0; }
   .hdr-row { flex-direction: column; align-items: stretch; gap: 12px; padding: 12px 12px 0; }
+  /* Stacked, width is the cross axis, where min-width: 0 does not stop a nowrap child (a host's
+     header title) from sizing the flex line past the viewport. Capping the children does. */
+  .hdr-row > * { max-width: 100%; }
   .verdict { align-self: flex-start; }
   .chips { gap: 8px; }
   .tools { margin-left: 0; }

--- a/packages/web/tests/viewer-component.test.ts
+++ b/packages/web/tests/viewer-component.test.ts
@@ -141,11 +141,13 @@ test('renderNodeActions, renderHeaderActions and renderHeaderTitle render in the
   await tick(30);
   assert.ok(el.querySelector('.node-actions .x-node'), 'node action button should render');
   assert.ok(el.querySelector('.header-actions .x-header'), 'header action button should render');
-  const header = el.querySelector('.hdr')!;
-  assert.ok(header.querySelector('.header-title .x-title'), 'header title should render inside the header');
-  // The slot exists to sit above the verdict and chips; anywhere else and an
-  // embedder is back to reaching into the DOM for the position it wanted.
-  assert.strictEqual(header.firstElementChild!.className, 'header-title');
+  const ident = el.querySelector('.hdr-ident')!;
+  assert.ok(ident.querySelector('.header-title .x-title'), 'header title should render inside the header');
+  // The title leads a column that sits beside the verdict with the status chips beneath it. Costing
+  // the header a row instead would leave a band of empty space for the toolbar to float in.
+  assert.strictEqual(ident.firstElementChild!.className, 'header-title');
+  assert.ok(ident.querySelector('.hdr-status .chips'), 'the chips sit under the title, same column');
+  assert.strictEqual(ident.previousElementSibling!.className, 'verdict');
   await act(async () => root.unmount());
 });
 


### PR DESCRIPTION
`renderHeaderTitle` (#306) shipped as a **full-width row above everything else**. That was the wrong place for it.

## The problem

A row of its own costs the header a whole row, and leaves the space to the right of the title empty. The toolbar — still a member of the status row below — then reads as sitting low in a header that grew around it:

```
┌─ before ─────────────────────────────────────────────────┐
│ PR #44215  test(workflow-tests): add Db2 case…           │   ← empty to the right
│ ✕ Failing   ●401 passed ●2 failed        [search ☀ … ⬤]  │   ← toolbar pinned here
│   420 tests · 14m 59s                                     │
│ ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ │
└──────────────────────────────────────────────────────────┘
```

## The change

The title now leads a column beside the verdict, with the status chips beneath it:

```
┌─ after ──────────────────────────────────────────────────┐
│ ┌─────────┐ PR #44215  test(workflow-tests): add Db2 case…│
│ │✕ Failing│ ●401 passed ●2 failed …       [search ☀ … ⬤] │
│ │420 tests│                                               │
│ └─────────┘                                               │
│ ▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬ │
└──────────────────────────────────────────────────────────┘
```

**It is nearly free vertically.** The verdict block is already two lines (40.74px); a title line (19.5px) over the chips (22px) is 45.5px. Measured at 1557px:

| | header height |
|---|---|
| no title | 86.74px |
| title beside the verdict (this PR) | **91.5px** (+4.76) |
| title on its own row (today) | 117.24px (+30.5) |

And because there is no empty band any more, verdict, the title-and-chips column, and the toolbar all land on one centre line — `midY 35.75` for all three.

Markup: `.hdr-ident` (the column) wrapping `.header-title` and a new `.hdr-status` (chips + carry-sum), both inside the existing `.hdr-row`. `.tools` does not move.

## No-title case is untouched

With no `renderHeaderTitle`, `.hdr-ident` collapses to exactly `.hdr-status`. Measured against `main`, pixel for pixel:

| | main | this PR |
|---|---|---|
| `.hdr` height | 86.74 | 86.74 |
| `.hdr-row` height | 64.74 | 64.74 |
| verdict left / midY | 18 / 33.37 | 18 / 33.37 |
| chips left / midY | 166.55 / 33.37 | 166.55 / 33.37 |
| tools midY | 33.37 | 33.37 |

## Mobile

Stacked under 640px, the header's width becomes the flex **cross** axis, where `min-width: 0` on the column does not stop a `nowrap` title from sizing the flex line past the viewport — a long title pushed the line to 617.82px in a 480px window and dragged the toolbar off-screen with it. Capping `.hdr-row > *` at `max-width: 100%` fixes it; the title truncates and the toolbar fits. `overflow: hidden` on the title does not work here, and was tried.

## Verification

Real browser, over `assets/demo-run.ndjson`, titled and untitled:

- 1557px: header 91.5px, all three mids at 35.75, no overflow.
- 700px: chips wrap, header 120.5px, still centred, title truncates, no overflow.
- 480px: title truncates, whole toolbar visible, `scrollWidth == innerWidth`, 44px touch targets intact.
- Untitled at 1557px and 480px: identical to `main` as tabulated above.

Tests updated to pin the new arrangement — title leads `.hdr-ident`, chips sit under it in `.hdr-status`, and the column follows the verdict. `packages/web` 183/183, `yarn lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
